### PR TITLE
KVM Remote desktop working in ES6

### DIFF
--- a/public/scripts/amt-0.2.0.js
+++ b/public/scripts/amt-0.2.0.js
@@ -1,3 +1,5 @@
+/* eslint-disable */
+
 /**
 * @fileoverview Intel(r) AMT Communication StackXX
 * @author Ylian Saint-Hilaire
@@ -973,4 +975,14 @@ function GetSidByteArray(sidString) {
     // the rest are in 32 bit in little endian
     for (var i = 3; i < sidParts.length; i++) r += IntToStrX(sidParts[i]);
     return r;
+}
+
+export {
+    AmtStackCreateService,
+    hex_md5,
+    execArgumentsToXml,
+    instanceToXml,
+    referenceToXml,
+    GetSidString,
+    GetSidByteArray
 }

--- a/public/scripts/amt-desktop-0.0.2.js
+++ b/public/scripts/amt-desktop-0.0.2.js
@@ -1,8 +1,13 @@
+/* eslint-disable */
+
 /** 
 * @description Remote Desktop
 * @author Ylian Saint-Hilaire
 * @version v0.0.2g
 */
+
+import { Q, QS, ReadInt, ReadShort, IntToStr, ShortToStr } from './common-0.0.1'
+import { ZLIB } from './zlib-inflate'
 
 // Construct a MeshServer object
 var CreateAmtRemoteDesktop = function (divid, scrolldiv) {
@@ -655,4 +660,8 @@ var CreateAmtRemoteDesktop = function (divid, scrolldiv) {
     }
 
     return obj;
+}
+
+export {
+    CreateAmtRemoteDesktop
 }

--- a/public/scripts/amt-redir-ws-0.1.0.js
+++ b/public/scripts/amt-redir-ws-0.1.0.js
@@ -1,8 +1,13 @@
+/* eslint-disable */
+
 /** 
 * @description Intel AMT Redirection Transport Module - using websocket relay
 * @author Ylian Saint-Hilaire
 * @version v0.0.1f
 */
+
+import { hex_md5 } from './amt-0.2.0'
+import { ReadIntX, IntToStrX} from './common-0.0.1'
 
 // Construct a MeshServer object
 var CreateAmtRedirect = function (module) {
@@ -306,4 +311,8 @@ var CreateAmtRedirect = function (module) {
     obj.RedirectStartIder = String.fromCharCode(0x10, 0x00, 0x00, 0x00, 0x49, 0x44, 0x45, 0x52);
 
     return obj;
+}
+
+export {
+    CreateAmtRedirect
 }

--- a/public/scripts/common-0.0.1.js
+++ b/public/scripts/common-0.0.1.js
@@ -1,3 +1,5 @@
+/* eslint-disable */
+
 /** 
 * @description Set of short commonly used methods for handling HTML elements
 * @author Ylian Saint-Hilaire
@@ -98,3 +100,41 @@ function random(max) { return Math.floor(Math.random() * max); }
 
 // Trademarks
 function trademarks(x) { return x.replace(/\(R\)/g, '&reg;').replace(/\(TM\)/g, '&trade;'); }
+
+export {
+    Q,
+    QS,
+    QE,
+    QV,
+    QA,
+    QH,
+    ReadShort,
+    ReadShortX,
+    ReadInt,
+    ReadSInt,
+    ReadIntX,
+    ShortToStr,
+    ShortToStrX,
+    IntToStr,
+    IntToStrX,
+    MakeToArray,
+    SplitArray,
+    Clone,
+    EscapeHtml,
+    EscapeHtmlBreaks,
+    ArrayElementMove,
+    ObjectToStringEx,
+    ObjectToStringEx2,
+    gap,
+    gap2,
+    ObjectToString,
+    ObjectToString2,
+    hex2rstr,
+    char2hex,
+    rstr2hex,
+    encode_utf8,
+    decode_utf8,
+    data2blob,
+    random,
+    trademarks
+}

--- a/public/scripts/zlib-inflate.js
+++ b/public/scripts/zlib-inflate.js
@@ -1,3 +1,5 @@
+/* eslint-disable */
+
 /* zlib-inflate.js -- JavaScript implementation for the zlib inflate.
   Version: 0.2.0
   LastModified: Apr 12 2012
@@ -70,6 +72,8 @@ Usage: z_stream.inflateReset();
     TODO document
 
 */
+
+import { ZLIB } from './zlib'
 
 if( typeof ZLIB === 'undefined' ) {
     alert('ZLIB is not defined.  SRC zlib.js before zlib-inflate.js')
@@ -1948,3 +1952,7 @@ ZLIB.z_stream.prototype.inflateReset = function(windowBits)
 };
 
 }());
+
+export {
+    ZLIB 
+}

--- a/public/scripts/zlib.js
+++ b/public/scripts/zlib.js
@@ -1,3 +1,5 @@
+/* eslint-disable */
+
 /* zlib.js -- JavaScript implementation for the zlib.
   Version: 0.2.0
   LastModified: Apr 12 2012
@@ -109,3 +111,7 @@ if(typeof ZLIB.common_initialized === 'undefined') {
 
 	ZLIB.common_initialized = true;
 } // common definitions
+
+export {
+    ZLIB
+}


### PR DESCRIPTION
This PR to use the scripts for KVM, using CIRA, to work in ES6 so you cant import them easily in another projects using
````js
import { CreateAmtRemoteDesktop } from '../../assets/scripts/amt/amt-desktop-0.0.2'
import { CreateAmtRedirect } from '../../assets/scripts/amt/amt-redir-ws-0.1.0'

CreateAmtRedirect(CreateAmtRemoteDesktop('desktop-canvas'))
````