### PR TITLE
Expand pluginHandler support for plugins

### DIFF
--- a/agents/meshcore.js
+++ b/agents/meshcore.js
@@ -819,15 +819,7 @@ function createMeshCore(agent) {
                 case 'ping': { mesh.SendCommand('{"action":"pong"}'); break; }
                 case 'pong': { break; }
                 case 'plugin': {
-                    if (typeof data.pluginaction == 'string') {
-                        try {
-                            MeshServerLog('Plugin called', data);
-                            // Not yet implemented
-                            // require(data.plugin.name).serveraction(data);
-                        } catch (e) {
-                            MeshServerLog('Error calling plugin', data);
-                        }
-                    }
+                    try { require(data.plugin).consoleaction(data, data.rights, data.sessionid, this); } catch (e) { throw e; }
                     break;
                 }
                 default:

--- a/agents/meshcore.min.js
+++ b/agents/meshcore.min.js
@@ -819,15 +819,7 @@ function createMeshCore(agent) {
                 case 'ping': { mesh.SendCommand('{"action":"pong"}'); break; }
                 case 'pong': { break; }
                 case 'plugin': {
-                    if (typeof data.pluginaction == 'string') {
-                        try {
-                            MeshServerLog('Plugin called', data);
-                            // Not yet implemented
-                            // require(data.plugin.name).serveraction(data);
-                        } catch (e) {
-                            MeshServerLog('Error calling plugin', data);
-                        }
-                    }
+                    try { require(data.plugin).consoleaction(data, data.rights, data.sessionid, this); } catch (e) { throw e; }
                     break;
                 }
                 default:

--- a/meshuser.js
+++ b/meshuser.js
@@ -50,6 +50,7 @@ module.exports.CreateMeshUser = function (parent, db, ws, req, args, domain, use
     var obj = {};
     obj.user = user;
     obj.domain = domain;
+    obj.ws = ws;
 
     // Server side Intel AMT stack
     const WsmanComm = require('./amt/amt-wsman-comm.js');
@@ -3105,7 +3106,10 @@ module.exports.CreateMeshUser = function (parent, db, ws, req, args, domain, use
                 if (command.routeToNode === true) {
                   routeCommandToNode(command);
                 } else {
-                  // TODO
+                  try { 
+                    var pluginHandler = require('./pluginHandler.js').pluginHandler(parent.parent);
+                    pluginHandler.plugins[command.plugin].serveraction(command, obj, parent);
+                  } catch (e) { console.log('Error loading plugin handler (' + e + ')'); }
                 }
                 
               break;


### PR DESCRIPTION
Expand pluginHandler support to communicate with browser<->server over the control channel. (Aids in gathering server-side plugin specific data).
Expand plugin functionality on agents to get plugin commands as their own action. (Aids in sending data to an agent from the server without abusing existing console msg's).