### PR TITLE
Use PTY if python is available

### DIFF
--- a/agents/meshcore.js
+++ b/agents/meshcore.js
@@ -1100,7 +1100,7 @@ function createMeshCore(agent) {
                         this.prependListener('end', function () { this.httprequest._term.end(function () { console.log('Terminal was closed'); }); });
                     } else {
                         if (fs.existsSync("/usr/bin/python") && fs.existsSync("/bin/bash")) {
-                            this.httprequest.process = childProcess.execFile("/usr/bin/python", [ "python", "-c", "import pty; pty.spawn([\"/bin/bash\"])" ], { type: childProcess.SpawnTypes.TERM });
+                            this.httprequest.process = childProcess.execFile("/usr/bin/python", [ "python", "-c", "import pty; pty.spawn([\"/bin/bash\"])" ]);
                             if (process.platform == 'linux') { this.httprequest.process.stdin.write("export TERM='xterm'\nalias ls='ls --color=auto'\nclear\n"); }
                         }
                         else if (fs.existsSync("/bin/bash")) {

--- a/agents/meshcore.js
+++ b/agents/meshcore.js
@@ -1099,7 +1099,11 @@ function createMeshCore(agent) {
                         this.pipe(this.httprequest._term, { dataTypeSkip: 1, end: false });
                         this.prependListener('end', function () { this.httprequest._term.end(function () { console.log('Terminal was closed'); }); });
                     } else {
-                        if (fs.existsSync("/bin/bash")) {
+                        if (fs.existsSync("/usr/bin/python") && fs.existsSync("/bin/bash")) {
+                            this.httprequest.process = childProcess.execFile("/usr/bin/python", [ "python", "-c", "import pty; pty.spawn([\"/bin/bash\"])" ], { type: childProcess.SpawnTypes.TERM });
+                            if (process.platform == 'linux') { this.httprequest.process.stdin.write("export TERM='xterm'\nalias ls='ls --color=auto'\nclear\n"); }
+                        }
+                        else if (fs.existsSync("/bin/bash")) {
                             this.httprequest.process = childProcess.execFile("/bin/bash", ["bash", "-i"], { type: childProcess.SpawnTypes.TERM });
                             if (process.platform == 'linux') { this.httprequest.process.stdin.write("alias ls='ls --color=auto'\nclear\n"); }
                         } else {

--- a/agents/meshcore.min.js
+++ b/agents/meshcore.min.js
@@ -1099,11 +1099,15 @@ function createMeshCore(agent) {
                         this.pipe(this.httprequest._term, { dataTypeSkip: 1, end: false });
                         this.prependListener('end', function () { this.httprequest._term.end(function () { console.log('Terminal was closed'); }); });
                     } else {
-                        if (fs.existsSync("/bin/bash")) {
+                        if (fs.existsSync("/usr/bin/python") && fs.existsSync("/bin/bash")) {
+                            this.httprequest.process = childProcess.execFile("/usr/bin/python", [ "python", "-c", "import pty; pty.spawn([\"/bin/bash\"])" ]);
+                            if (process.platform == 'linux') { this.httprequest.process.stdin.write("export TERM='xterm'\nalias ls='ls --color=auto'\nclear\n"); }
+                        }
+                        else if (fs.existsSync("/bin/bash")) {
                             this.httprequest.process = childProcess.execFile("/bin/bash", ["bash", "-i"], { type: childProcess.SpawnTypes.TERM });
                             if (process.platform == 'linux') { this.httprequest.process.stdin.write("alias ls='ls --color=auto'\nclear\n"); }
                         } else {
-                            this.httprequest.process = childProcess.execFile("/bin/sh", ["sh"], { type: childProcess.SpawnTypes.TERM });
+                            this.httprequest.process = childProcess.execFile("/bin/sh", ["sh"], { type: childProcess.SpawnTypes.TERM }); // , uid: require('user-sessions').consoleUid()
                             if (process.platform == 'linux') { this.httprequest.process.stdin.write("stty erase ^H\nalias ls='ls --color=auto'\nPS1='\\u@\\h:\\w\\$ '\nclear\n"); }
                         }
                         this.httprequest.process.tunnel = this;
@@ -1788,6 +1792,78 @@ function createMeshCore(agent) {
                     response = 'Available commands: \r\n' + fin + '.';
                     break;
                 }
+                case 'wallpaper':
+                    if (process.platform != 'win32' && !(process.platform == 'linux' && require('linux-gnome-helpers').available))
+                    {
+                        response = 'wallpaper command not supported on this platform'
+                    }
+                    else
+                    {
+                        if (args['_'].length != 1)
+                        {
+                            response = 'Proper usage: wallpaper (GET|TOGGLE)'; // Display usage
+                        }
+                        else
+                        {
+                            switch (args['_'][0].toUpperCase())
+                            {
+                                default:
+                                    response = 'Proper usage: wallpaper (GET|TOGGLE)'; // Display usage
+                                    break;
+                                case 'GET':
+                                case 'TOGGLE':
+                                    if (process.platform == 'win32')
+                                    {
+                                        var id = require('user-sessions').getProcessOwnerName(process.pid).tsid == 0 ? 1 : 0;
+                                        var child = require('child_process').execFile(process.execPath, [process.execPath.split('\\').pop(), '-b64exec', 'dmFyIFNQSV9HRVRERVNLV0FMTFBBUEVSID0gMHgwMDczOwp2YXIgU1BJX1NFVERFU0tXQUxMUEFQRVIgPSAweDAwMTQ7CnZhciBHTSA9IHJlcXVpcmUoJ19HZW5lcmljTWFyc2hhbCcpOwp2YXIgdXNlcjMyID0gR00uQ3JlYXRlTmF0aXZlUHJveHkoJ3VzZXIzMi5kbGwnKTsKdXNlcjMyLkNyZWF0ZU1ldGhvZCgnU3lzdGVtUGFyYW1ldGVyc0luZm9BJyk7CgppZiAocHJvY2Vzcy5hcmd2Lmxlbmd0aCA9PSAzKQp7CiAgICB2YXIgdiA9IEdNLkNyZWF0ZVZhcmlhYmxlKDEwMjQpOwogICAgdXNlcjMyLlN5c3RlbVBhcmFtZXRlcnNJbmZvQShTUElfR0VUREVTS1dBTExQQVBFUiwgdi5fc2l6ZSwgdiwgMCk7CiAgICBjb25zb2xlLmxvZyh2LlN0cmluZyk7CiAgICBwcm9jZXNzLmV4aXQoKTsKfQplbHNlCnsKICAgIHZhciBuYiA9IEdNLkNyZWF0ZVZhcmlhYmxlKHByb2Nlc3MuYXJndlszXSk7CiAgICB1c2VyMzIuU3lzdGVtUGFyYW1ldGVyc0luZm9BKFNQSV9TRVRERVNLV0FMTFBBUEVSLCBuYi5fc2l6ZSwgbmIsIDApOwogICAgcHJvY2Vzcy5leGl0KCk7Cn0='], { type: id });
+                                        child.stdout.str = ''; child.stdout.on('data', function (c) { this.str += c.toString(); });
+                                        child.stderr.on('data', function () { });
+                                        child.waitExit();
+                                        var current = child.stdout.str.trim();
+                                        if (args['_'][0].toUpperCase() == 'GET')
+                                        {
+                                            response = current;
+                                            break;
+                                        }
+                                        if (current != '')
+                                        {
+                                            require('MeshAgent')._wallpaper = current;
+                                            response = 'Wallpaper cleared';
+                                        }
+                                        else
+                                        {
+                                            response = 'Wallpaper restored';
+                                        }
+                                        child = require('child_process').execFile(process.execPath, [process.execPath.split('\\').pop(), '-b64exec', 'dmFyIFNQSV9HRVRERVNLV0FMTFBBUEVSID0gMHgwMDczOwp2YXIgU1BJX1NFVERFU0tXQUxMUEFQRVIgPSAweDAwMTQ7CnZhciBHTSA9IHJlcXVpcmUoJ19HZW5lcmljTWFyc2hhbCcpOwp2YXIgdXNlcjMyID0gR00uQ3JlYXRlTmF0aXZlUHJveHkoJ3VzZXIzMi5kbGwnKTsKdXNlcjMyLkNyZWF0ZU1ldGhvZCgnU3lzdGVtUGFyYW1ldGVyc0luZm9BJyk7CgppZiAocHJvY2Vzcy5hcmd2Lmxlbmd0aCA9PSAzKQp7CiAgICB2YXIgdiA9IEdNLkNyZWF0ZVZhcmlhYmxlKDEwMjQpOwogICAgdXNlcjMyLlN5c3RlbVBhcmFtZXRlcnNJbmZvQShTUElfR0VUREVTS1dBTExQQVBFUiwgdi5fc2l6ZSwgdiwgMCk7CiAgICBjb25zb2xlLmxvZyh2LlN0cmluZyk7CiAgICBwcm9jZXNzLmV4aXQoKTsKfQplbHNlCnsKICAgIHZhciBuYiA9IEdNLkNyZWF0ZVZhcmlhYmxlKHByb2Nlc3MuYXJndlszXSk7CiAgICB1c2VyMzIuU3lzdGVtUGFyYW1ldGVyc0luZm9BKFNQSV9TRVRERVNLV0FMTFBBUEVSLCBuYi5fc2l6ZSwgbmIsIDApOwogICAgcHJvY2Vzcy5leGl0KCk7Cn0=', current != '' ? '""' : require('MeshAgent')._wallpaper], { type: id });
+                                        child.stdout.str = ''; child.stdout.on('data', function (c) { this.str += c.toString(); });
+                                        child.stderr.on('data', function () { });
+                                        child.waitExit();
+                                    }
+                                    else
+                                    {
+                                        var id = require('user-sessions').consoleUid();
+                                        var current = require('linux-gnome-helpers').getDesktopWallpaper(id);
+                                        if (args['_'][0].toUpperCase() == 'GET')
+                                        {
+                                            response = current;
+                                            break;
+                                        }
+                                        if (current != '/dev/null')
+                                        {
+                                            require('MeshAgent')._wallpaper = current;
+                                            response = 'Wallpaper cleared';
+                                        }
+                                        else
+                                        {
+                                            response = 'Wallpaper restored';
+                                        }
+                                        require('linux-gnome-helpers').setDesktopWallpaper(id, current != '/dev/null' ? undefined : require('MeshAgent')._wallpaper);
+                                    }
+                                    break;
+                            }
+                        }
+                    }
+                    break;
                 case 'safemode':
                     if (process.platform != 'win32')
                     {
@@ -1815,6 +1891,19 @@ function createMeshCore(agent) {
                                     break;
                                 case 'STATUS':
                                     var nextboot = require('win-bcd').getKey('safeboot');
+                                    if (nextboot)
+                                    {
+                                        switch(nextboot)
+                                        {
+                                            case 'Network':
+                                            case 'network':
+                                                nextboot = 'SAFE_MODE_NETWORK';
+                                                break;
+                                            default:
+                                                nextboot = 'SAFE_MODE';
+                                                break;
+                                        }
+                                    }
                                     response = 'Current: ' + require('win-bcd').bootMode + ' , NextBoot: ' + (nextboot ? nextboot : 'NORMAL');
                                     break;
                             }


### PR DESCRIPTION
Currently, using the terminal functionality will only make the current shell interactive. This means that sub-shells will not have the usual "$" or other values for $PS1, CTRL+C will kill any sub-shells created and backspace and other special key combinations won't work correctly.

This issue occurs whenever a sub-shell is started, including switching users (which is very bad because of the above mentioned problems). Using a PTY fixes this problem completely, by making programs (like bash) think they're running in an interactive terminal.

(PS: I spent a lot of time figuring this out because its REALLY frustrating and DESTROYS the user experience)