### PR TITLE
Fix available plugin actions

### DIFF
--- a/views/default.handlebars
+++ b/views/default.handlebars
@@ -9563,7 +9563,7 @@
                     p.actions = '<select onchange="return pluginAction(this,\'' + p._id + '\');"><option value=""> --</option>';
                     var entries = Object.entries(statusAvailability[p.status]);
                     for (var k in entries) {
-                        if (cant_action.indexOf(k) === -1) {
+                        if (cant_action.indexOf(entries[k][0]) === -1) {
                             p.actions += '<option value="' + entries[k][0] + '">' + entries[k][1] + '</option>';
                         }
                     }


### PR DESCRIPTION
Looks like something in the pull request / rework caused the denied plugin actions to check based on the index rather than the actual values (so no cant_actions are actually accounted for). This compares the correct values and populates the options appropriately.