### PR TITLE
Fix MeshCentral version comparisons. 

### DIFF
--- a/pluginHandler.js
+++ b/pluginHandler.js
@@ -285,8 +285,8 @@ module.exports.pluginHandler = function (parent) {
                             var s = require('semver');
                             // MeshCentral doesn't adhere to semantic versioning (due to the -<alpha_char> at the end of the version)
                             // Convert the letter to ASCII for a "true" version number comparison
-                            var mcCurVer = parent.currentVer.replace(/-(.)$/, (m, p1) => { return p1.charCodeAt(0); });
-                            var piCompatVer = newconf.meshCentralCompat.replace(/-(.)\b/g, (m, p1) => { return p1.charCodeAt(0); });
+                            var mcCurVer = parent.currentVer.replace(/-(.)$/, (m, p1) => { return ("000" + p1.charCodeAt(0)).substr(-3,3); });
+                            var piCompatVer = newconf.meshCentralCompat.replace(/-(.)\b/g, (m, p1) => { return ("000" + p1.charCodeAt(0)).substr(-3,3); });
                             latestRet.push({
                                 'id': curconf._id,
                                 'installedVersion': curconf.version,


### PR DESCRIPTION
Currently breaking versions comparisons for versions -a through -c (ASCII char val is 97, 98, 99) which appears to be a lower version than intended for version comparisons.

E.g. 0.4.4-z is evaluated as 0.4.4122 (z ASCII is 122) so a comparison with 0.4.5-a is 0.4.597, which appears to be lower in version. This PR pads the conversion from -alpha_char to 3 numbers so version 0.4.5-a would become 0.4.5097, thus satisfying an upgrade comparison correctly.