### PR TITLE
Plugin Tab OnStates / Better MeshCore processing

### DIFF
--- a/pluginHandler.js
+++ b/pluginHandler.js
@@ -93,6 +93,7 @@ module.exports.pluginHandler = function (parent) {
             var d = null;
             if (typeof pluginRegInfo == 'function') d = pluginRegInfo();
             else d = pluginRegInfo;
+            if (d.tabId == null || d.tabTitle == null) { return false; }
             if (!Q(d.tabId)) {
                 var defaultOn = 'class="on"';
                 if (Q('p19headers').querySelectorAll("span.on").length) defaultOn = '';

--- a/plugin_development.md
+++ b/plugin_development.md
@@ -60,7 +60,7 @@ These are separated into the following categories depending on the type of funct
 
 ### Web UI Hooks
 `onDeviceRefeshEnd`: called when a device is selected in the MeshCentral web interface
-`registerPluginTab`: called when a device is selected in the MeshCentral web interface to register a new tab for plugin data, if required
+`registerPluginTab`: callable when a device is selected in the MeshCentral web interface to register a new tab for plugin data, if required. Accepts an object, or function that returns an object, with the following properties: { tabId: "yourShortNameHere", tabTitle: "Your Display Name"}. A tab and div with the associated ID and title will be created for your use
 `onDesktopDisconnect`: called when a remote desktop session is disconnected
 
 #### Exports

--- a/public/styles/style.css
+++ b/public/styles/style.css
@@ -2645,3 +2645,24 @@ a {
     width: 100%;
     height: 100%;
 }
+
+#p19headers {
+    padding-right: 7px;
+    padding-bottom: 10px;
+    font-weight: bold;
+    border-bottom: 1px dotted blue;
+}
+
+#p19headers > span:nth-child(n+2) {
+    border-left: 1px solid black;
+}
+
+#p19headers > span {
+    padding-left: 4px;
+    padding-right: 4px;
+    cursor: pointer;
+    font-weight: lighter;
+}
+#p19headers > span.on {
+    font-weight: bold;
+}

--- a/views/default.handlebars
+++ b/views/default.handlebars
@@ -893,23 +893,6 @@
             </div>
             <div id=p19 style="display:none">
                 <h1>Plugins - <span id=p19deviceName></span></h1>
-                <style>
-                    #p19headers {
-                        padding-right: 7px;
-                        padding-bottom: 10px;
-                        font-weight: bold;
-                        border-bottom: 1px dotted blue;
-                    }
-
-                        #p19headers > span:nth-child(n+2) {
-                            border-left: 1px solid black;
-                        }
-
-                        #p19headers > span {
-                            padding-left: 4px;
-                            padding-right: 4px;
-                        }
-                </style>
                 <div id="p19headers"></div>
                 <div id=p19pages></div>
             </div>


### PR DESCRIPTION
A couple small updates:

- OnStates for current plugin tab within the device page
- Move p19 styles to stylesheet from the default.handlebars
- Wait to update meshcore until after all plugins loaded, rather than after each plugin is loaded
- More intuitive registerPluginTab functionality / flexibility (with backward compat)
