### PR TITLE
Show/Hide Plugins tab in device view

### DIFF
--- a/pluginHandler.js
+++ b/pluginHandler.js
@@ -100,6 +100,7 @@ module.exports.pluginHandler = function (parent) {
                 QA('p19headers', '<span ' + defaultOn + ' onclick="return pluginHandler.callPluginPage(\\''+d.tabId+'\\', this);">'+d.tabTitle+'</span>');
                 QA('p19pages', '<div id="' + d.tabId + '"></div>');
             }
+            QV('MainDevPlugins', true);
         };
         obj.callPluginPage = function(id, el) {
             var pages = Q('p19pages').querySelectorAll("#p19pages>div"); 

--- a/views/default.handlebars
+++ b/views/default.handlebars
@@ -4528,7 +4528,7 @@
                 QV('MainDevFiles', ((mesh.mtype == 2) && ((node.agent == null) || (node.agent.caps == null) || ((node.agent.caps & 4) != 0))) && (meshrights & 8) && fileAccess);
                 QV('MainDevAmt', (node.intelamt != null) && ((node.intelamt.state == 2) || (node.conn & 2)) && (meshrights & 8) && amtAccess);
                 QV('MainDevConsole', (consoleRights && (mesh.mtype == 2) && ((node.agent == null) || (node.agent.caps == null) || ((node.agent.caps & 8) != 0))) && (meshrights & 8));
-                QV('MainDevPlugins', pluginHandler != null);
+                QV('MainDevPlugins', false);
                 QV('p15uploadCore', (node.agent != null) && (node.agent.caps != null) && ((node.agent.caps & 16) != 0));
                 QH('p15coreName', ((node.agent != null) && (node.agent.core != null))?node.agent.core:'');
 


### PR DESCRIPTION
Show plugins tab in device tab only if plugins exists that use that functionality.

Note that while testing I was receiving "updateMapMarkers is not defined" in the console. Seems 
 @Ylianst is working on some GeoLocation.

Satisfies #699 

