### PR TITLE
Plugin Admin Links Broken

### DIFF
--- a/pluginHandler.js
+++ b/pluginHandler.js
@@ -412,12 +412,16 @@ module.exports.pluginHandler = function (parent) {
                                         } else {
                                             parent.db.updatePlugin(id, { status: 1, version: version_only.name }, func);
                                         }
-                                        obj.plugins[plugin.shortName] = require(obj.pluginPath + '/' + plugin.shortName + '/' + plugin.shortName + '.js')[plugin.shortName](obj);
-                                        obj.exports[plugin.shortName] = obj.plugins[plugin.shortName].exports;
-                                        if (typeof obj.plugins[plugin.shortName].server_startup == 'function') obj.plugins[plugin.shortName].server_startup();
-                                        var plugin_config = obj.fs.readFileSync(obj.pluginPath + '/' + plugin.shortName + '/config.json');
-                                        plugin_config = JSON.parse(plugin_config);
-                                        parent.db.updatePlugin(plugin._id, plugin_config);
+                                        try {
+                                            obj.plugins[plugin.shortName] = require(obj.pluginPath + '/' + plugin.shortName + '/' + plugin.shortName + '.js')[plugin.shortName](obj);
+                                            obj.exports[plugin.shortName] = obj.plugins[plugin.shortName].exports;
+                                            if (typeof obj.plugins[plugin.shortName].server_startup == 'function') obj.plugins[plugin.shortName].server_startup();
+                                        } catch (e) { console.log('Error instantiating new plugin: ', e); }
+                                        try {
+                                            var plugin_config = obj.fs.readFileSync(obj.pluginPath + '/' + plugin.shortName + '/config.json');
+                                            plugin_config = JSON.parse(plugin_config);
+                                            parent.db.updatePlugin(plugin._id, plugin_config);
+                                        } catch (e) { console.log('Error reading plugin config upon install'); }
                                         parent.updateMeshCore();
                                     });
                                 });

--- a/views/default.handlebars
+++ b/views/default.handlebars
@@ -9539,7 +9539,7 @@
                 installedPluginList.forEach(function(p){
                     var cant_action = [];
                     if (p.hasAdminPanel == true && p.status) {
-                        p.nameHtml = '<a onclick="return goPlugin(' + p.shortName + ', ' + p.name + ');">' + p.name + '</a>';
+                        p.nameHtml = '<a onclick="return goPlugin(\'' + p.shortName + '\', \'' + p.name.replace(/'/g, "\\'") + '\');">' + p.name + '</a>';
                     } else {
                         p.nameHtml = p.name;
                     }


### PR DESCRIPTION
Hi @Ylianst ,

It looks like you refactored some plugin code using inline javascript variables for templating in the "IE11 Fixes" commit. I didn't realize that broke IE11, sorry!

While you were fixing it, quotes were removed from the plugin admin links, meaning javascript functions were called with the name of the plugin as variables instead of text. (e.g. goPlugin("eventlog", "Event Log"); became goPlugin(eventlog, Event Log);)

This fixes that, as well as the opportunity that a plugin may contain a single quote that would break it in the same fashion.