### PR TITLE
Fix updateMeshCore Call

### DIFF
--- a/pluginHandler.js
+++ b/pluginHandler.js
@@ -490,6 +490,7 @@ module.exports.pluginHandler = function (parent) {
             parent.db.setPluginStatus(id, 0, func);
             delete obj.plugins[plugin.shortName];
             delete obj.exports[plugin.shortName];
+            parent.updateMeshCore();
         });
     };
 
@@ -501,7 +502,6 @@ module.exports.pluginHandler = function (parent) {
             rimraf.sync(pluginPath);
             parent.db.deletePlugin(id, func);
             delete obj.plugins[plugin.shortName];
-            obj.parent.updateMeshCore();
         });
     };
 


### PR DESCRIPTION
Move updateMeshCore call to when a plugin is disabled instead of removed, as the core should be modified when the plugin is disabled, not removed.