### PR TITLE
Reenable broken group actions in My Devices overview screen

### DIFF
--- a/translate/translate.json
+++ b/translate/translate.json
@@ -5379,11 +5379,11 @@
     },
     {
       "cs": "DeviceCheckbox",
-      "de": "Geräte-Checkbox",
+      "de": "DeviceCheckbox",
       "en": "DeviceCheckbox",
       "ja": "DeviceCheckbox",
-      "nl": "Apparaat Checkbox",
-      "pt": "Caixa de seleção do dispositivo",
+      "nl": "DeviceCheckbox",
+      "pt": "DeviceCheckbox",
       "ru": "DeviceCheckbox",
       "xloc": [
         "default.handlebars->23->394"


### PR DESCRIPTION
The group actions in My Devices overview screen were broken in the following language translations due to translation of an identifier as reported in #793 :

 * de
 * nl
 * pt

The translations of the identifier have been reverted to the English original to mitigate the problem.
Final solution should be the removal of the identifier "DeviceCheckbox" from translatable strings.