### PR TITLE
Improve the way dynamic dependencies work

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,11 +38,11 @@
     "express-handlebars": "^3.1.0",
     "express-ws": "^4.0.0",
     "ipcheck": "^0.1.0",
-    "meshcentral": "*",
     "minimist": "^1.2.0",
     "multiparty": "^4.2.1",
     "nedb": "^1.8.0",
     "node-forge": "^0.8.4",
+    "otplib": "^12.0.1",
     "ws": "^6.2.1",
     "xmldom": "^0.1.27",
     "yauzl": "^2.10.0"


### PR DESCRIPTION
Meshcentral can now specify specific versions of dynamic dependencies and the module system will try to match said version automatically. This removes the need for the weird greenlock hacks and allows meshcentral to control dynamic modules similarly to package.json.

I also added otplib as a dependency, since it's required by default.