### PR TITLE
Fix mongodump command syntax

### DIFF
--- a/db.js
+++ b/db.js
@@ -987,7 +987,7 @@ module.exports.CreateDB = function (parent, func) {
                 if (parent.config.settings.autobackup && parent.config.settings.autobackup.mongodumppath) { mongoDumpPath = parent.config.settings.autobackup.mongodumppath; }
                 const child_process = require('child_process');
                 const cmd = '\"' + mongoDumpPath + '\" --db=\"' + dbname + '\" --archive=\"' + newBackupPath + '.archive\"';
-                if (dburl) { cmd = '\"' + mongoDumpPath + '\" --url=\"' + dburl + '\" --db=\"' + dbname + '\" --archive=\"' + newBackupPath + '.archive\"'; }
+                if (dburl) { cmd = '\"' + mongoDumpPath + '\" --uri=\"' + dburl + '\" --archive=\"' + newBackupPath + '.archive\"'; }
                 var backupProcess = child_process.exec(cmd, { cwd: backupPath }, function (error, stdout, stderr) {
                     try {
                         backupProcess = null;


### PR DESCRIPTION
This pull request fixes two mistakes that I found in the syntax of the current `mongodump` command.

1. The command line flag `--url` does not exist; the correct flag is `--uri` ([source](https://docs.mongodb.com/manual/reference/program/mongodump/#cmdoption-mongodump-uri)).
2. The command line flags `--uri` and `--db` cannot be used together ([source](https://docs.mongodb.com/manual/reference/program/mongodump/#cmdoption-mongodump-db)).

This change should fix #717 and fix #885.