### PR TITLE
Add existing CIRA connection exception from periodic AMT scanning.

### DIFF
--- a/amtscanner.js
+++ b/amtscanner.js
@@ -166,7 +166,8 @@ module.exports.CreateAmtScanner = function (parent) {
             if (err == null && docs.length > 0) {
                 for (var i in docs) {
                     var doc = docs[i], host = doc.host.toLowerCase();
-                    if ((host != '127.0.0.1') && (host != '::1') && (host.toLowerCase() != 'localhost')) {
+                    var cira = obj.parent.mpsserver.ciraConnections[doc._id]
+                    if ((host != '127.0.0.1') && (host != '::1') && (host.toLowerCase() != 'localhost') && (cira==null || cira==undefined)) {
                         var scaninfo = obj.scanTable[doc._id];
                         if (scaninfo == undefined) {
                             var tag = obj.nextTag++;


### PR DESCRIPTION
This to alleviate issue when AMT CIRA status unintentionally reset due to TCP check failure. We are seeing multiple instances where AMT connectivity state unintentionally set to offline because TCP check returned false because AMT device is in CIRA mode. 

We may need to add additional exception for checking for hybrid mode because amtscanner attempted to perform scan on device connected over the internet (behind NAT). We should only perform AMT TCP check if the source IP of MeshAgent connection is one of the IP of the interfaces reported by AMT (via MeshAgent).

CC: @matt-primrose @Ganeshr93 for review