### PR TITLE
Fix missing sendText on amt-redir-ws.

### DIFF
--- a/public/scripts/amt-redir-ws-0.1.0.js
+++ b/public/scripts/amt-redir-ws-0.1.0.js
@@ -270,6 +270,8 @@ var CreateAmtRedirect = function (module, authCookie) {
         }
     }
 
+    obj.sendText = obj.xxSend;
+
     obj.send = function (x) {
         if (obj.socket == null || obj.connectstate != 1) return;
         if (obj.protocol == 1) { obj.xxSend(String.fromCharCode(0x28, 0x00, 0x00, 0x00) + IntToStrX(obj.amtsequence++) + ShortToStrX(x.length) + x); } else { obj.xxSend(x); }


### PR DESCRIPTION
This fix AMT terminal not working because of missing obj.parent.sendText on amt-terminal. The other alternative fix is to replace occurence of obj.parent..sendText at amt-terminal with obj.parent.xxSend. but I think add alias for sendText is clearer.
