### PR TITLE
meshCentralCompat version comparison changes and updated docs for cla…

### DIFF
--- a/pluginHandler.js
+++ b/pluginHandler.js
@@ -276,12 +276,12 @@ module.exports.pluginHandler = function (parent) {
 
     // MeshCentral doesn't adhere to semantic versioning (due to the -<alpha_char> at the end of the version)
     // Convert 1.2.3-a to 1.2.3-3 where the letter is converted to a number.
-    function versionToNumber(ver) { var x = ver.split('-'); if (x.length != 2) return ver; x[1] = x[1].toLowerCase().charCodeAt(0) - 96; return x.join('.'); }
+    obj.versionToNumber = function(ver) { var x = ver.split('-'); if (x.length != 2) return ver; x[1] = x[1].toLowerCase().charCodeAt(0) - 96; return x.join('.'); }
 
     // Check if the current version of MeshCentral is at least the minimal required.
-    function checkMeshCentralVersion(current, minimal) {
+    obj.versionCompare = function(current, minimal) {
         if (minimal.startsWith('>=')) { minimal = minimal.substring(2); }
-        var c = versionToNumber(current).split('.'), m = versionToNumber(minimal).split('.');
+        var c = obj.versionToNumber(current).split('.'), m = obj.versionToNumber(minimal).split('.');
         if (c.length != m.length) return false;
         for (var i = 0; i < c.length; i++) { var cx = parseInt(c[i]), cm = parseInt(m[i]); if (cx > cm) { return true; } if (cx < cm) { return false; } }
         return true;
@@ -312,7 +312,7 @@ module.exports.pluginHandler = function (parent) {
                                 'installedVersion': curconf.version,
                                 'version': newconf.version,
                                 'hasUpdate': s.gt(newconf.version, curconf.version),
-                                'meshCentralCompat': checkMeshCentralVersion(parent.currentVer, newconf.meshCentralCompat),
+                                'meshCentralCompat': obj.versionCompare(parent.currentVer, newconf.meshCentralCompat),
                                 'changelogUrl': curconf.changelogUrl,
                                 'status': curconf.status
                             });

--- a/plugin_development.md
+++ b/plugin_development.md
@@ -49,7 +49,7 @@ A valid JSON object within a file named `config.json` in the root folder of your
 | repository.type | Yes | string | valid values are `git` and in the future, `npm` will also be supported in the future
 | repository.url | Yes | string | the URL to the project's repository
 | versionHistoryUrl | No | string | the URL to the project's versions/tags
-| meshCentralCompat | Yes | string | the semantic version string of required compatibility with the MeshCentral server
+| meshCentralCompat | Yes | string | the minimum version string of required compatibility with the MeshCentral server, can be formatted as "0.1.2-c" or ">=0.1.2-c". Currently only supports minimum version, not full semantic checking.
 
 ## Plugin Hooks
 These are separated into the following categories depending on the type of functionality the plugin should offer.


### PR DESCRIPTION
…rity

Update the documentation to more accurately reflect the new version comparison.

Make versionCompare and versionToNumber member objects (in the event a developer wants to maintain compatibility with older versions, but "feature block" some aspects with checks in their own code based on the version of MC currently in use).

I also saw the changes to rimraf you made. I believe rimraf gets installed as devDeps of other dependent packages, so it shouldn't have a real change in most environments. However it does present the issue that without rimraf installed the plugin folder will not be removed from the file system. Aside of storage space being used that would otherwise not be, it won't affect anything. However I'm open to your thoughts on whether we should add rimraf as a dependency if plugins are enabled. It looks like Node's native recursive directory removal is still in an "Experimental" state as of v12 and v13.

Thank you!