### PR TITLE
Add metadata to the relay connection for user -> device tracking

### DIFF
--- a/meshuser.js
+++ b/meshuser.js
@@ -1034,6 +1034,7 @@ module.exports.CreateMeshUser = function (parent, db, ws, req, args, domain, use
                                 r += 'id: ' + i + ', state: ' + parent.wsrelays[i].state;
                                 if (parent.wsrelays[i].peer1 != null) { r += ', peer1: ' + cleanRemoteAddr(parent.wsrelays[i].peer1.req.ip); }
                                 if (parent.wsrelays[i].peer2 != null) { r += ', peer2: ' + cleanRemoteAddr(parent.wsrelays[i].peer2.req.ip); }
+                                if (parent.wsrelays[i].metadata != null) { r += ', ' + parent.wsrelays[i].metadata.authUser._id + ' connected to ' + parent.wsrelays[i].metadata.peer2.name; }
                                 r += '\r\n';
                             }
                             if (r == '') { r = 'No relays.'; }


### PR DESCRIPTION
Update server console command 'relays' to display friendly information

A small quality of life update for users who utilize relays so that the Server Console -> "relays" command outputs the user and peer device utilizing the connection.

![image](https://user-images.githubusercontent.com/1929277/79171126-43539c80-7dbf-11ea-91d7-474d99ee85a9.png)

I often use the "relays" command to see if my server is being used for relays (Work From Home) people before upgrading / restarting the service. Rather than just numbers (and backtracking from IP's to devices), this adds the user id and name of the node they are connected to.