### PR TITLE
1. Add latency timer and callback opportunity to CreateAgentRedirect

### DIFF
--- a/agents/meshcore.js
+++ b/agents/meshcore.js
@@ -1912,6 +1912,10 @@ function createMeshCore(agent) {
                 if (sdp != null) { ws.write({ type: 'answer', ctrlChannel: '102938', sdp: sdp }); }
                 break;
             }
+            case 'latency': {
+                ws.write({ type: 'latency', ctrlChannel: '102938', time: obj.time });
+                break;
+            }
         }
     }
 

--- a/views/default.handlebars
+++ b/views/default.handlebars
@@ -515,6 +515,7 @@
                             <span id=connectbutton1hspan>&nbsp;<input type=button id=connectbutton1h value="HW Connect" title="Connect using Intel AMT hardware KVM" onclick=connectDesktop(event,2) onkeypress="return false" onkeydown="return false" disabled="disabled" /></span>
                             <span id=disconnectbutton1span>&nbsp;<input type=button id=disconnectbutton1 value="Disconnect" onclick=connectDesktop(event,0) onkeypress="return false" onkeydown="return false" /></span>
                             &nbsp;<span id="deskstatus">Disconnected</span>
+                            <span id="connectLatency">(Ping: <span id="connectLatencyTime">0</span>ms)</span>
                         </div>
                     </div>
                     <div id=deskarea2 style="">
@@ -5860,6 +5861,7 @@
                     desktop.m.onDisplayinfo = deskDisplayInfo;
                     desktop.m.onScreenSizeChange = deskAdjust;
                     desktop.Start(desktopNode._id);
+                    desktop.latency.onUpdate(function(ms) { QH('connectLatencyTime', ms); });
                     desktop.contype = 1;
                 } else if (contype == 3) {
                     // Ask for user sessions


### PR DESCRIPTION
2. Add latency to Remote Desktop view

Another quality of life update. I added a latency timer to the CreateAgentRedirect object that, once started, sends a control channel message every ~3 seconds to measure latency between the MC user and the client machine.

As an example (and probably one of the more useful places for it) I added the output to the Remote Desktop device tab- but it can be easily added to anywhere a CreateAgentRedirect is used to measure latency via `varName.latency.onUpdate([callbackFunc])`