### PR TITLE
Fix minifying renders MC 0.5.22+ unusable if enabled #1336

### DIFF
--- a/pluginHandler.js
+++ b/pluginHandler.js
@@ -123,7 +123,7 @@ module.exports.pluginHandler = function (parent) {
             st.src = '/pluginHandler.js';
             document.body.appendChild(st);
         };
-        return obj; };`;
+        return obj; }`;
         return str;
     }
 


### PR DESCRIPTION
* pluginHandler.js: Removed superfluous ; to fix faulty substitution in minifying mode