### PR TITLE
Import and update meshcental account  email from LDAP

### DIFF
--- a/meshctrl.js
+++ b/meshctrl.js
@@ -418,7 +418,7 @@ function displayConfigHelp() {
 }
 
 function performConfigOperations(args) {
-    var domainValues = ['title', 'title2', 'titlepicture', 'trustedcert', 'welcomepicture', 'welcometext', 'userquota', 'meshquota', 'newaccounts', 'usernameisemail', 'newaccountemaildomains', 'newaccountspass', 'newaccountsrights', 'geolocation', 'lockagentdownload', 'userconsentflags', 'Usersessionidletimeout', 'auth', 'ldapoptions', 'ldapusername', 'ldapuserbinarykey', 'ldapoptions', 'footer', 'certurl', 'loginKey', 'userallowedip', 'agentallowedip', 'agentnoproxy', 'agentconfig', 'orphanagentuser', 'httpheaders', 'yubikey', 'passwordrequirements', 'limits', 'amtacmactivation', 'redirects', 'sessionrecording', 'hide', 'loginkey'];
+    var domainValues = ['title', 'title2', 'titlepicture', 'trustedcert', 'welcomepicture', 'welcometext', 'userquota', 'meshquota', 'newaccounts', 'usernameisemail', 'newaccountemaildomains', 'newaccountspass', 'newaccountsrights', 'geolocation', 'lockagentdownload', 'userconsentflags', 'Usersessionidletimeout', 'auth', 'ldapoptions', 'ldapusername', 'ldapuserbinarykey', 'ldapoptions', 'ldapuseremail', 'footer', 'certurl', 'loginKey', 'userallowedip', 'agentallowedip', 'agentnoproxy', 'agentconfig', 'orphanagentuser', 'httpheaders', 'yubikey', 'passwordrequirements', 'limits', 'amtacmactivation', 'redirects', 'sessionrecording', 'hide', 'loginkey'];
     var domainObjectValues = [ 'ldapoptions', 'httpheaders', 'yubikey', 'passwordrequirements', 'limits', 'amtacmactivation', 'redirects', 'sessionrecording' ];
     var domainArrayValues = [ 'newaccountemaildomains', 'newaccountsrights', 'loginkey', 'agentconfig' ];
     var configChange = false;


### PR DESCRIPTION
Hi,

I use LDAP for users, and unfortunately meshcentral does not import user mail address from the directory. Most directories have some sort of email attribute. This PR :
- adds the `ldapuserEmail` option that allows to choose wich LDAP attribute to use. default is `mail`
- supports multivalued mail attribute. if the attribute is multivalued, which is allowed in LDAP, it uses the firs email address returned
- adds email on first import
- updates email if it changes when user logs in (same as username)

I did some quick tests both with the test LDAP and  real LDAP server and so far, I did not  notice any problem.

I don't know what exactly the `domainValues` in meshctrl.js is for. Everything worked well without `ldapuseremail`beeing added to the list. This is in a separate commit so it's easy to revert. BTW, I noticed that `ldapoptions` is present twice in the list...

Can be quickly tested wiht the following config.json if you log in with user anne or so.

Hope you'll like it.
Schplurtz
```
"domains": {
  "": {
    "Auth": "ldap",
    "ldapusername": "gecos",
    "ldapuserkey": "uid",
    "ldapuserEmail": "otherMail",
    "ldapoptions": {
      "url": "test",
      "anne": {
        "gecos": "Anne O'Nyme",
        "displayName": "O Nyme anne",
        "uid": "anneonyme",
        "mail": "anneonyme@example.com",
        "email": "anneonyme@example.com",
        "otherMail": [ "other.anneonyme@example.com", "anneonyme@example.com" ]
      },
      "so": {
        "displayName": "Sticker Sophie",
        "gecos": "Sophie Sticker",
        "uid": "ssticker",
        "mail": "ssticker@example.com",
        "email": "ssticker@example.com",
        "otherMail": [ "other.ssticker@example.com", "ssticker@example.com" ]
      }
    }
  }
}
```

