### PR TITLE
Add robots.txt to block search engines

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /


### PR DESCRIPTION
As much as I enjoy googling to find everyone running MeshCentral servers and see how outdated some of them are... they probably shouldn't be listed!

Also referenced [here](https://github.com/Ylianst/MeshCentral/issues/1227#issuecomment-618667608), but figured I'd just issue a PR for it in case it was forgotten about!