### PR TITLE
Fixed: Testing for a valid filename on a folder path causes plugins w…

### DIFF
--- a/pluginHandler.js
+++ b/pluginHandler.js
@@ -518,7 +518,8 @@ module.exports.pluginHandler = function (parent) {
     obj.handleAdminReq = function (req, res, user, serv) {
         if ((req.query.pin == null) || (obj.common.isAlphaNumeric(req.query.pin) !== true)) { res.sendStatus(401); return; }
         var path = obj.path.join(obj.pluginPath, req.query.pin, 'views');
-        if (obj.common.IsFilenameValid(path) !== true) { res.sendStatus(401); return; }
+        // path isn't a filename, it is a folder path
+        //if (obj.common.IsFilenameValid(path) !== true) { res.sendStatus(401); return; }
         serv.app.set('views', path);
         if ((obj.plugins[req.query.pin] != null) && (typeof obj.plugins[req.query.pin].handleAdminReq == 'function')) {
             obj.plugins[req.query.pin].handleAdminReq(req, res, user);
@@ -530,7 +531,8 @@ module.exports.pluginHandler = function (parent) {
     obj.handleAdminPostReq = function (req, res, user, serv) {
         if ((req.query.pin == null) || (obj.common.isAlphaNumeric(req.query.pin) !== true)) { res.sendStatus(401); return; }
         var path = obj.path.join(obj.pluginPath, req.query.pin, 'views');
-        if (obj.common.IsFilenameValid(path) !== true) { res.sendStatus(401); return; }
+        // path isn't a filename, it is a folder path
+        //if (obj.common.IsFilenameValid(path) !== true) { res.sendStatus(401); return; }
         serv.app.set('views', path);
         if ((obj.plugins[req.query.pin] != null) && (typeof obj.plugins[req.query.pin].handleAdminPostReq == 'function')) {
             obj.plugins[req.query.pin].handleAdminPostReq(req, res, user);


### PR DESCRIPTION
…ith views to fail to load associated views

Looks like commit 7f75ae419cee8fc7357d96ab93360a3b7826e38d added some validation checks, including this folder path with a file name validity check (causing a failure since it is a folder).

Not sure if there's a new built-in folder validation you'd want to use instead or if IsFilenameValid() should be updated for folders as well, but I saw [this](https://www.reddit.com/r/MeshCentral/comments/hn5fs0/plugin_unauthorized/) post with the issue and verified it.

Thank you as always!