### PR TITLE
Fix incorrect command in meshctrl.js's --help output

### DIFF
--- a/meshctrl.js
+++ b/meshctrl.js
@@ -19,7 +19,7 @@ if (args['_'].length == 0) {
     console.log("  ServerInfo                - Show server information.");
     console.log("  UserInfo                  - Show user information.");
     console.log("  ListUsers                 - List user accounts.");
-    console.log("  ListUsersSessions         - List online users.");
+    console.log("  ListUserSessions          - List online users.");
     console.log("  ListUserGroups            - List user groups.");
     console.log("  ListDevices               - List devices.");
     console.log("  ListDeviceGroups          - List device groups.");


### PR DESCRIPTION
This pull request fixes a typo in the output of meshctrl.js's `--help` flag. The command for listing online users is `ListUserSessions`, not `ListUsersSessions`.