### PR TITLE
Update the error text and "help" output for all commands which use a device or group ID

### DIFF
--- a/meshctrl.js
+++ b/meshctrl.js
@@ -71,36 +71,36 @@ if (args['_'].length == 0) {
         case 'listdevicegroups': { ok = true; break; }
         case 'listdevices': { ok = true; break; }
         case 'listusersofdevicegroup': {
-            if (args.id == null) { console.log("Missing group id, use --id [groupid]"); }
+            if (args.id == null) { console.log("Missing group id, use --id '[groupid]'"); }
             else { ok = true; }
             break;
         }
         case 'deviceinfo': {
-            if (args.id == null) { console.log("Missing device id, use --id [deviceid]"); }
+            if (args.id == null) { console.log("Missing device id, use --id '[deviceid]'"); }
             else { ok = true; }
             break;
         }
         case 'addusertodevicegroup': {
-            if ((args.id == null) && (args.group == null)) { console.log("Device group identifier missing, use --id [groupid] or --group [groupname]"); }
+            if ((args.id == null) && (args.group == null)) { console.log("Device group identifier missing, use --id '[groupid]' or --group [groupname]"); }
             else if (args.userid == null) { console.log("Add user to group missing useid, use --userid [userid]"); }
             else { ok = true; }
             break;
         }
         case 'removeuserfromdevicegroup': {
-            if ((args.id == null) && (args.group == null)) { console.log("Device group identifier missing, use --id [groupid] or --group [groupname]"); }
+            if ((args.id == null) && (args.group == null)) { console.log("Device group identifier missing, use --id '[groupid]' or --group [groupname]"); }
             else if (args.userid == null) { console.log("Remove user from group missing useid, use --userid [userid]"); }
             else { ok = true; }
             break;
         }
         case 'addusertodevice': {
-            if (args.userid == null) { console.log("Add user to device missing useid, use --userid [userid]"); }
-            else if (args.id == null) { console.log("Add user to device missing device id, use --id [deviceid]"); }
+            if (args.userid == null) { console.log("Add user to device missing userid, use --userid [userid]"); }
+            else if (args.id == null) { console.log("Add user to device missing device id, use --id '[deviceid]'"); }
             else { ok = true; }
             break;
         }
         case 'removeuserfromdevice': {
-            if (args.userid == null) { console.log("Remove user from device missing useid, use --userid [userid]"); }
-            else if (args.id == null) { console.log("Remove user from device missing device id, use --id [deviceid]"); }
+            if (args.userid == null) { console.log("Remove user from device missing userid, use --userid [userid]"); }
+            else if (args.id == null) { console.log("Remove user from device missing device id, use --id '[deviceid]'"); }
             else { ok = true; }
             break;
         }
@@ -110,13 +110,13 @@ if (args['_'].length == 0) {
             break;
         }
         case 'removedevicegroup': {
-            if ((args.id == null) && (args.group == null)) { console.log("Device group identifier missing, use --id [groupid] or --group [groupname]"); }
+            if ((args.id == null) && (args.group == null)) { console.log("Device group identifier missing, use --id '[groupid]' or --group [groupname]"); }
             else { ok = true; }
             break;
         }
         case 'movetodevicegroup': {
-            if ((args.id == null) && (args.group == null)) { console.log("Device group identifier missing, use --id [groupid] or --group [groupname]"); }
-            else if (args.devid == null) { console.log("Device identifier missing, use --devid [deviceid]"); }
+            if ((args.id == null) && (args.group == null)) { console.log("Device group identifier missing, use --id '[groupid]' or --group [groupname]"); }
+            else if (args.devid == null) { console.log("Device identifier missing, use --devid '[deviceid]'"); }
             else { ok = true; }
             break;
         }
@@ -146,35 +146,35 @@ if (args['_'].length == 0) {
             break;
         }
         case 'removeusergroup': {
-            if (args.groupid == null) { console.log("Remove user group id missing, use --groupid [id]"); }
+            if (args.groupid == null) { console.log("Remove user group id missing, use --groupid '[id]'"); }
             else { ok = true; }
             break;
         }
         case 'sendinviteemail': {
-            if ((args.id == null) && (args.group == null)) { console.log("Device group identifier missing, use --id [groupid] or --group [groupname]"); }
+            if ((args.id == null) && (args.group == null)) { console.log("Device group identifier missing, use --id '[groupid]' or --group [groupname]"); }
             else if (args.email == null) { console.log("Device email is missing, use --email [email]"); }
 			else { ok = true; }
             break;
         }
         case 'generateinvitelink': {
-            if ((args.id == null) && (args.group == null)) { console.log("Device group identifier missing, use --id [groupid] or --group [groupname]"); }
+            if ((args.id == null) && (args.group == null)) { console.log("Device group identifier missing, use --id '[groupid]' or --group [groupname]"); }
             else if (args.hours == null) { console.log("Invitation validity period missing, use --hours [hours]"); }
             else { ok = true; }
             break;
         }
         case 'runcommand': {
-            if (args.id == null) { console.log("Missing device id, use --id [deviceid]"); }
+            if (args.id == null) { console.log("Missing device id, use --id '[deviceid]'"); }
             else if (args.run == null) { console.log("Missing run, use --run \"command\""); }
             else { ok = true; }
             break;
         }
         case 'shell': {
-            if (args.id == null) { console.log("Missing device id, use --id [deviceid]"); }
+            if (args.id == null) { console.log("Missing device id, use --id '[deviceid]'"); }
             else { ok = true; }
             break;
         }
         case 'upload': {
-            if (args.id == null) { console.log("Missing device id, use --id [deviceid]"); }
+            if (args.id == null) { console.log("Missing device id, use --id '[deviceid]'"); }
             else if (args.file == null) { console.log("Local file missing, use --file [file] specify the file to upload"); }
             else if (args.target == null) { console.log("Remote target path missing, use --target [path] to specify the remote location"); }
             else if (require('fs').existsSync(args.file) == false) { console.log("Local file does not exists, check --file"); }
@@ -182,7 +182,7 @@ if (args['_'].length == 0) {
             break;
         }
         case 'download': {
-            if (args.id == null) { console.log("Missing device id, use --id [deviceid]"); }
+            if (args.id == null) { console.log("Missing device id, use --id '[deviceid]'"); }
             else if (args.file == null) { console.log("Remote file missing, use --file [file] specify the remote file to download"); }
             else if (args.target == null) { console.log("Target path missing, use --target [path] to specify the local download location"); }
             else { ok = true; }
@@ -199,10 +199,10 @@ if (args['_'].length == 0) {
                     }
                     case 'sendinviteemail': {
                         console.log("Send invitation email with instructions on how to install the mesh agent for a specific device group. Example usage:\r\n");
-                        console.log("  MeshCtrl SendInviteEmail --id devicegroupid --message \"msg\" --email user@sample.com");
+                        console.log("  MeshCtrl SendInviteEmail --id 'groupid' --message \"msg\" --email user@sample.com");
                         console.log("  MeshCtrl SendInviteEmail --group \"My Computers\" --name \"Jack\" --email user@sample.com");
                         console.log("\r\nRequired arguments:\r\n");
-                        console.log("  --id [groupid]         - Device group identifier (or --group).");
+                        console.log("  --id '[groupid]'       - Device group identifier (or --group).");
                         console.log("  --group [groupname]    - Device group name (or --id).");
                         console.log("  --email [email]        - Email address.");
                         console.log("\r\nOptional arguments:\r\n");
@@ -212,10 +212,10 @@ if (args['_'].length == 0) {
                     }
                     case 'generateinvitelink': {
                         console.log("Generate a agent invitation URL for a given group. Example usage:\r\n");
-                        console.log("  MeshCtrl GenerateInviteLink --id devicegroupid --hours 24");
+                        console.log("  MeshCtrl GenerateInviteLink --id 'groupid' --hours 24");
                         console.log("  MeshCtrl GenerateInviteLink --group \"My Computers\" --hours 0");
                         console.log("\r\nRequired arguments:\r\n");
-                        console.log("  --id [groupid]         - Device group identifier (or --group).");
+                        console.log("  --id '[groupid]'       - Device group identifier (or --group).");
                         console.log("  --group [groupname]    - Device group name (or --id).");
                         console.log("  --hours [hours]        - Validity period in hours or 0 for infinit.");
                         break;
@@ -276,10 +276,10 @@ if (args['_'].length == 0) {
                     case 'listdevices': {
                         console.log("List devices, Example usages:\r\n");
                         console.log("  MeshCtrl ListDevices");
-                        console.log("  MeshCtrl ListDevices -id [groupid] --json");
+                        console.log("  MeshCtrl ListDevices -id '[groupid]' --json");
                         console.log("\r\nOptional arguments:\r\n");
-                        console.log("  --id [groupid]         - Filter by  group identifier (or --group).");
-                        console.log("  --group [groupname]    - Filter by  group name (or --id).");
+                        console.log("  --id '[groupid]'       - Filter by group identifier (or --group).");
+                        console.log("  --group [groupname]    - Filter by group name (or --id).");
                         console.log("  --count                - Only return the device count.");
                         console.log("  --json                 - Show result as JSON.");
                         break;
@@ -288,7 +288,7 @@ if (args['_'].length == 0) {
                         console.log("List users that have permissions for a given device group, Example usage:\r\n");
                         console.log("  MeshCtrl ListUserOfDeviceGroup ");
                         console.log("\r\nRequired arguments:\r\n");
-                        console.log("  --id [groupid]         - Device group identifier.");
+                        console.log("  --id '[groupid]'       - Device group identifier.");
                         console.log("\r\nOptional arguments:\r\n");
                         console.log("  --json                 - Show result as JSON.");
                         break;
@@ -334,27 +334,27 @@ if (args['_'].length == 0) {
                     }
                     case 'removedevicegroup': {
                         console.log("Remove a device group, Example usages:\r\n");
-                        console.log("  MeshCtrl RemoveDeviceGroup --id groupid");
+                        console.log("  MeshCtrl RemoveDeviceGroup --id 'groupid'");
                         console.log("\r\nRequired arguments:\r\n");
-                        console.log("  --id [groupid]         - Device group identifier (or --group).");
+                        console.log("  --id '[groupid]'       - Device group identifier (or --group).");
                         console.log("  --group [groupname]    - Device group name (or --id).");
                         break;
                     }
                     case 'movetodevicegroup': {
                         console.log("Move a device to a new device group, Example usages:\r\n");
-                        console.log("  MeshCtrl MoveToDeviceGroup --devid deviceid --id groupid");
+                        console.log("  MeshCtrl MoveToDeviceGroup --devid 'deviceid' --id 'groupid'");
                         console.log("\r\nRequired arguments:\r\n");
-                        console.log("  --id [groupid]         - Device group identifier (or --group).");
+                        console.log("  --id '[groupid]'       - Device group identifier (or --group).");
                         console.log("  --group [groupname]    - Device group name (or --id).");
-                        console.log("  --devid [deviceid]     - Device identifier.");
+                        console.log("  --devid '[deviceid]'   - Device identifier.");
                         break;
                     }
                     case 'addusertodevicegroup': {
                         console.log("Add a user to a device group, Example usages:\r\n");
-                        console.log("  MeshCtrl AddUserToDeviceGroup --id groupid --userid userid --fullrights");
+                        console.log("  MeshCtrl AddUserToDeviceGroup --id 'groupid' --userid userid --fullrights");
                         console.log("  MeshCtrl AddUserToDeviceGroup --group groupname --userid userid --editgroup --manageusers");
                         console.log("\r\nRequired arguments:\r\n");
-                        console.log("  --id [groupid]         - Device group identifier (or --group).");
+                        console.log("  --id '[groupid]'       - Device group identifier (or --group).");
                         console.log("  --group [groupname]    - Device group name (or --id).");
                         console.log("  --userid [userid]      - The user identifier.");
                         console.log("\r\nOptional arguments:\r\n");
@@ -384,19 +384,19 @@ if (args['_'].length == 0) {
                     }
                     case 'removeuserfromdevicegroup': {
                         console.log("Remove a user from a device group, Example usages:\r\n");
-                        console.log("  MeshCtrl RemoveuserFromDeviceGroup --id groupid --userid userid");
+                        console.log("  MeshCtrl RemoveuserFromDeviceGroup --id 'groupid' --userid userid");
                         console.log("\r\nRequired arguments:\r\n");
-                        console.log("  --id [groupid]         - Device group identifier (or --group).");
+                        console.log("  --id '[groupid]'       - Device group identifier (or --group).");
                         console.log("  --group [groupname]    - Device group name (or --id).");
                         console.log("  --userid [userid]      - The user identifier.");
                         break;
                     }
                     case 'addusertodevice': {
                         console.log("Add a user to a device, Example usages:\r\n");
-                        console.log("  MeshCtrl AddUserToDevice --id deviceid --userid userid --fullrights");
-                        console.log("  MeshCtrl AddUserToDevice --id deviceid --userid userid --remotecontrol");
+                        console.log("  MeshCtrl AddUserToDevice --id 'deviceid' --userid userid --fullrights");
+                        console.log("  MeshCtrl AddUserToDevice --id 'deviceid' --userid userid --remotecontrol");
                         console.log("\r\nRequired arguments:\r\n");
-                        console.log("  --id [deviceid]        - The device identifier.");
+                        console.log("  --id '[deviceid]'      - The device identifier.");
                         console.log("  --userid [userid]      - The user identifier.");
                         console.log("\r\nOptional arguments:\r\n");
                         console.log("  --fullrights           - Allow full rights over this device.");
@@ -417,9 +417,9 @@ if (args['_'].length == 0) {
                     }
                     case 'removeuserfromdevice': {
                         console.log("Remove a user from a device, Example usages:\r\n");
-                        console.log("  MeshCtrl RemoveuserFromDeviceGroup --id deviceid --userid userid");
+                        console.log("  MeshCtrl RemoveuserFromDeviceGroup --id 'deviceid' --userid userid");
                         console.log("\r\nRequired arguments:\r\n");
-                        console.log("  --id [deviceid]        - The device identifier.");
+                        console.log("  --id '[deviceid]'      - The device identifier.");
                         console.log("  --userid [userid]      - The user identifier.");
                         break;
                     }
@@ -432,10 +432,10 @@ if (args['_'].length == 0) {
                     }
                     case 'deviceinfo': {
                         console.log("Display information about a device, Example usages:\r\n");
-                        console.log("  MeshCtrl DeviceInfo --id deviceid");
-                        console.log("  MeshCtrl DeviceInfo --id deviceid --json");
+                        console.log("  MeshCtrl DeviceInfo --id 'deviceid'");
+                        console.log("  MeshCtrl DeviceInfo --id 'deviceid' --json");
                         console.log("\r\nRequired arguments:\r\n");
-                        console.log("  --id [deviceid]        - The device identifier.");
+                        console.log("  --id '[deviceid]'      - The device identifier.");
                         console.log("\r\nOptional arguments:\r\n");
                         console.log("  --raw                  - Output raw data in JSON format.");
                         console.log("  --json                 - Give results in JSON format.");
@@ -443,10 +443,10 @@ if (args['_'].length == 0) {
                     }
                     case 'runcommand': {
                         console.log("Run a shell command on a remote device, Example usages:\r\n");
-                        console.log("  MeshCtrl RunCommand --id deviceid --run \"command\"");
-                        console.log("  MeshCtrl RunCommand --id deviceid --run \"command\" --powershell");
+                        console.log("  MeshCtrl RunCommand --id 'deviceid' --run \"command\"");
+                        console.log("  MeshCtrl RunCommand --id 'deviceid' --run \"command\" --powershell");
                         console.log("\r\nRequired arguments:\r\n");
-                        console.log("  --id [deviceid]        - The device identifier.");
+                        console.log("  --id '[deviceid]'      - The device identifier.");
                         console.log("  --run \"[command]\"    - Shell command to execute on the remote device.");
                         console.log("\r\nOptional arguments:\r\n");
                         console.log("  --powershell           - Run in Windows PowerShell.");
@@ -454,30 +454,30 @@ if (args['_'].length == 0) {
                     }
                     case 'shell': {
                         console.log("Access a command shell on a remote device, Example usages:\r\n");
-                        console.log("  MeshCtrl Shell --id deviceid");
-                        console.log("  MeshCtrl Shell --id deviceid --powershell");
+                        console.log("  MeshCtrl Shell --id 'deviceid'");
+                        console.log("  MeshCtrl Shell --id 'deviceid' --powershell");
                         console.log("\r\nRequired arguments:\r\n");
-                        console.log("  --id [deviceid]        - The device identifier.");
+                        console.log("  --id '[deviceid]'      - The device identifier.");
                         console.log("\r\nOptional arguments:\r\n");
                         console.log("  --powershell           - Run a Windows PowerShell.");
                         break;
                     }
                     case 'upload': {
                         console.log("Upload a local file to a remote device, Example usages:\r\n");
-                        console.log("  MeshCtrl Upload --id deviceid --file sample.txt --target c:\\");
-                        console.log("  MeshCtrl Upload --id deviceid --file sample.txt --target /tmp");
+                        console.log("  MeshCtrl Upload --id 'deviceid' --file sample.txt --target c:\\");
+                        console.log("  MeshCtrl Upload --id 'deviceid' --file sample.txt --target /tmp");
                         console.log("\r\nRequired arguments:\r\n");
-                        console.log("  --id [deviceid]        - The device identifier.");
+                        console.log("  --id '[deviceid]'      - The device identifier.");
                         console.log("  --file [localfile]     - The local file to upload.");
                         console.log("  --target [remotepath]  - The remote path to upload the file to.");
                         break;
                     }
                     case 'download': {
                         console.log("Download a file from a remote device, Example usages:\r\n");
-                        console.log("  MeshCtrl Download --id deviceid --file C:\\sample.txt --target c:\\temp");
-                        console.log("  MeshCtrl Download --id deviceid --file /tmp/sample.txt --target /tmp");
+                        console.log("  MeshCtrl Download --id 'deviceid' --file C:\\sample.txt --target c:\\temp");
+                        console.log("  MeshCtrl Download --id 'deviceid' --file /tmp/sample.txt --target /tmp");
                         console.log("\r\nRequired arguments:\r\n");
-                        console.log("  --id [deviceid]        - The device identifier.");
+                        console.log("  --id '[deviceid]'      - The device identifier.");
                         console.log("  --file [remotefile]    - The remote file to download.");
                         console.log("\r\nOptional arguments:\r\n");
                         console.log("  --target [localpath]   - The local path to download the file to.");


### PR DESCRIPTION
**Error text:** Before

```
whalehub@pdh:~# meshctrl deviceinfo
Missing device id, use --id [deviceid]
```

**Error text:** After

```
whalehub@pdh:~# meshctrl deviceinfo
Missing device id, use --id '[deviceid]'
```

#

**Help text:** Before

```
whalehub@pdh:~# meshctrl help deviceinfo
Display information about a device, Example usages:

  MeshCtrl DeviceInfo --id deviceid
  MeshCtrl DeviceInfo --id deviceid --json

Required arguments:

  --id [deviceid]        - The device identifier.

Optional arguments:

  --raw                  - Output raw data in JSON format.
  --json                 - Give results in JSON format.
```

**Help text:** After

```
whalehub@pdh:~# meshctrl help deviceinfo
Display information about a device, Example usages:

  MeshCtrl DeviceInfo --id 'deviceid'
  MeshCtrl DeviceInfo --id 'deviceid' --json

Required arguments:

  --id '[deviceid]'      - The device identifier.

Optional arguments:

  --raw                  - Output raw data in JSON format.
  --json                 - Give results in JSON format.
```