### PR TITLE
Add check node.agent!=null to fix AMT only broken view.

### DIFF
--- a/views/default.handlebars
+++ b/views/default.handlebars
@@ -5617,7 +5617,7 @@
                 x += '<input type=button value="' + "Log Event" + '" title="' + "Write an event for this device" + '" onclick=writeDeviceEvent("' + encodeURIComponentEx(node._id) + '") />';
                 if ((connectivity & 1) && (meshrights & 8)) { x += '<input type=button value="' + "Message" + '" title="' + "Display a text message on the remote device" + '" onclick=deviceMessageFunction() />';  }
                 //if ((connectivity & 1) && (meshrights & 8) && (node.agent.id < 5)) { x += '<input type=button value=Toast title="' + "Display a text message of the remote device" + '" onclick=deviceToastFunction() />';  }
-                if ((node.agent.caps & 1) && (connectivity & 1) && (meshrights & 8) && ((meshrights == 0xFFFFFFFF) || ((meshrights & 4352) == 0))) { x += '<input type=button value="' + "Share" + '" title="' + "Create a link to share this device with a guest" + '" onclick=showShareDevice() />'; }
+                if ((node.agent!=null) && (node.agent.caps & 1) && (connectivity & 1) && (meshrights & 8) && ((meshrights == 0xFFFFFFFF) || ((meshrights & 4352) == 0))) { x += '<input type=button value="' + "Share" + '" title="' + "Create a link to share this device with a guest" + '" onclick=showShareDevice() />'; }
 
                 // Custom UI
                 if ((customui != null) && (customui.devicebuttons != null)) {


### PR DESCRIPTION
This small patch fix broken view on AMT only device. On AMT only device (CIRA or Direct) node.agent property does not exists thus it will throws exception which in turn break view rendering.