### PR TITLE
meshcentral-config-schema.json: Fix schema URL

### DIFF
--- a/meshcentral-config-schema.json
+++ b/meshcentral-config-schema.json
@@ -1,5 +1,5 @@
 {
-  "id": "http://info.meshcentral.com/download/meshcentral-config-schema.json",
+  "id": "https://info.meshcentral.com/downloads/meshcentral-config-schema.json",
   "$schema": "http://json-schema.org/draft-04/schema#",
   "description": "MeshCentral configuration file schema",
   "type": "object",


### PR DESCRIPTION
The current URL points to a 404 page. This pull request fixes that issue.