### PR TITLE
mongodump to dev null for dry-run effect

### DIFF
--- a/db.js
+++ b/db.js
@@ -1595,6 +1595,7 @@ module.exports.CreateDB = function (parent, func) {
             if (parent.config.settings.autobackup && parent.config.settings.autobackup.mongodumppath) { mongoDumpPath = parent.config.settings.autobackup.mongodumppath; }
             var cmd = '"' + mongoDumpPath + '"';
             if (dburl) { cmd = '\"' + mongoDumpPath + '\" --uri=\"' + dburl.replace('?', '/?') + '\"'; }
+            cmd += (parent.platform == 'win32') ? ' --archive=\"nul\"' : ' --archive=\"/dev/null\"';
             const child_process = require('child_process');
             child_process.exec(cmd, { cwd: backupPath }, function (error, stdout, stderr) {
                 try {


### PR DESCRIPTION
This change causes mongodump to dump to a null device when it runs `checkBackupCapability` as to not actually create a dump file. Mongodump does not have any builtin dry-run option for testing if the command will be successful.

- Tested for windows, linux, openbsd

#### Reason for the change
As it stands, when meshcentral starts and checks for mongodump backup capabilities in `checkBackupCapability`, it does so by simply running mongodump.

When mongodump is run without the --archive flag, it simply dumps the entire mongodb database into the current working directory. Every time meshcentral starts, it dumps the entire mongodb into the backup directory, unzipped and without a password.

In my view, this defeats the purpose of being able to password protect the zip files. It also seems like an unwanted side-effect.


Example:
<pre>noah_zalev@L460:~/Documents/meshc_testing$ node node_modules/meshcentral
MeshCentral HTTP redirection server running on port 1024.
MeshCentral v0.8.7, LAN mode.
Server has no users, next new account will be site administrator.

WARNING: MeshCentral is running without permissions to use ports below 1025.
         Use setcap to grant access to lower ports, or read installation guide.

   sudo setcap &apos;cap_net_bind_service=+ep&apos; `which node` 
MeshCentral HTTPS server running on port 1025.
^CServer Ctrl-C exit...
<br>
noah_zalev@L460:~/Documents/meshc_testing$ ls -l meshcentral-backup/
total 4
drwxrwxr-x 4 noah_z noah_z 4096 Apr 10 14:26 <font color="#295FCC"><b>dump</b></font>
<br>
noah_zalev@L460:~/Documents/meshc_testing$ ls -l meshcentral-backup/dump/
total 8
drwxrwxr-x 2 noah_z noah_z 4096 Apr 10 14:26 <font color="#295FCC"><b>admin</b></font>
drwxrwxr-x 2 noah_z noah_z 4096 Apr 10 14:26 <font color="#295FCC"><b>meshcentral</b></font>
noah_zalev@L460:~/Documents/meshc_testing$ 
</pre>