### PR TITLE
Add mariadb/mysql db dumps to autobackups

### DIFF
--- a/db.js
+++ b/db.js
@@ -1841,7 +1841,7 @@ module.exports.CreateDB = function (parent, func) {
                         }
                         output.on('close', function () {
                             obj.performingBackup = false;
-                            if (func) { if (sqlDumpSuccess) { func('Auto-backup completed.'); } else { func('Auto-backup completed without mongodb database: ' + error); } }
+                            if (func) { if (sqlDumpSuccess) { func('Auto-backup completed.'); } else { func('Auto-backup completed without MySQL/MariaDB database: ' + error); } }
                             obj.performCloudBackup(newAutoBackupPath + '.zip', func);
                             setTimeout(function () { try { parent.fs.unlink(newBackupPath + '.sql', function () { }); } catch (ex) { console.log(ex); } }, 5000);
                         });

--- a/db.js
+++ b/db.js
@@ -1618,10 +1618,12 @@ module.exports.CreateDB = function (parent, func) {
             var props = (obj.databaseType == 4) ? parent.args.mariadb : parent.args.mysql;
             var mysqldumpPath = 'mysqldump';
             if (parent.config.settings.autobackup && parent.config.settings.autobackup.mysqldumppath) { mysqldumpPath = parent.config.settings.autobackup.mysqldumppath; }
-            var cmd = '\"' + mysqldumpPath + '\" --user=\'' + props.user + '\' --password=\'' + props.password + '\'';
+            var cmd = '\"' + mysqldumpPath + '\" --user=\'' + props.user + '\'';
+            // Windows will treat ' as part of the pw. Linux/Unix requires it to escape.
+            cmd += (parent.platform == 'win32') ? ' --password=\"' + props.password + '\"' : ' --password=\'' + props.password + '\'';
             if (props.host) { cmd += ' -h ' + props.host; }
             if (props.port) { cmd += ' -P ' + props.port; }
-            cmd += ' meshcentral --result-file=' + ((parent.platform == 'win32') ? '\"nul\"' : '\"/dev/null\"');
+            cmd += ' meshcentral > ' + ((parent.platform == 'win32') ? '\"nul\"' : '\"/dev/null\"');
             const child_process = require('child_process');
             child_process.exec(cmd, { cwd: backupPath }, function(error, stdout, stdin) {
                 try {
@@ -1815,7 +1817,9 @@ module.exports.CreateDB = function (parent, func) {
                 var props = (obj.databaseType == 4) ? parent.args.mariadb : parent.args.mysql;
                 var mysqldumpPath = 'mysqldump';
                 if (parent.config.settings.autobackup && parent.config.settings.autobackup.mysqldumppath) { mysqldumpPath = parent.config.settings.autobackup.mysqldumppath; }
-                var cmd = '\"' + mysqldumpPath + '\" --user=\'' + props.user + '\' --password=\'' + props.password + '\'';
+                var cmd = '\"' + mysqldumpPath + '\" --user=\'' + props.user + '\'';
+                // Windows will treat ' as part of the pw. Linux/Unix requires it to escape.
+                cmd += (parent.platform == 'win32') ? ' --password=\"' + props.password + '\"' : ' --password=\'' + props.password + '\'';
                 if (props.host) { cmd += ' -h ' + props.host; }
                 if (props.port) { cmd += ' -P ' + props.port; }
                 cmd += ' meshcentral --result-file=\"' + newBackupPath + '.sql\"';

--- a/meshcentral-config-schema.json
+++ b/meshcentral-config-schema.json
@@ -141,6 +141,7 @@
           "type": "object",
           "properties": {
             "mongoDumpPath": { "type": "string" },
+            "mysqlDumpPath": { "type": "string"},
             "backupIntervalHours": { "type": "integer" },
             "keepLastDaysBackup": { "type": "integer" },
             "zipPassword": { "type": "string" },


### PR DESCRIPTION
I have added mysql/mariadb database dumps to the automatic backups.

There are three main areas added:

1. Added a check for mysqldump to checkBackupCapability
2. Added db dump + archive for mysql and mariadb databases in performBackup
3. Added mysqldump path to config schema

I have tested MariaDB on linux and windows. MySQL has the same syntax.

<br>
<br>
PS:
The logic of performing db backups is very similar between MongoDB and MariaDB/MySQL. The overall structure is the same:

1. set up the dump command
2. run child process
3. perform archiving in callback function

If you want, I can refactor the db backups in a future commit (both mongodb and mariadb/mysql) since the only real difference is in setting up the dump command.