### PR TITLE
Register output error listener in autobackups

### DIFF
--- a/db.js
+++ b/db.js
@@ -1802,6 +1802,7 @@ module.exports.CreateDB = function (parent, func) {
                             setTimeout(function () { try { parent.fs.unlink(newBackupPath + '.archive', function () { }); } catch (ex) { console.log(ex); } }, 5000);
                         });
                         output.on('end', function () { });
+                        output.on('error', function (err) { console.log('Backup error: ' + err); if (func) { func('Backup error: ' + err); } });
                         archive.on('warning', function (err) { console.log('Backup warning: ' + err); if (func) { func('Backup warning: ' + err); } });
                         archive.on('error', function (err) { console.log('Backup error: ' + err); if (func) { func('Backup error: ' + err); } });
                         archive.pipe(output);
@@ -1846,6 +1847,7 @@ module.exports.CreateDB = function (parent, func) {
                             setTimeout(function () { try { parent.fs.unlink(newBackupPath + '.sql', function () { }); } catch (ex) { console.log(ex); } }, 5000);
                         });
                         output.on('end', function () { });
+                        output.on('error', function (err) { console.log('Backup error: ' + err); if (func) { func('Backup error: ' + err); } });
                         archive.on('warning', function (err) { console.log('Backup warning: ' + err); if (func) { func('Backup warning: ' + err); } });
                         archive.on('error', function (err) { console.log('Backup error: ' + err); if (func) { func('Backup error: ' + err); } });
                         archive.pipe(output);
@@ -1867,6 +1869,7 @@ module.exports.CreateDB = function (parent, func) {
                 }
                 output.on('close', function () { obj.performingBackup = false; if (func) { func('Auto-backup completed.'); } obj.performCloudBackup(newAutoBackupPath + '.zip', func); });
                 output.on('end', function () { });
+                output.on('error', function (err) { console.log('Backup error: ' + err); if (func) { func('Backup error: ' + err); } });
                 archive.on('warning', function (err) { console.log('Backup warning: ' + err); if (func) { func('Backup warning: ' + err); } });
                 archive.on('error', function (err) { console.log('Backup error: ' + err); if (func) { func('Backup error: ' + err); } });
                 archive.pipe(output);


### PR DESCRIPTION
An invalid path name (or other similar errors) will cause meshcentral to crash and restart during an autobackup. This happens because `output` emits an ENOENT event. This is resolved by registering an error listener.

---

##### Crash example
<pre><font color="#4CE64C"><b>noah_zalev@L460</b></font>:<font color="#295FCC"><b>~/Documents/meshc_testing</b></font>$ node node_modules/meshcentral/
WARNING: Unable to find mysqldump, MySQL/MariaDB database auto-backup will not be performed.
MeshCentral HTTP redirection server running on port 1024.
MeshCentral v0.8.7, LAN mode.
MeshCentral HTTPS server running on port 4430.
ERROR: Unable to perform MySQL/MariaDB backup: Error: spawn /bin/sh ENOENT
ERR: events.js:174
      throw er; // Unhandled &apos;error&apos; event
      ^

Error: ENOENT: no such file or directory, open &apos;/invalid/path/meshcentral-autobackup-2021-04-11-21-45.zip&apos;
Emitted &apos;error&apos; event at:
    at errorOrDestroy (/home/noah_zalev/Documents/meshc_testing/node_modules/readable-stream/lib/internal/streams/destroy.js:98:101)
    at WriteStream.onerror (/home/noah_zalev/Documents/meshc_testing/node_modules/readable-stream/lib/_stream_readable.js:704:47)
    at WriteStream.emit (events.js:198:13)
    at lazyFs.open (internal/fs/streams.js:277:12)
    at FSReqWrap.args [as oncomplete] (fs.js:140:20)
{ Error: Command failed: /usr/bin/node /home/noah_zalev/Documents/meshc_testing/node_modules/meshcentral --launch 2091761
events.js:174
      throw er; // Unhandled &apos;error&apos; event
      ^

Error: ENOENT: no such file or directory, open &apos;/invalid/path/meshcentral-autobackup-2021-04-11-21-45.zip&apos;
Emitted &apos;error&apos; event at:
    at errorOrDestroy (/home/noah_zalev/Documents/meshc_testing/node_modules/readable-stream/lib/internal/streams/destroy.js:98:101)
    at WriteStream.onerror (/home/noah_zalev/Documents/meshc_testing/node_modules/readable-stream/lib/_stream_readable.js:704:47)
    at WriteStream.emit (events.js:198:13)
    at lazyFs.open (internal/fs/streams.js:277:12)
    at FSReqWrap.args [as oncomplete] (fs.js:140:20)

    at ChildProcess.exithandler (child_process.js:294:12)
    at ChildProcess.emit (events.js:203:15)
    at maybeClose (internal/child_process.js:982:16)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:259:5)
  killed: <font color="#AA5500">false</font>,
  code: <font color="#AA5500">1</font>,
  signal: <font color="#FFFFFF"><b>null</b></font>,
  cmd:
   <font color="#44AA44">&apos;/usr/bin/node /home/noah_zalev/Documents/meshc_testing/node_modules/meshcentral --launch 2091761&apos;</font> }
ERROR: MeshCentral failed with critical error, check mesherrors.txt. Restarting in 5 seconds...
</pre>

---

##### New behaviour

![2504](https://user-images.githubusercontent.com/63608819/114330964-e9d89780-9b10-11eb-847f-742d1e6e28a0.png)
