### PR TITLE
Fixed log.txt permission bits

### DIFF
--- a/meshcentral.js
+++ b/meshcentral.js
@@ -2844,7 +2844,7 @@ function CreateMeshCentralServer(config, args) {
                 const d = new Date();
                 if (obj.xxLogFile == null) {
                     try {
-                        obj.xxLogFile = obj.fs.openSync(obj.getConfigFilePath('log.txt'), 'a+', 666);
+                        obj.xxLogFile = obj.fs.openSync(obj.getConfigFilePath('log.txt'), 'a+', 0o666);
                         obj.fs.writeSync(obj.xxLogFile, '---- Log start at ' + new Date().toLocaleString() + ' ----\r\n');
                         obj.xxLogDateStr = d.toLocaleDateString();
                     } catch (ex) { }


### PR DESCRIPTION
The permission bits must be expressed in octal.

Old behaviour
<pre>--w--wx--T 1 noah_z noah_z   99 Apr 19 12:55 <font color="#4CE64C"><b>log.txt</b></font></pre>

New behaviour
<pre>-rw-rw-r-- 1 noah_z noah_z   99 Apr 19 12:59 log.txt</pre>