### PR TITLE
Bail if unable to connect to db

### DIFF
--- a/db.js
+++ b/db.js
@@ -467,7 +467,10 @@ module.exports.CreateDB = function (parent, func) {
         // Set the default database for the rest of this connections lifetime
         var useDatabase = 'USE ' + dbname;
         sqlDbQuery(useDatabase, null, function (err, docs) {
-            if (err != null) { console.log(err); parent.debug('db', 'ERROR: ' + useDatabase + ': ' + err); }
+            if (err != null) {
+                console.log("Unable to connect to database: " + err);
+                process.exit();
+            }
             if (err == null) {
                 parent.debug('db', 'Checking tables...');
                 sqlDbBatchExec([


### PR DESCRIPTION
When I changed how a new database will be created in mysql/mariadb, I missed the final error condition which would call `setupFunctions()`. This will cause it to hang in the case that it doesn't have a database backend to work with. 

This also fixes the old behaviour, which was to start meshcentral _without a backend_, only for all data to be lost the next time it started.

The new behaviour is the same as what will happen with mongodb, which is to print an error and exit.

----

Mongodb
<pre><font color="#4CE64C"><b>noah_zalev@L460</b></font>:<font color="#295FCC"><b>~/Documents/meshc_testing</b></font>$ node node_modules/meshcentral/
Unable to connect to database: MongoServerSelectionError: connect ECONNREFUSED 127.0.0.1:27018
</pre>


New mysql/mariadb

Example error 1
<pre><font color="#4CE64C"><b>noah_zalev@L460</b></font>:<font color="#295FCC"><b>~/Documents/meshc_testing</b></font>$ node node_modules/meshcentral/
Unable to connect to database: Error: (conn=475, no: 1044, SQLState: 42000) Access denied for user &apos;meshcentral&apos;@&apos;localhost&apos; to database &apos;_meshcentral&apos;
sql: USE _meshcentral - parameters:[]
<font color="#4CE64C"><b>noah_zalev@L460</b></font>:<font color="#295FCC"><b>~/Documents/meshc_testing</b></font>$
</pre>
Example error 2
<pre>
<font color="#4CE64C"><b>noah_zalev@L460</b></font>:<font color="#295FCC"><b>~/Documents/meshc_testing</b></font>$ node node_modules/meshcentral/
Unable to connect to database: Error: retrieve connection from pool timeout after 10001ms
<font color="#4CE64C"><b>noah_zalev@L460</b></font>:<font color="#295FCC"><b>~/Documents/meshc_testing</b></font>$</pre>