### PR TITLE
Improved connectionObject creation

### DIFF
--- a/db.js
+++ b/db.js
@@ -443,15 +443,8 @@ module.exports.CreateDB = function (parent, func) {
         var dbname = (connectinArgs.database != null) ? connectinArgs.database : 'meshcentral';
 
         // Including the db name in the connection obj will cause a connection failure if it does not exist
-        var connectionObject = { 
-            'host': connectinArgs.host,
-            'port': connectinArgs.port,
-            'user': connectinArgs.user,
-            'password': connectinArgs.password,
-            'connectionLimit': null
-        };
-        if (connectinArgs.connectionLimit != null) connectionObject.connectionLimit = connectinArgs.connectionLimit;
-        
+        var connectionObject = Clone(connectinArgs);
+        delete connectionObject.database;
 
         if (parent.args.mariadb) {
             // Use MariaDB


### PR DESCRIPTION
Step 1 in adding good mariadb/mysql ssl support
this cleans up creating the connection object used by the mariadb and mysql connectors

This is enough to use trusted ca signed certificates.

I will be able to finish the rest (support for self-signed certs) by this weekend for sure, I think.