### PR TITLE
Added selfsigned cert support to mysql/mariadb ssl

### DIFF
--- a/db.js
+++ b/db.js
@@ -446,6 +446,15 @@ module.exports.CreateDB = function (parent, func) {
         var connectionObject = Clone(connectinArgs);
         delete connectionObject.database;
 
+        try {
+            if (connectinArgs.ssl.cacertpath) { connectionObject.ssl.ca = [require('fs').readFileSync(connectinArgs.ssl.cacertpath, 'utf8')]; }
+            if (connectinArgs.ssl.clientcertpath) { connectionObject.ssl.cert = [require('fs').readFileSync(connectinArgs.ssl.clientcertpath, 'utf8')]; }
+            if (connectinArgs.ssl.clientkeypath) { connectionObject.ssl.key = [require('fs').readFileSync(connectinArgs.ssl.clientkeypath, 'utf8')]; }
+        } catch (ex) {
+            console.log('Error loading SQL Connector certificate: ' + ex);
+            process.exit();
+        }
+
         if (parent.args.mariadb) {
             // Use MariaDB
             obj.databaseType = 4;

--- a/meshcentral-config-schema.json
+++ b/meshcentral-config-schema.json
@@ -21,7 +21,16 @@
             "port": { "type": "number", "description": "MariaDB port number" },
             "password": { "type": "string", "description": "MariaDB password" },
             "connectionLimit": { "type": "number", "description": "MariaDB connection limit" },
-            "database": { "type": "string", "default": "meshcentral", "description": "Name of MariaDB database used" }
+            "database": { "type": "string", "default": "meshcentral", "description": "Name of MariaDB database used" },
+            "ssl": { 
+              "type": "object",
+              "description": "SSL Options. Set to true (boolean) for default options.",
+              "properties": {
+                "caCertPath": { "type": "string", "description": "Absolute path to the CA certificate. Required for self-signed certificates" },
+                "clientCertPath": { "type": "string", "description": "Absolute path to the client certificate. Required for two-way SSL Authentication" },
+                "clientKeyPath": { "type": "string", "description": "Absolute path to the client key. Required for two-way SSL Authentication" }
+              }
+            }
           }
         },
         "mySQL": {
@@ -32,7 +41,16 @@
             "port": { "type": "number", "description": "MySQL port number" },
             "user": { "type": "string", "description": "MySQL username" },
             "password": { "type": "string", "description": "MySQL password" },
-            "database": { "type": "string", "default": "meshcentral", "description": "Name of MySQL database used" }
+            "database": { "type": "string", "default": "meshcentral", "description": "Name of MySQL database used" },
+            "ssl": { 
+              "type": "object",
+              "description": "SSL Options. Set to true (boolean) for default options.",
+              "properties": {
+                "caCertPath": { "type": "string", "description": "Absolute path to the CA certificate. Required for self-signed certificates" },
+                "clientCertPath": { "type": "string", "description": "Absolute path to the client certificate. Required for two-way SSL Authentication" },
+                "clientKeyPath": { "type": "string", "description": "Absolute path to the client key. Required for two-way SSL Authentication" }
+              }
+            }
           }
         },
         "WANonly": { "type": "boolean", "default": false, "description": "When enabled, only MeshCentral WAN features are enabled and agents will connect to the server using a well known DNS name." },


### PR DESCRIPTION
Part 2 of mysql/mariadb connector SSL support

This adds support for using self-signed certificates at the database server. The needed CA certificate can be loaded off disk via the `caCertPath` ssl option (added to config schema). Currently, this uses an absolute path.

This also adds support for two-way ssl authentication, by giving the option to load a client certificate + key off the disk as well.