### PR TITLE
Mysql/mariadb ssl support

### DIFF
--- a/db.js
+++ b/db.js
@@ -438,37 +438,8 @@ module.exports.CreateDB = function (parent, func) {
         obj.dbRecordsDecryptKey = parent.crypto.createHash('sha384').update(parent.args.dbrecordsdecryptkey).digest('raw').slice(0, 32);
     }
 
-    if (parent.args.mariadb || parent.args.mysql) {
-        var connectinArgs = (parent.args.mariadb) ? parent.args.mariadb : parent.args.mysql;
-        var dbname = (connectinArgs.database != null) ? connectinArgs.database : 'meshcentral';
 
-        // Including the db name in the connection obj will cause a connection failure if it does not exist
-        var connectionObject = Clone(connectinArgs);
-        delete connectionObject.database;
-
-        try {
-            if (connectinArgs.ssl) {
-                if (connectinArgs.ssl.cacertpath) { connectionObject.ssl.ca = [require('fs').readFileSync(connectinArgs.ssl.cacertpath, 'utf8')]; }
-                if (connectinArgs.ssl.clientcertpath) { connectionObject.ssl.cert = [require('fs').readFileSync(connectinArgs.ssl.clientcertpath, 'utf8')]; }
-                if (connectinArgs.ssl.clientkeypath) { connectionObject.ssl.key = [require('fs').readFileSync(connectinArgs.ssl.clientkeypath, 'utf8')]; }
-            }
-        } catch (ex) {
-            console.log('Error loading SQL Connector certificate: ' + ex);
-            process.exit();
-        }
-
-        if (parent.args.mariadb) {
-            // Use MariaDB
-            obj.databaseType = 4;
-            Datastore = require('mariadb').createPool(connectionObject);
-        } else if (parent.args.mysql) {
-            // Use MySQL
-            Datastore = require('mysql').createConnection(connectionObject);
-            obj.databaseType = 5;
-        }
-        sqlDbQuery('CREATE DATABASE IF NOT EXISTS ' + dbname);
-
-        // Set the default database for the rest of this connections lifetime
+    function createTablesIfNotExist(dbname) {
         var useDatabase = 'USE ' + dbname;
         sqlDbQuery(useDatabase, null, function (err, docs) {
             if (err != null) {
@@ -503,6 +474,55 @@ module.exports.CreateDB = function (parent, func) {
                 });
             }
         });
+    }
+
+    if (parent.args.mariadb || parent.args.mysql) {
+        var connectinArgs = (parent.args.mariadb) ? parent.args.mariadb : parent.args.mysql;
+        var dbname = (connectinArgs.database != null) ? connectinArgs.database : 'meshcentral';
+
+        // Including the db name in the connection obj will cause a connection failure if it does not exist
+        var connectionObject = Clone(connectinArgs);
+        delete connectionObject.database;
+
+        try {
+            if (connectinArgs.ssl) {
+                if (connectinArgs.ssl.cacertpath) { connectionObject.ssl.ca = [require('fs').readFileSync(connectinArgs.ssl.cacertpath, 'utf8')]; }
+                if (connectinArgs.ssl.clientcertpath) { connectionObject.ssl.cert = [require('fs').readFileSync(connectinArgs.ssl.clientcertpath, 'utf8')]; }
+                if (connectinArgs.ssl.clientkeypath) { connectionObject.ssl.key = [require('fs').readFileSync(connectinArgs.ssl.clientkeypath, 'utf8')]; }
+            }
+        } catch (ex) {
+            console.log('Error loading SQL Connector certificate: ' + ex);
+            process.exit();
+        }
+
+        if (parent.args.mariadb) {
+            // Use MariaDB
+            obj.databaseType = 4;
+            var tempDatastore = require('mariadb').createPool(connectionObject);
+            tempDatastore.getConnection().then(function (conn) {
+                conn.query('CREATE DATABASE IF NOT EXISTS ' + dbname).then(function (result) {
+                    conn.release();
+                }).catch(function (ex) { console.log('Auto-create database failed: ' + ex); });
+            }).catch(function (ex) { console.log('Auto-create database failed: ' + ex); });
+            setTimeout(function () { tempDatastore.end(); }, 2000);
+
+            connectionObject.database = dbname;
+            Datastore = require('mariadb').createPool(connectionObject);
+            createTablesIfNotExist(dbname);
+        } else if (parent.args.mysql) {
+            // Use MySQL
+            obj.databaseType = 5;
+            var tempDatastore = require('mysql').createConnection(connectionObject);
+            tempDatastore.query('CREATE DATABASE IF NOT EXISTS ' + dbname, function (error) {
+                if (error != null) {
+                    console.log('Auto-create database failed: ' + error);
+                }
+                connectionObject.database = dbname;
+                Datastore = require('mysql').createConnection(connectionObject);
+                createTablesIfNotExist(dbname);
+            });
+            setTimeout(function () { tempDatastore.end(); }, 2000);
+        }
     } else if (parent.args.mongodb) {
         // Use MongoDB
         obj.databaseType = 3;

--- a/db.js
+++ b/db.js
@@ -447,9 +447,11 @@ module.exports.CreateDB = function (parent, func) {
         delete connectionObject.database;
 
         try {
-            if (connectinArgs.ssl.cacertpath) { connectionObject.ssl.ca = [require('fs').readFileSync(connectinArgs.ssl.cacertpath, 'utf8')]; }
-            if (connectinArgs.ssl.clientcertpath) { connectionObject.ssl.cert = [require('fs').readFileSync(connectinArgs.ssl.clientcertpath, 'utf8')]; }
-            if (connectinArgs.ssl.clientkeypath) { connectionObject.ssl.key = [require('fs').readFileSync(connectinArgs.ssl.clientkeypath, 'utf8')]; }
+            if (connectinArgs.ssl) {
+                if (connectinArgs.ssl.cacertpath) { connectionObject.ssl.ca = [require('fs').readFileSync(connectinArgs.ssl.cacertpath, 'utf8')]; }
+                if (connectinArgs.ssl.clientcertpath) { connectionObject.ssl.cert = [require('fs').readFileSync(connectinArgs.ssl.clientcertpath, 'utf8')]; }
+                if (connectinArgs.ssl.clientkeypath) { connectionObject.ssl.key = [require('fs').readFileSync(connectinArgs.ssl.clientkeypath, 'utf8')]; }
+            }
         } catch (ex) {
             console.log('Error loading SQL Connector certificate: ' + ex);
             process.exit();
@@ -1596,11 +1598,15 @@ module.exports.CreateDB = function (parent, func) {
         // SSL options different on mariadb/mysql
         var sslOptions = '';
         if (obj.databaseType == 4) {
-            if (props.ssl) sslOptions = ' --ssl';
-            if (props.ssl.cacertpath) sslOptions = ' --ssl-verify-server-cert --ssl-ca=' + props.ssl.cacertpath;
+            if (props.ssl) {
+                sslOptions = ' --ssl';
+                if (props.ssl.cacertpath) sslOptions = ' --ssl-verify-server-cert --ssl-ca=' + props.ssl.cacertpath;
+            } 
         } else {
-            if (props.ssl) sslOptions = ' --ssl-mode=required';
-            if (props.ssl.cacertpath) sslOptions = ' --ssl-mode=verify_identity --ssl-ca=' + props.ssl.cacertpath;
+            if (props.ssl) {
+                sslOptions = ' --ssl-mode=required';
+                if (props.ssl.cacertpath) sslOptions = ' --ssl-mode=verify_identity --ssl-ca=' + props.ssl.cacertpath;
+            }
         }
         cmd += sslOptions;
 


### PR DESCRIPTION
Part 3 of SSL support and other bugfixes

This pull introduces a number of things:

1. dedicated function to build the sqldump command (with more and more options, this becomes complex enough to warrant its own function)
2. adds ssl support to mysqldump
3. fixes inappropriately checking properties of `mysql.ssl` / `mysql.ssl` when `ssl` does not exist (cannot access a property of undefined - my bad)
4. don't rely on `use database` - although this worked on all the versions I tested, it does not work on *all* versions

What's going on with 4)
If the `database` parameter is set in the connection object, the connection will fail if the db does not exist - this makes the automatic db creation feature unusable. To keep this feature working, the `database` must be removed from the connObj. 

`USE database` gets around this for most db versions - however, while expanding the number of test servers to experiment with ssl, I found `USE database` does not work on all versions.

The next best thing I could think of is to connect to the server without a db specified, create db if not exists, and disconnect. Then re-add the database parameter to the connection object, and continue normally. This is obviously a lot more complex, and what I was trying to avoid the first time.