### PR TITLE
Mysql/mariadb ssl support - additional options

### DIFF
--- a/db.js
+++ b/db.js
@@ -1621,11 +1621,15 @@ module.exports.CreateDB = function (parent, func) {
             if (props.ssl) {
                 sslOptions = ' --ssl';
                 if (props.ssl.cacertpath) sslOptions = ' --ssl-verify-server-cert --ssl-ca=' + props.ssl.cacertpath;
+                if (props.ssl.clientcertpath) sslOptions += ' --ssl-cert=' + props.ssl.clientcertpath;
+                if (props.ssl.clientkeypath) sslOptions += ' --ssl-key=' + props.ssl.clientkeypath;
             } 
         } else {
             if (props.ssl) {
                 sslOptions = ' --ssl-mode=required';
                 if (props.ssl.cacertpath) sslOptions = ' --ssl-mode=verify_identity --ssl-ca=' + props.ssl.cacertpath;
+                if (props.ssl.clientcertpath) sslOptions += ' --ssl-cert=' + props.ssl.clientcertpath;
+                if (props.ssl.clientkeypath) sslOptions += ' --ssl-key=' + props.ssl.clientkeypath;
             }
         }
         cmd += sslOptions;

--- a/db.js
+++ b/db.js
@@ -486,6 +486,7 @@ module.exports.CreateDB = function (parent, func) {
 
         try {
             if (connectinArgs.ssl) {
+                if (connectinArgs.ssl.dontcheckserveridentity == true) { connectionObject.ssl.checkServerIdentity = function(name, cert) { return undefined; } };
                 if (connectinArgs.ssl.cacertpath) { connectionObject.ssl.ca = [require('fs').readFileSync(connectinArgs.ssl.cacertpath, 'utf8')]; }
                 if (connectinArgs.ssl.clientcertpath) { connectionObject.ssl.cert = [require('fs').readFileSync(connectinArgs.ssl.clientcertpath, 'utf8')]; }
                 if (connectinArgs.ssl.clientkeypath) { connectionObject.ssl.key = [require('fs').readFileSync(connectinArgs.ssl.clientkeypath, 'utf8')]; }
@@ -1620,14 +1621,17 @@ module.exports.CreateDB = function (parent, func) {
         if (obj.databaseType == 4) {
             if (props.ssl) {
                 sslOptions = ' --ssl';
-                if (props.ssl.cacertpath) sslOptions = ' --ssl-verify-server-cert --ssl-ca=' + props.ssl.cacertpath;
+                if (props.ssl.cacertpath) sslOptions = ' --ssl-ca=' + props.ssl.cacertpath;
+                if (props.ssl.dontcheckserveridentity != true) sslOptions += ' --ssl-verify-server-cert';
                 if (props.ssl.clientcertpath) sslOptions += ' --ssl-cert=' + props.ssl.clientcertpath;
                 if (props.ssl.clientkeypath) sslOptions += ' --ssl-key=' + props.ssl.clientkeypath;
             } 
         } else {
             if (props.ssl) {
                 sslOptions = ' --ssl-mode=required';
-                if (props.ssl.cacertpath) sslOptions = ' --ssl-mode=verify_identity --ssl-ca=' + props.ssl.cacertpath;
+                if (props.ssl.cacertpath) sslOptions = ' --ssl-ca=' + props.ssl.cacertpath;
+                if (props.ssl.dontcheckserveridentity != true) sslOptions += ' --ssl-mode=verify_identity';
+                else sslOptions += ' --ssl-mode=required';
                 if (props.ssl.clientcertpath) sslOptions += ' --ssl-cert=' + props.ssl.clientcertpath;
                 if (props.ssl.clientkeypath) sslOptions += ' --ssl-key=' + props.ssl.clientkeypath;
             }

--- a/meshcentral-config-schema.json
+++ b/meshcentral-config-schema.json
@@ -28,7 +28,8 @@
               "properties": {
                 "caCertPath": { "type": "string", "description": "Absolute path to the CA certificate. Required for self-signed certificates" },
                 "clientCertPath": { "type": "string", "description": "Absolute path to the client certificate. Required for two-way SSL Authentication" },
-                "clientKeyPath": { "type": "string", "description": "Absolute path to the client key. Required for two-way SSL Authentication" }
+                "clientKeyPath": { "type": "string", "description": "Absolute path to the client key. Required for two-way SSL Authentication" },
+                "dontCheckServerIdentity": { "type": "boolean", "description": "Set true to not check the server hostname during verification" }
               }
             }
           }
@@ -48,7 +49,8 @@
               "properties": {
                 "caCertPath": { "type": "string", "description": "Absolute path to the CA certificate. Required for self-signed certificates" },
                 "clientCertPath": { "type": "string", "description": "Absolute path to the client certificate. Required for two-way SSL Authentication" },
-                "clientKeyPath": { "type": "string", "description": "Absolute path to the client key. Required for two-way SSL Authentication" }
+                "clientKeyPath": { "type": "string", "description": "Absolute path to the client key. Required for two-way SSL Authentication" },
+                "dontCheckServerIdentity": { "type": "boolean", "description": "Set true to not check the server hostname during verification" }
               }
             }
           }


### PR DESCRIPTION
Added last needed options to mysqldump to support 2-way authentication
Added `dontCheckServerIdentity` option to disable hostname checking during certificate verification. Useful for self-signed certs where the hostname on the cert may not match.