### PR TITLE
Bugfix: MySQL/MariaDB crash when deleting groups

### DIFF
--- a/db.js
+++ b/db.js
@@ -1003,7 +1003,7 @@ module.exports.CreateDB = function (parent, func) {
             obj.RemoveAll = function (func) { sqlDbQuery('DELETE FROM main', null, func); };
             obj.RemoveAllOfType = function (type, func) { sqlDbQuery('DELETE FROM main WHERE type = ?', [type], func); };
             obj.InsertMany = function (data, func) { var pendingOps = 0; for (var i in data) { pendingOps++; obj.SetRaw(data[i], function () { if (--pendingOps == 0) { func(); } }); } }; // Insert records directly, no link escaping
-            obj.RemoveMeshDocuments = function (id) { sqlDbQuery('DELETE FROM main WHERE extra = ?', [id], function () { sqlDbQuery('DELETE FROM main WHERE id = ?', ['nt' + id], func); } ); };
+            obj.RemoveMeshDocuments = function (id, func) { sqlDbQuery('DELETE FROM main WHERE extra = ?', [id], function () { sqlDbQuery('DELETE FROM main WHERE id = ?', ['nt' + id], func); } ); };
             obj.MakeSiteAdmin = function (username, domain) { obj.Get('user/' + domain + '/' + username, function (err, docs) { if ((err == null) && (docs.length == 1)) { docs[0].siteadmin = 0xFFFFFFFF; obj.Set(docs[0]); } }); };
             obj.DeleteDomain = function (domain, func) { sqlDbQuery('DELETE FROM main WHERE domain = ?', [domain], func); };
             obj.SetUser = function (user) { if (user.subscriptions != null) { var u = Clone(user); if (u.subscriptions) { delete u.subscriptions; } obj.Set(u); } else { obj.Set(user); } };


### PR DESCRIPTION
Deleting a device group while using MySQL/MariaDB causes Meshcentral to crash. This bug goes back to the original implementation - surprised it hasn't come up before.

The callback function used in `CreateDB` gets passed around throughout db.js, until it is eventually re-called in `RemoveMeshDocuments`.
![bug](https://user-images.githubusercontent.com/63608819/117390280-da543080-aebb-11eb-9f2c-e26857e9eeed.png)

This results in the hilariously useless stack trace:
<pre>SQLERR1 TypeError: Cannot read property &apos;SetupDatabase&apos; of null
    at /home/noah_zalev/Documents/meshc_testing/node_modules/meshcentral/meshcentral.js:717:24
    at /home/noah_zalev/Documents/meshc_testing/node_modules/meshcentral/db.js:898:45
    at process._tickCallback (internal/process/next_tick.js:68:7)
</pre>

It was very hard to find, but the fix is very simple :).