### PR TITLE
Add version arg to selfupdate console cmd

### DIFF
--- a/meshuser.js
+++ b/meshuser.js
@@ -1188,7 +1188,15 @@ module.exports.CreateMeshUser = function (parent, db, ws, req, args, domain, use
                         }
                         case 'serverupdate': {
                             r = 'Performing server update...';
-                            if (parent.parent.performServerUpdate() == false) { r = 'Server self-update not possible.'; }
+                            var version = null;
+
+                            if (cmdargs['_'].length > 0) {
+                                version = cmdargs['_'][0];
+                            }
+
+                            if (parent.parent.performServerUpdate(version) == false) { 
+                                r = 'Server self-update not possible.';
+                            }
                             break;
                         }
                         case 'print': {


### PR DESCRIPTION

Part 1 of 2 (#2704)

This allows the `serverupdate` console command to accept a version argument.

Since distribution tags are valid for the install command, `npm install meshcentral@stable` and `npm install meshcentral@latest` both work out of the box. Therefore, "stable" and "latest" are supported arguments.

----

Coming in part 2:

I am currently working on validating the version argument. If an invalid version argument is given, it will make its way to `npm install meshcentral@version`, and the install will fail. This isn't harmful, but it causes the server to restart without updating to a new version, which is unideal. 