### PR TITLE
Added version validation to serverupdate

### DIFF
--- a/meshuser.js
+++ b/meshuser.js
@@ -924,6 +924,7 @@ module.exports.CreateMeshUser = function (parent, db, ws, req, args, domain, use
                                     case 'usersessions': { r = "usersessions: Returns a list of active sessions grouped by user."; break; }
                                     case 'closeusersessions': { r = "closeusersessions: Disconnects all sessions for a specified user."; break; }
                                     case 'tasklimiter': { r = "tasklimiter: Returns the internal status of the tasklimiter. This is a system used to smooth out work done by the server. It's used by, for example, agent updates so that not all agents are updated at the same time."; break; }
+                                    case 'serverupdate': { r = "serverupdate: Updates server to latest version. Optional version argument to install specific version. Example: serverupdate 0.8.49"; break; }
                                     default: { r = 'No help information about this command.'; break; }
                                 }
                             }

--- a/meshuser.js
+++ b/meshuser.js
@@ -1192,11 +1192,37 @@ module.exports.CreateMeshUser = function (parent, db, ws, req, args, domain, use
 
                             if (cmdargs['_'].length > 0) {
                                 version = cmdargs['_'][0];
+
+                                // This call is SLOW. We only want to validate version if we have to
+                                if (version != 'stable' && version != 'latest') {
+                                    parent.parent.getServerVersions((data) => {
+                                        var versions = JSON.parse(data);
+
+                                        if (versions.includes(version)) {
+                                            if (parent.parent.performServerUpdate(version) == false) { 
+                                                try { 
+                                                    ws.send(JSON.stringify({ action: 'serverconsole',
+                                                                             value: 'Server self-update not possible.'}));
+                                                } catch (ex) { }
+                                            }
+                                        } else {
+                                            try { 
+                                                ws.send(JSON.stringify({ action: 'serverconsole',
+                                                                         value: 'Invalid version. Aborting update'}));
+                                            } catch (ex) { }
+                                        }
+                                    });
+                                } else {
+                                    if (parent.parent.performServerUpdate(version) == false) { 
+                                        r = 'Server self-update not possible.';
+                                    }
+                                }  
+                            } else {
+                                if (parent.parent.performServerUpdate(version) == false) { 
+                                    r = 'Server self-update not possible.';
+                                }
                             }
 
-                            if (parent.parent.performServerUpdate(version) == false) { 
-                                r = 'Server self-update not possible.';
-                            }
                             break;
                         }
                         case 'print': {


### PR DESCRIPTION
Part 2 of 2 (#2704)

This update adds version name/number validation to the serverupdate console command. This prevents the server from restarting itself uselessly in the case that an invalid version argument is given.

The list of version numbers is retreived via the command `npm view meshcentral versions --json`. Because there are more than 1400 versions, running this command is relatively slow, so I avoid using it unless 1) an argument is given and 2) the argument is not "stable" or "latest" which do not need to be validated.