### PR TITLE
Add no limit option to events,userevents dropdowns

### DIFF
--- a/views/default.handlebars
+++ b/views/default.handlebars
@@ -421,6 +421,7 @@
                                 <option value=250>Last 250</option>
                                 <option value=500>Last 500</option>
                                 <option value=1000>Last 1000</option>
+                                <option value="">No limit</option>
                             </select>&nbsp;
                             <a href=# onclick=p3showDownloadEventsDialog(2)><img src=images/link4.png height=10 width=10 title="Download Events" style=cursor:pointer></a>&nbsp;
                         </td>
@@ -1012,6 +1013,7 @@
                                 <option value=250>Last 250</option>
                                 <option value=500>Last 500</option>
                                 <option value=1000>Last 1000</option>
+                                <option value="">No limit</option>
                             </select>
                             <a href=# onclick=p3showDownloadEventsDialog(3)><img src=images/link4.png height=10 width=10 title="Download Events" style=cursor:pointer></a>&nbsp;
                         </td>


### PR DESCRIPTION
Minor (incomplete) resolution for #2929

Both user events and general events have queries which exist without limits, so it is just a matter of adding an option in the dropdowns where `limit` is null.

This at least allows users to view all the events in the UI, though I agree more needs to be added. I can look at adding filters soon.