### PR TITLE
Added Last Seen column to device view

### DIFF
--- a/meshuser.js
+++ b/meshuser.js
@@ -5554,12 +5554,11 @@ module.exports.CreateMeshUser = function (parent, db, ws, req, args, domain, use
                 for (var j in docs) {
                     var nodeid = docs[j]._id.substring(2);
                     if (LCs[nodeid] != null) {
-                        delete docs[j]._id;
-                        LCs[nodeid] = docs[j];
+                        LCs[nodeid] = docs[j].time;
                     }
                 }
 
-                console.log(LCs);
+                try { ws.send(JSON.stringify({ action: 'lastseen', lastconnects: LCs })); } catch (ex) { }
             });
         });
     }

--- a/meshuser.js
+++ b/meshuser.js
@@ -5404,6 +5404,7 @@ module.exports.CreateMeshUser = function (parent, db, ws, req, args, domain, use
         'getnetworkinfo': serverCommandGetNetworkInfo,
         'getsysinfo': serverCommandGetSysInfo,
         'lastconnect': serverCommandLastConnect,
+        'lastseen': serverCommandLastSeen,
         'meshes': serverCommandMeshes,
         'serverconsole': serverCommandServerConsole,
         'servererrors': serverCommandServerErrors,
@@ -5533,6 +5534,32 @@ module.exports.CreateMeshUser = function (parent, db, ws, req, args, domain, use
                 } else {
                     try { ws.send(JSON.stringify({ action: 'lastconnect', nodeid: command.nodeid, tag: command.tag, noinfo: true, result: 'No data' })); } catch (ex) { }
                 }
+            });
+        });
+    }
+
+    function serverCommandLastSeen(command) {
+        var links = parent.GetAllMeshIdWithRights(user);
+        var extraids = getUserExtraIds();
+        db.GetAllTypeNoTypeFieldMeshFiltered(links, extraids, domain.id, 'node', null, (err, docs) => {
+            if (docs == null) { docs = []; }
+
+            // use associative array to join lastconnects on to users's nodes (left join) 
+            var LCs = {}
+            for (var i in docs) {
+                LCs[docs[i]._id] = '';
+            }
+
+            db.GetAllType('lastconnect', (err, docs) => {
+                for (var j in docs) {
+                    var nodeid = docs[j]._id.substring(2);
+                    if (LCs[nodeid] != null) {
+                        delete docs[j]._id;
+                        LCs[nodeid] = docs[j];
+                    }
+                }
+
+                console.log(LCs);
             });
         });
     }

--- a/meshuser.js
+++ b/meshuser.js
@@ -657,17 +657,7 @@ module.exports.CreateMeshUser = function (parent, db, ws, req, args, domain, use
                                 links = parent.GetAllMeshIdWithRights(user);
 
                                 // Add any nodes with direct rights or any nodes with user group direct rights
-                                if (obj.user.links != null) {
-                                    for (var i in obj.user.links) {
-                                        if (i.startsWith('node/')) { if (extraids == null) { extraids = []; } extraids.push(i); }
-                                        else if (i.startsWith('ugrp/')) {
-                                            const g = parent.userGroups[i];
-                                            if ((g != null) && (g.links != null)) {
-                                                for (var j in g.links) { if (j.startsWith('node/')) { if (extraids == null) { extraids = []; } extraids.push(j); } }
-                                            }
-                                        }
-                                    }
-                                }
+                                extraids = getUserExtraIds();
                             } else {
                                 // Request list of all nodes for one specific meshid
                                 meshid = command.meshid;
@@ -6181,6 +6171,22 @@ module.exports.CreateMeshUser = function (parent, db, ws, req, args, domain, use
         return true;
     }
 
+    function getUserExtraIds() {
+        var extraids = null;
+        if (obj.user.links != null) {
+            for (var i in obj.user.links) {
+                if (i.startsWith('node/')) { if (extraids == null) { extraids = []; } extraids.push(i); }
+                else if (i.startsWith('ugrp/')) {
+                    const g = parent.userGroups[i];
+                    if ((g != null) && (g.links != null)) {
+                        for (var j in g.links) { if (j.startsWith('node/')) { if (extraids == null) { extraids = []; } extraids.push(j); } }
+                    }
+                }
+            }
+        }
+        return extraids;
+    }
+
     function csvClean(s) { return '\"' + s.split('\"').join('').split(',').join('').split('\r').join('').split('\n').join('') + '\"'; }
 
     // Return detailed information about an array of nodeid's
@@ -6229,18 +6235,7 @@ module.exports.CreateMeshUser = function (parent, db, ws, req, args, domain, use
         var links = parent.GetAllMeshIdWithRights(user);
 
         // Add any nodes with direct rights or any nodes with user group direct rights
-        var extraids = null;
-        if (obj.user.links != null) {
-            for (var i in obj.user.links) {
-                if (i.startsWith('node/')) { if (extraids == null) { extraids = []; } extraids.push(i); }
-                else if (i.startsWith('ugrp/')) {
-                    const g = parent.userGroups[i];
-                    if ((g != null) && (g.links != null)) {
-                        for (var j in g.links) { if (j.startsWith('node/')) { if (extraids == null) { extraids = []; } extraids.push(j); } }
-                    }
-                }
-            }
-        }
+        var extraids = getUserExtraIds();
 
         // Request a list of all nodes
         db.GetAllTypeNoTypeFieldMeshFiltered(links, extraids, domain.id, 'node', null, function (err, docs) {

--- a/views/default.handlebars
+++ b/views/default.handlebars
@@ -2291,6 +2291,14 @@
                     }
                     break;
                 }
+                case 'lastseen': {
+                    var lcnodes = Object.keys(message.lastconnects);
+                    for (var i in lcnodes) {
+                        var lcnodeid = lcnodes[i];
+                        var node = getNodeFromId(lcnodeid);
+                        if (node != null) { node.lastconnect = message.lastconnects[lcnodeid] }
+                    }
+                }
                 case 'msg': {
                     // Check if this is a message from a node
                     if (message.nodeid != null) {

--- a/views/default.handlebars
+++ b/views/default.handlebars
@@ -1929,6 +1929,7 @@
                 meshserver.send({ action: 'usergroups' });
                 meshserver.send({ action: 'meshes' });
                 meshserver.send({ action: 'nodes', id: '{{currentNode}}' });
+                meshserver.send({ action: 'lastseen' });
                 meshserver.send({ action: 'loginTokens' });
                 if (pluginHandler != null) { meshserver.send({ action: 'plugins' }); }
                 if ('{{currentNode}}'.toLowerCase() == '') { meshserver.send({ action: 'files' }); }

--- a/views/default.handlebars
+++ b/views/default.handlebars
@@ -4244,7 +4244,7 @@
                 if (deviceViewSettings.devsCols.indexOf('user') >= 0) { r += '<td style=text-align:center>' + getUserShortStr(node); } // User
                 if (deviceViewSettings.devsCols.indexOf('ip') >= 0) { r += '<td style=text-align:center>' + (node.ip != null ? node.ip : ''); } // IP address
                 if (deviceViewSettings.devsCols.indexOf('conn') >= 0) { r += '<td style=text-align:center>' + states.join('&nbsp;+&nbsp;'); } // Connectivity
-                if (deviceViewSettings.devsCols.indexOf('lastseen') >= 0) { r += '<td style=text-align:center;font-size:x-small>' + ((node.conn & 23 > 0) ? '' : printDateTime(new Date(node.lastconnect))); }
+                if (deviceViewSettings.devsCols.indexOf('lastseen') >= 0) { r += '<td style=text-align:center;font-size:x-small>' + ((node.conn & 23 > 0 || node.lastconnect != null) ? '' : printDateTime(new Date(node.lastconnect))); }
 
                 div.innerHTML = r;
             } else if ((view == 3) || (view == 5)) {

--- a/views/default.handlebars
+++ b/views/default.handlebars
@@ -4244,7 +4244,7 @@
                 if (deviceViewSettings.devsCols.indexOf('user') >= 0) { r += '<td style=text-align:center>' + getUserShortStr(node); } // User
                 if (deviceViewSettings.devsCols.indexOf('ip') >= 0) { r += '<td style=text-align:center>' + (node.ip != null ? node.ip : ''); } // IP address
                 if (deviceViewSettings.devsCols.indexOf('conn') >= 0) { r += '<td style=text-align:center>' + states.join('&nbsp;+&nbsp;'); } // Connectivity
-                if (deviceViewSettings.devsCols.indexOf('lastseen') >= 0) { r += '<td style=text-align:center;font-size:x-small>' + ((node.conn & 23 > 0 || node.lastconnect != null) ? '' : printDateTime(new Date(node.lastconnect))); }
+                if (deviceViewSettings.devsCols.indexOf('lastseen') >= 0) { r += '<td style=text-align:center;font-size:x-small>' + ((node.conn & 23 > 0 || node.lastconnect == null) ? '' : printDateTime(new Date(node.lastconnect))); }
 
                 div.innerHTML = r;
             } else if ((view == 3) || (view == 5)) {

--- a/views/default.handlebars
+++ b/views/default.handlebars
@@ -3555,6 +3555,7 @@
             x += '<label><input id=d2c2 type=checkbox' + ((deviceViewSettings.devsCols.indexOf('user') >= 0)?' checked':'') + '>' + "Logged in users" + '</label><br />';
             x += '<label><input id=d2c3 type=checkbox' + ((deviceViewSettings.devsCols.indexOf('ip') >= 0)?' checked':'') + '>' + "Agent IP address" + '</label><br />';
             x += '<label><input id=d2c4 type=checkbox' + ((deviceViewSettings.devsCols.indexOf('conn') >= 0)?' checked':'') + '>' + "Server Connectivity" + '</label><br />';
+            x += '<label><input id=d2c7 type=checkbox' + ((deviceViewSettings.devsCols.indexOf('lastseen') >= 0)?' checked':'') + '>' + "Last Seen" + '</label><br />';
             setDialogMode(2, "Device View Columns", 3, onDeviceViewSettingsEx, x);
         }
 
@@ -3566,6 +3567,7 @@
             if (Q('d2c4').checked) { cols.push('conn'); }
             if (Q('d2c5').checked) { cols.push('os'); }
             if (Q('d2c6').checked) { cols.push('desc'); }
+            if (Q('d2c7').checked) { cols.push('lastseen'); }
             deviceViewSettings.devsCols = cols;
             putstore('_deviceViewSettings', JSON.stringify(deviceViewSettings));
             mainUpdate(4);
@@ -3981,6 +3983,7 @@
                         if (deviceViewSettings.devsCols.indexOf('user') >= 0) { colums += '<th style=color:gray;width:120px>' + "User"; }
                         if (deviceViewSettings.devsCols.indexOf('ip') >= 0) { colums += '<th style=color:gray;width:120px>' + "Address"; }
                         if (deviceViewSettings.devsCols.indexOf('conn') >= 0) { colums += '<th style=color:gray;width:100px>' + "Connectivity"; }
+                        if (deviceViewSettings.devsCols.indexOf('lastseen') >= 0) { colums += '<th style=color:gray;width:120px>' + "Last Seen"; }
 
                         // This height of 1 div at the end to fix a problem in Linux firefox browsers
                         r = '<table style=width:100%;margin-top:4px cellpadding=0 cellspacing=0><th style=color:gray>' + colums + r + '</tr></table><div style=height:1px></div>';
@@ -4240,6 +4243,7 @@
                 if (deviceViewSettings.devsCols.indexOf('user') >= 0) { r += '<td style=text-align:center>' + getUserShortStr(node); } // User
                 if (deviceViewSettings.devsCols.indexOf('ip') >= 0) { r += '<td style=text-align:center>' + (node.ip != null ? node.ip : ''); } // IP address
                 if (deviceViewSettings.devsCols.indexOf('conn') >= 0) { r += '<td style=text-align:center>' + states.join('&nbsp;+&nbsp;'); } // Connectivity
+                if (deviceViewSettings.devsCols.indexOf('lastseen') >= 0) { r += '<td style=text-align:center;font-size:x-small>' + ((node.conn & 23 > 0) ? '' : printDateTime(new Date(node.lastconnect))); }
 
                 div.innerHTML = r;
             } else if ((view == 3) || (view == 5)) {


### PR DESCRIPTION
I have finally added the Last Seen column to the device list view.

The main problem in adding a last seen column was that not all the `lastconnect` data was loaded. However, agents which connect/disconnect do update `node.lastconnect`. I am loading all the last seen data for a user's nodes on page load, and only once. When agents connect/disconnect, they already update the info on their own.

On the server side, the last seen command gets a user's nodes and creates an associative array using the node IDs. Then all `lastconnect` docs are pulled from the db, `lcnode//` is converted to `node//`, and the last connect time is inserted only if the ID already exists in the associative array. This avoids leaking any information about nodes the user does not have access to. This is effectively left-joining the LC times on to the user's nodes.

The UI changes are pretty simple. The client side handler for `lastseen` update's the `lastconnect` property of nodes in the list `nodes`.

Finally, I factored out the code that gets a user's extra node IDs into its own function, since I needed to re-use it.

![Screenshot from 2021-07-25 01-20-50](https://user-images.githubusercontent.com/63608819/126889975-7869aaae-4371-49c0-9e44-38ca9e7bfe23.png)
![Screenshot from 2021-07-25 01-20-35](https://user-images.githubusercontent.com/63608819/126889976-44aab247-184b-4a3a-8c2e-afd19658d6df.png)
