### PR TITLE
Bugfix - correct power timeline query

### DIFF
--- a/db.js
+++ b/db.js
@@ -1064,7 +1064,7 @@ module.exports.CreateDB = function (parent, func) {
             // Database actions on the power collection
             obj.getAllPower = function (func) { sqlDbQuery('SELECT doc FROM power', null, func); };
             obj.storePowerEvent = function (event, multiServer, func) { obj.dbCounters.powerSet++; if (multiServer != null) { event.server = multiServer.serverid; } sqlDbQuery('INSERT INTO power VALUE (?, ?, ?, ?)', [null, event.time, event.nodeid ? event.nodeid : null, JSON.stringify(event)], func); };
-            obj.getPowerTimeline = function (nodeid, func) { sqlDbQuery('SELECT doc FROM power WHERE ((nodeid = ?) OR (nodeid = "*")) ORDER BY time DESC', [nodeid], func); };
+            obj.getPowerTimeline = function (nodeid, func) { sqlDbQuery('SELECT doc FROM power WHERE ((nodeid = ?) OR (nodeid = "*")) ORDER BY time ASC', [nodeid], func); };
             obj.removeAllPowerEvents = function () { sqlDbQuery('DELETE FROM power', null, function (err, docs) { }); };
             obj.removeAllPowerEventsForNode = function (nodeid) { sqlDbQuery('DELETE FROM power WHERE nodeid = ?', [nodeid], function (err, docs) { }); };
 


### PR DESCRIPTION
The SQL query for `getPowerTimeline` was ordering in desc. This causes the newest times to appear first (think in terms of epoch timestamp being higher).

Now, when 'powertimeline' in meshuser calculates deltas, it creates a negative delta because the initial `time` is greater than the last `doc.time`.
```javascript
timeline.push((doc.time - time) / 1000, doc.power);
```

The result:
![2021-07-27](https://user-images.githubusercontent.com/63608819/127221587-52caff2f-281b-42b5-a185-1261cd7dd2c8.png)

Obviously, this breaks the power timeline.

fix: don't order in desc.