### PR TITLE
Added Last Seen sort option

### DIFF
--- a/views/default.handlebars
+++ b/views/default.handlebars
@@ -318,6 +318,7 @@
                                     <option>Device</option>
                                     <option>Tags</option>
                                     <option>Group-Tags</option>
+                                    <option>Last Seen</option>
                                 </select>
                                 &nbsp;
                             </div>
@@ -3775,6 +3776,17 @@
                 if (sort == 0) { nodes.sort(meshSort); }
                 else if (sort == 1) { nodes.sort(powerSort); }
                 else if (sort == 2) { if (showRealNames == true) { nodes.sort(deviceHostSort); } else { nodes.sort(deviceSort); } }
+                else if (sort == 5) {
+                    // if the last seen column is not turned on, turn it on first (we require this to sort the data)
+                    if (!(deviceViewSettings && deviceViewSettings.devsCols && deviceViewSettings.devsCols.indexOf('lastseen') >= 0)) {
+                        // force initialize the view settings
+                        if (deviceViewSettings == null) { deviceViewSettings = {}; }
+                        if (!Array.isArray(deviceViewSettings.devsCols)) { deviceViewSettings.devsCols = ['user','ip','conn', 'lastseen']; }
+                        else { deviceViewSettings.devsCols.push('lastseen'); }
+                    }
+                    nodes.sort(lastConnectSort);
+                }
+
 
                 // Compute the width of the device view.
                 var totalDeviceViewWidth = Q('column_l').clientWidth - 60;
@@ -3845,7 +3857,7 @@
                             c = 0;
                             if ((view == 1) || (view == 3) || (view == 5)) { r += '<div id=DevxCol' + deviceHeaderId + ((collapsed === true)?' style=display:none':'') + '>'; } // Open collapse div
                         }
-                    } else if (sort == 2) {
+                    } else if (sort == 2 || sort == 5) {
                         // Device header
                         if (current == null) { current = '1'; }
                     }
@@ -5283,6 +5295,7 @@
         function powerSort(a, b) { var ap = a.pwr?a.pwr:0; var bp = b.pwr?b.pwr:0; if (ap > bp) return -1; if (ap < bp) return 1; if (ap == bp) { if (showRealNames == true) { if (a.rnamel > b.rnamel) return 1; if (a.rnamel < b.rnamel) return -1; return 0; } else { if (a.namel > b.namel) return 1; if (a.namel < b.namel) return -1; return 0; } } return 0; }
         function deviceSort(a, b) { if (a.namel > b.namel) return 1; if (a.namel < b.namel) return -1; return 0; }
         function deviceHostSort(a, b) { if (a.rnamel > b.rnamel) return 1; if (a.rnamel < b.rnamel) return -1; return 0; }
+        function lastConnectSort(a, b) { return a.lastconnect - b.lastconnect; }
         function onSearchFocus(x) { searchFocus = x; }
         function clearDeviceSearch() { Q('KvmSearchInput').value = Q('SearchInput').value = ''; Q('DevFilterSelect').value = 0; onOnlineCheckBox(); mainUpdate(1); }
         function onMapSearchFocus(x) { mapSearchFocus = x; }


### PR DESCRIPTION
I think this is a fairly niche feature, but useful for users who have a very large number of deployed agents.

It is useful to find agents which have been disconnected for a long time: they may have been decomissioned and need to be removed, the agent may not be connecting and needs to be reinstalled, etc.

Up until the Last Seen column, it has been too tedious to go through disconnected agents and find how long they have been disconnected. However, when there are a very large number of agents, it can still be difficult to go through the list even with the last seen column.

Being able to sort by Last Seen solves this problem.

---

If the last seen column is not selected, sorting by last seen will automatically select it:
![Screenshot from 2021-07-30 13-49-35](https://user-images.githubusercontent.com/63608819/127693087-70cc8d19-352b-41b3-9ae7-233c39c3bffe.png)
![Screenshot from 2021-07-30 13-53-24](https://user-images.githubusercontent.com/63608819/127693126-96752dbb-3317-474f-9479-511610251424.png)
![Screenshot from 2021-07-30 13-54-53](https://user-images.githubusercontent.com/63608819/127693130-71fa8761-3051-4448-9212-f1cae48ef28b.png)

If the lastconnect data has not been fetched yet, it will be fetched and updated automatically.
