### PR TITLE
Handle all configurable paths as potentially absolute

### DIFF
--- a/amtprovisioningserver.js
+++ b/amtprovisioningserver.js
@@ -619,7 +619,7 @@ module.exports.CreateAmtProvisioningServer = function (parent, config) {
         if ((domain.amtacmactivation == null) || (domain.amtacmactivation.log == null) || (typeof domain.amtacmactivation.log != 'string')) {
             if (domain.id == '') { logpath = parent.path.join(obj.parent.datapath, 'amtactivation.log'); } else { logpath = parent.path.join(obj.parent.datapath, 'amtactivation-' + domain.id + '.log'); }
         } else {
-            if ((domain.amtacmactivation.log.length >= 2) && ((domain.amtacmactivation.log[0] == '/') || (domain.amtacmactivation.log[1] == ':'))) { logpath = domain.amtacmactivation.log; } else { logpath = parent.path.join(obj.parent.datapath, domain.amtacmactivation.log); }
+            logpath = parent.common.joinPath(obj.parent.datapath, domain.amtacmactivation.log);
         }
         try { parent.fs.appendFileSync(logpath, JSON.stringify(x) + '\r\n'); } catch (ex) { console.log(ex); return false; }
         return true;

--- a/certoperations.js
+++ b/certoperations.js
@@ -158,7 +158,7 @@ module.exports.CertificateOperations = function (parent) {
         if ((domain.amtacmactivation == null) || (domain.amtacmactivation.log == null) || (typeof domain.amtacmactivation.log != 'string')) {
             if (domain.id == '') { logpath = parent.path.join(obj.parent.datapath, 'amtactivation.log'); } else { logpath = parent.path.join(obj.parent.datapath, 'amtactivation-' + domain.id + '.log'); }
         } else {
-            if ((domain.amtacmactivation.log.length >= 2) && ((domain.amtacmactivation.log[0] == '/') || (domain.amtacmactivation.log[1] == ':'))) { logpath = domain.amtacmactivation.log; } else { logpath = parent.path.join(obj.parent.datapath, domain.amtacmactivation.log); }
+            logpath = parent.common.joinPath(obj.parent.datapath, domain.amtacmactivation.log);
         }
         try { obj.fs.appendFileSync(logpath, JSON.stringify(x) + '\r\n'); } catch (ex) { console.log(ex); return false; }
         return true;
@@ -175,13 +175,13 @@ module.exports.CertificateOperations = function (parent) {
 
                 if ((typeof acmconfig.certpfx == 'string') && (typeof acmconfig.certpfxpass == 'string')) {
                     // P12 format, certpfx and certpfxpass
-                    try { r = obj.loadPfxCertificate(obj.parent.path.join(obj.parent.datapath, acmconfig.certpfx), acmconfig.certpfxpass); } catch (ex) { console.log(ex); }
+                    try { r = obj.loadPfxCertificate(obj.parent.common.joinPath(obj.parent.datapath, acmconfig.certpfx), acmconfig.certpfxpass); } catch (ex) { console.log(ex); }
                     if ((r == null) || (r.certs == null) || (r.keys == null) || (r.certs.length < 2) || (r.keys.length != 1)) continue;
                 } else if ((typeof acmconfig.certfiles == 'object') && (typeof acmconfig.keyfile == 'string')) {
                     // PEM format, certfiles and keyfile
                     r = { certs: [], keys: [] };
-                    for (var k in acmconfig.certfiles) { r.certs.push(obj.pki.certificateFromPem(obj.fs.readFileSync(obj.parent.path.join(obj.parent.datapath, acmconfig.certfiles[k])))); }
-                    r.keys.push(obj.pki.privateKeyFromPem(obj.fs.readFileSync(obj.parent.path.join(obj.parent.datapath, acmconfig.keyfile))));
+                    for (var k in acmconfig.certfiles) { r.certs.push(obj.pki.certificateFromPem(obj.fs.readFileSync(obj.common.joinPath(obj.parent.datapath, acmconfig.certfiles[k])))); }
+                    r.keys.push(obj.pki.privateKeyFromPem(obj.fs.readFileSync(obj.parent.joinPath(obj.parent.datapath, acmconfig.keyfile))));
                     if ((r.certs.length < 2) || (r.keys.length != 1)) continue;
                 }
 

--- a/common.js
+++ b/common.js
@@ -16,6 +16,7 @@
 
 const fs = require('fs');
 const crypto = require('crypto');
+const path = require('path');
 
 // Binary encoding and decoding functions
 module.exports.ReadShort = function (v, p) { return (v.charCodeAt(p) << 8) + v.charCodeAt(p + 1); };
@@ -31,6 +32,7 @@ module.exports.SplitArray = function (v) { return v.split(','); };
 module.exports.Clone = function (v) { return JSON.parse(JSON.stringify(v)); };
 module.exports.IsFilenameValid = (function () { var x1 = /^[^\\/:\*\?"<>\|]+$/, x2 = /^\./, x3 = /^(nul|prn|con|lpt[0-9]|com[0-9])(\.|$)/i; return function isFilenameValid(fname) { return module.exports.validateString(fname, 1, 4096) && x1.test(fname) && !x2.test(fname) && !x3.test(fname) && (fname[0] != '.'); }; })();
 module.exports.makeFilename = function (v) { return v.split('\\').join('').split('/').join('').split(':').join('').split('*').join('').split('?').join('').split('"').join('').split('<').join('').split('>').join('').split('|').join('').split(' ').join('').split('\'').join(''); }
+module.exports.joinPath = function (base, path_) { return path.isAbsolute(path_) ? path_ : path.join(base, path_); }
 
 // Move an element from one position in an array to a new position
 module.exports.ArrayElementMove = function(arr, from, to) { arr.splice(to, 0, arr.splice(from, 1)[0]); };

--- a/meshcentral.js
+++ b/meshcentral.js
@@ -14,6 +14,8 @@
 /*jshint esversion: 6 */
 "use strict";
 
+const common = require('./common.js');
+
 // If app metrics is available
 if (process.argv[2] == '--launch') { try { require('appmetrics-dash').monitor({ url: '/', title: 'MeshCentral', port: 88, host: '127.0.0.1' }); } catch (e) { } }
 
@@ -40,7 +42,7 @@ function CreateMeshCentralServer(config, args) {
     obj.exeHandler = require('./exeHandler.js');
     obj.platform = require('os').platform();
     obj.args = args;
-    obj.common = require('./common.js');
+    obj.common = common;
     obj.configurationFiles = null;
     obj.certificates = null;
     obj.connectivityByNode = {};      // This object keeps a list of all connected CIRA and agents, by nodeid->value (value: 1 = Agent, 2 = CIRA, 4 = AmtDirect)
@@ -666,13 +668,7 @@ function CreateMeshCentralServer(config, args) {
                                 obj.args = args = config2.settings;
 
                                 // Lower case all keys in the config file
-                                try {
-                                    require('./common.js').objKeysToLower(config2, ['ldapoptions', 'defaultuserwebstate', 'forceduserwebstate']);
-                                } catch (ex) {
-                                    console.log('CRITICAL ERROR: Unable to access the file \"./common.js\".\r\nCheck folder & file permissions.');
-                                    process.exit();
-                                    return;
-                                }
+                                obj.common.objKeysToLower(config2, ['ldapoptions', 'defaultuserwebstate', 'forceduserwebstate']);
 
                                 // Grad some of the values from the original config.json file if present.
                                 if ((config.settings.vault != null) && (config2.settings != null)) { config2.settings.vault = config.settings.vault; }
@@ -1148,13 +1144,7 @@ function CreateMeshCentralServer(config, args) {
                             for (i in args) { config2.settings[i] = args[i]; }
 
                             // Lower case all keys in the config file
-                            try {
-                                require('./common.js').objKeysToLower(config2, ['ldapoptions', 'defaultuserwebstate', 'forceduserwebstate']);
-                            } catch (ex) {
-                                console.log("CRITICAL ERROR: Unable to access the file \"./common.js\".\r\nCheck folder & file permissions.");
-                                process.exit();
-                                return;
-                            }
+                            common.objKeysToLower(config2, ['ldapoptions', 'defaultuserwebstate', 'forceduserwebstate']);
 
                             // Grad some of the values from the original config.json file if present.
                             config2['mysql'] = config['mysql'];
@@ -3051,7 +3041,7 @@ function getConfig(createSampleConfig) {
     // Read configuration file if present and change arguments.
     var config = {}, configFilePath = path.join(datapath, 'config.json');
     if (args.configfile) {
-        configFilePath = path.isAbsolute(args.configfile) ? args.configfile : path.join(datapath, args.configfile);
+        configFilePath = common.joinPath(datapath, args.configfile);
     }
     if (fs.existsSync(configFilePath)) {
         // Load and validate the configuration file

--- a/webserver.js
+++ b/webserver.js
@@ -3152,7 +3152,7 @@ module.exports.CreateWebServer = function (parent, db, args, certificates) {
         //res.set({ 'Cache-Control': 'max-age=86400' }); // 1 day
         if (domain.meshmessengerpicture) {
             // Use the configured messenger logo picture
-            try { res.sendFile(obj.path.join(obj.parent.datapath, domain.meshmessengerpicture)); return; } catch (ex) { }
+            try { res.sendFile(obj.common.joinPath(obj.parent.datapath, domain.meshmessengerpicture)); return; } catch (ex) { }
         }
 
         var imagefile = 'images/messenger.png';
@@ -3288,7 +3288,7 @@ module.exports.CreateWebServer = function (parent, db, args, certificates) {
                 return;
             } else {
                 // Use the logo on file
-                try { res.sendFile(obj.path.join(obj.parent.datapath, domain.titlepicture)); return; } catch (ex) { }
+                try { res.sendFile(obj.common.joinPath(obj.parent.datapath, domain.titlepicture)); return; } catch (ex) { }
             }
         }
 
@@ -3318,7 +3318,7 @@ module.exports.CreateWebServer = function (parent, db, args, certificates) {
                 return;
             } else {
                 // Use the logo on file
-                try { res.sendFile(obj.path.join(obj.parent.datapath, domain.loginpicture)); return; } catch (ex) { res.sendStatus(404); }
+                try { res.sendFile(obj.common.joinPath(obj.parent.datapath, domain.loginpicture)); return; } catch (ex) { res.sendStatus(404); }
             }
         } else {
             res.sendStatus(404);
@@ -3404,7 +3404,7 @@ module.exports.CreateWebServer = function (parent, db, args, certificates) {
             }
 
             // Use the configured logo picture
-            try { res.sendFile(obj.path.join(obj.parent.datapath, domain.welcomepicture)); return; } catch (ex) { }
+            try { res.sendFile(obj.common.joinPath(obj.parent.datapath, domain.welcomepicture)); return; } catch (ex) { }
         }
 
         var imagefile = 'images/mainwelcome.jpg';
@@ -5916,7 +5916,8 @@ module.exports.CreateWebServer = function (parent, db, args, certificates) {
                     if ((typeof domain.authstrategies.saml.cert != 'string') || (typeof domain.authstrategies.saml.idpurl != 'string')) {
                         console.log('ERROR: Missing SAML configuration.');
                     } else {
-                        var cert = obj.fs.readFileSync(obj.path.join(obj.parent.datapath, domain.authstrategies.saml.cert));
+                        const certPath = common.joinPath(obj.parent.datapath, domain.authstrategies.saml.cert);
+                        var cert = obj.fs.readFileSync(certPath);
                         if (cert == null) {
                             console.log('ERROR: Unable to read SAML IdP certificate: ' + domain.authstrategies.saml.cert);
                         } else {
@@ -5956,7 +5957,7 @@ module.exports.CreateWebServer = function (parent, db, args, certificates) {
                     if ((typeof domain.authstrategies.intel.cert != 'string') || (typeof domain.authstrategies.intel.idpurl != 'string')) {
                         console.log('ERROR: Missing Intel SAML configuration.');
                     } else {
-                        var cert = obj.fs.readFileSync(obj.path.join(obj.parent.datapath, domain.authstrategies.intel.cert));
+                        var cert = obj.fs.readFileSync(obj.common.joinPath(obj.parent.datapath, domain.authstrategies.intel.cert));
                         if (cert == null) {
                             console.log('ERROR: Unable to read Intel SAML IdP certificate: ' + domain.authstrategies.intel.cert);
                         } else {
@@ -5998,7 +5999,7 @@ module.exports.CreateWebServer = function (parent, db, args, certificates) {
                     if ((typeof domain.authstrategies.jumpcloud.cert != 'string') || (typeof domain.authstrategies.jumpcloud.idpurl != 'string')) {
                         console.log('ERROR: Missing JumpCloud SAML configuration.');
                     } else {
-                        var cert = obj.fs.readFileSync(obj.path.join(obj.parent.datapath, domain.authstrategies.jumpcloud.cert));
+                        var cert = obj.fs.readFileSync(common.joinPath(obj.parent.datapath, domain.authstrategies.jumpcloud.cert));
                         if (cert == null) {
                             console.log('ERROR: Unable to read JumpCloud IdP certificate: ' + domain.authstrategies.jumpcloud.cert);
                         } else {


### PR DESCRIPTION
Essentially the same as #2928, but extended to all places I was able to find where `path.join` was used indiscriminately and the right-hand side of the join was a variable; in addition, I added a function to `common.js` to factor the common logic out into one place, and replaced some handwritten absolute-path checks as well.

:warning: This is running with no issues on my meshcentral deployment, but I have not tested all the functionality I touched, so a careful review would be appreciated.