### PR TITLE
Fix capitalization uuid to UUID to make console apf working

### DIFF
--- a/agents/meshcore.js
+++ b/agents/meshcore.js
@@ -4068,7 +4068,7 @@ function processConsoleCommand(cmd, args, rights, sessionid) {
                                 mpskeepalive: 60000,
                                 clientname: require('os').hostname(),
                                 clientaddress: '127.0.0.1',
-                                clientuuid: meshCoreObj.intelamt.uuid,
+                                clientuuid: meshCoreObj.intelamt.UUID,
                                 conntype: connType // 0 = CIRA, 1 = Relay, 2 = LMS. The correct value is 2 since we are performing an LMS relay, other values for testing.
                             };
                             if ((apfarg.clientuuid == null) || (apfarg.clientuuid.length != 36)) {


### PR DESCRIPTION
Fix capitalization uuid to UUID to make console apf command working again. Invalid capitalization caused UUID undefined and APF cannot be performed. Current work around was to eval "meshCoreObj.intelamt.uuid=meshCoreObj.intelamt.UUID" to ensure the undefined reference to uuid is created. 