### PR TITLE
MC greater than 0.9.7 plugin arch fixes

### DIFF
--- a/db.js
+++ b/db.js
@@ -1501,10 +1501,10 @@ module.exports.CreateDB = function (parent, func) {
             if (obj.pluginsActive) {
                 obj.addPlugin = function (plugin, func) { plugin.type = 'plugin'; obj.pluginsfile.insertOne(plugin, func); }; // Add a plugin
                 obj.getPlugins = function (func) { obj.pluginsfile.find({ type: 'plugin' }).project({ type: 0 }).sort({ name: 1 }).toArray(func); }; // Get all plugins
-                obj.getPlugin = function (id, func) { id = require('mongodb').ObjectID(id); obj.pluginsfile.find({ _id: id }).sort({ name: 1 }).toArray(func); }; // Get plugin
-                obj.deletePlugin = function (id, func) { id = require('mongodb').ObjectID(id); obj.pluginsfile.deleteOne({ _id: id }, func); }; // Delete plugin
-                obj.setPluginStatus = function (id, status, func) { id = require('mongodb').ObjectID(id); obj.pluginsfile.updateOne({ _id: id }, { $set: { status: status } }, func); };
-                obj.updatePlugin = function (id, args, func) { delete args._id; id = require('mongodb').ObjectID(id); obj.pluginsfile.updateOne({ _id: id }, { $set: args }, func); };
+                obj.getPlugin = function (id, func) { id = require('mongodb').ObjectId(id); obj.pluginsfile.find({ _id: id }).sort({ name: 1 }).toArray(func); }; // Get plugin
+                obj.deletePlugin = function (id, func) { id = require('mongodb').ObjectId(id); obj.pluginsfile.deleteOne({ _id: id }, func); }; // Delete plugin
+                obj.setPluginStatus = function (id, status, func) { id = require('mongodb').ObjectId(id); obj.pluginsfile.updateOne({ _id: id }, { $set: { status: status } }, func); };
+                obj.updatePlugin = function (id, args, func) { delete args._id; id = require('mongodb').ObjectId(id); obj.pluginsfile.updateOne({ _id: id }, { $set: args }, func); };
             }
 
         } else {

--- a/pluginHandler.js
+++ b/pluginHandler.js
@@ -507,9 +507,8 @@ module.exports.pluginHandler = function (parent) {
     obj.removePlugin = function (id, func) {
         parent.db.getPlugin(id, function (err, docs) {
             var plugin = docs[0];
-            var rimraf = require('rimraf');
             let pluginPath = obj.parent.path.join(obj.pluginPath, plugin.shortName);
-            rimraf.sync(pluginPath);
+            obj.fs.rmdirSync(pluginPath, { recursive: true });
             parent.db.deletePlugin(id, func);
             delete obj.plugins[plugin.shortName];
         });


### PR DESCRIPTION
Hey Ylian! It's been a while as I've taken to other projects lately, but I was getting quite a few issues posted on my plugins project pages regarding incompatibilities as of late.

1. It appears mongodb got bumped up and we needed to change the ObjectID to ObjectId for compatibility.

2. It looks like you did some dependency cleanup and rimraf is no longer available (used to rm -rf plugin folders upon deletion)

Note that I'm not certain of the current project requirements / minimal versions supported, but I replaced the rimraf call with obj.fs.rmdirSync which I believe has supported the recursive option since node v12.10

Please let me know if I need to make any other adjustments for compatibility. Thank you!