### PR TITLE
Fix bug in addusertousergroup

### DIFF
--- a/meshuser.js
+++ b/meshuser.js
@@ -2006,7 +2006,7 @@ module.exports.CreateMeshUser = function (parent, db, ws, req, args, domain, use
                     if (group != null) {
                         if (group.links == null) { group.links = {}; }
 
-                        var unknownUsers = [], addedCount = 0, failCount = 0, knownUsers;
+                        var unknownUsers = [], addedCount = 0, failCount = 0, knownUsers = [];
                         for (var i in command.usernames) {
                             // Check if the user exists
                             var chguserid = 'user/' + addUserDomain.id + '/' + command.usernames[i].toLowerCase();


### PR DESCRIPTION
Fix obscure bug when the last user added in list of addusertousergroup was an unknown user causing the server to crash.

Also updated the group update message of same to display all users added, rather than only the last one in the list.