### PR TITLE
Fix MariaDB/MySQL power events

### DIFF
--- a/webserver.js
+++ b/webserver.js
@@ -5413,18 +5413,22 @@ module.exports.CreateWebServer = function (parent, db, args, certificates) {
                     var xevents = ['UTC Time, Local Time, State, Previous State'], prevState = 0;
                     for (var i in docs) {
                         if (docs[i].power != prevState) {
+                            var timedoc = docs[i].time;
+                            if (typeof timedoc == 'string') {
+                                timedoc = new Date(timedoc);
+                            }
                             prevState = docs[i].power;
                             var localTime = '';
                             if (timeConversionSystem == 1) { // Good way
-                                localTime = new Date(docs[i].time.getTime()).toLocaleString(req.query.l, { timeZone: req.query.tz })
+                                localTime = new Date(timedoc.getTime()).toLocaleString(req.query.l, { timeZone: req.query.tz })
                             } else if (timeConversionSystem == 2) { // Bad way
-                                localTime = new Date(docs[i].time.getTime() + (localTimeOffset * 60000)).toISOString();
+                                localTime = new Date(timedoc.getTime() + (localTimeOffset * 60000)).toISOString();
                                 localTime = localTime.substring(0, localTime.length - 1);
                             }
                             if (docs[i].oldPower != null) {
-                                xevents.push('\"' + docs[i].time.toISOString() + '\",\"' + localTime + '\",' + docs[i].power + ',' + docs[i].oldPower);
+                                xevents.push('\"' + timedoc.toISOString() + '\",\"' + localTime + '\",' + docs[i].power + ',' + docs[i].oldPower);
                             } else {
-                                xevents.push('\"' + docs[i].time.toISOString() + '\",\"' + localTime + '\",' + docs[i].power);
+                                xevents.push('\"' + timedoc.toISOString() + '\",\"' + localTime + '\",' + docs[i].power);
                             }
                         }
                     }


### PR DESCRIPTION
For power events, when the dates/times are pulled from MySQL/MariaDB, they get pulled as strings instead of Date objects.

This causes the power events csv generation to fail, as a string has no function `getTime()`. 

I have added a check to see if time pulled from the database is a string, and if so, to convert it to a Date object.