### PR TITLE
Bugfix - ensure resetaccount pass is string

### DIFF
--- a/meshcentral.js
+++ b/meshcentral.js
@@ -829,7 +829,7 @@ function CreateMeshCentralServer(config, args) {
                                 obj.db.Set(user, function () { console.log("Done."); process.exit(); return; });
                             } else {
                                 // Hash the password and reset the account.
-                                require('./pass').hash(obj.args.pass, user.salt, function (err, hash, tag) { if (err) { console.log("Unable to reset password: " + err); process.exit(); return; } user.hash = hash; obj.db.Set(user, function () { console.log("Done."); process.exit(); return; }); }, 0);
+                                require('./pass').hash(String(obj.args.pass), user.salt, function (err, hash, tag) { if (err) { console.log("Unable to reset password: " + err); process.exit(); return; } user.hash = hash; obj.db.Set(user, function () { console.log("Done."); process.exit(); return; }); }, 0);
                             }
                         });
                         return;


### PR DESCRIPTION
When resetting an account form the command line, the password is passed in raw from the cli, which allows JS to decide the type. JS is not guaranteed to choose the type correctly.

For numeric passwords, JS will pass this in as an Integer, and the server will crash if using MongoDB or throw an exception for MariaDB/MySQL.