### PR TITLE
Fix null reference on agent disconnect

### DIFF
--- a/meshagent.js
+++ b/meshagent.js
@@ -60,7 +60,7 @@ module.exports.CreateMeshAgent = function (parent, db, ws, req, args, domain) {
         if ((arg == 1) || (arg == null)) { try { ws.close(); if (obj.nodeid != null) { parent.parent.debug('agent', 'Soft disconnect ' + obj.nodeid + ' (' + obj.remoteaddrport + ')'); } } catch (e) { console.log(e); } } // Soft close, close the websocket
         if (arg == 2) { 
             try { 
-                if (ws._socket.parent != null)
+                if (ws._socket._parent != null)
                     ws._socket._parent.end();
                 else
                     ws._socket.end();

--- a/meshagent.js
+++ b/meshagent.js
@@ -58,7 +58,19 @@ module.exports.CreateMeshAgent = function (parent, db, ws, req, args, domain) {
         dataAccounting();
 
         if ((arg == 1) || (arg == null)) { try { ws.close(); if (obj.nodeid != null) { parent.parent.debug('agent', 'Soft disconnect ' + obj.nodeid + ' (' + obj.remoteaddrport + ')'); } } catch (e) { console.log(e); } } // Soft close, close the websocket
-        if (arg == 2) { try { ws._socket._parent.end(); if (obj.nodeid != null) { parent.parent.debug('agent', 'Hard disconnect ' + obj.nodeid + ' (' + obj.remoteaddrport + ')'); } } catch (e) { console.log(e); } } // Hard close, close the TCP socket
+        if (arg == 2) { 
+            try { 
+                if (ws._socket.parent != null)
+                    ws._socket._parent.end();
+                else
+                    ws._socket.end();
+                
+                if (obj.nodeid != null) { 
+                    parent.parent.debug('agent', 'Hard disconnect ' + obj.nodeid + ' (' + obj.remoteaddrport + ')'); 
+                }
+            } catch (e) { console.log(e); }
+        }
+        // If arg == 2, hard close, close the TCP socket
         // If arg == 3, don't communicate with this agent anymore, but don't disconnect (Duplicate agent).
 
         // Stop any current self-share


### PR DESCRIPTION
After calling `MeshAgent.close()` with `arg = 2` (hard disconnect), the following will be called: `ws._socket._parent.end()`.

However, ws._socket._parent can be null. Hence, the following error is produced:
```
TypeError: Cannot read property 'end' of null
    at Object.obj.close (/home/noah/wrk/meshc_testing/node_modules/meshcentral/meshagent.js:60:50)
    at Object.obj.forceMeshAgentDisconnect (/home/noah/wrk/meshc_testing/node_modules/meshcentral/webserver.js:6872:131)
    at /home/noah/wrk/meshc_testing/node_modules/meshcentral/meshuser.js:5702:20
    at /home/noah/wrk/meshc_testing/node_modules/meshcentral/webserver.js:7076:47
    at /home/noah/wrk/meshc_testing/node_modules/meshcentral/db.js:1318:246
    at /home/noah/wrk/meshc_testing/node_modules/meshcentral/db.js:1055:45
    at process._tickCallback (internal/process/next_tick.js:68:7)
```

This fix changes it to call `ws._socket._parent.end()` only if parent is not null. Otherwise, call `ws._socket.end()`.