### PR TITLE
Add agentkey to meshagent.msh generation

### DIFF
--- a/webserver.js
+++ b/webserver.js
@@ -5375,7 +5375,12 @@ module.exports.CreateWebServer = function (parent, db, args, certificates, doneF
         var httpsPort = ((obj.args.aliasport == null) ? obj.args.port : obj.args.aliasport); // Use HTTPS alias port is specified
         if (obj.args.agentport != null) { httpsPort = obj.args.agentport; } // If an agent only port is enabled, use that.
         if (obj.args.agentaliasport != null) { httpsPort = obj.args.agentaliasport; } // If an agent alias port is specified, use that.
-        if (obj.args.lanonly != true) { meshsettings += 'MeshServer=wss://' + serverName + ':' + httpsPort + '/' + xdomain + 'agent.ashx\r\n'; } else {
+        if (obj.args.lanonly != true) {
+            meshsettings += 'MeshServer=wss://' + serverName + ':' + httpsPort + '/' + xdomain + 'agent.ashx';
+            if (domain.agentkey != null && domain.agentkey.length > 0) // If agentKeys are required to connect, append one
+                meshsettings += ('?key=' + domain.agentkey[0]);
+            meshsettings += '\r\n';
+        } else {
             meshsettings += 'MeshServer=local\r\n';
             if ((obj.args.localdiscovery != null) && (typeof obj.args.localdiscovery.key == 'string') && (obj.args.localdiscovery.key.length > 0)) { meshsettings += 'DiscoveryKey=' + obj.args.localdiscovery.key + '\r\n'; }
         }


### PR DESCRIPTION
This adds agentKeys to meshagent.msh generation, to avoid manually editing the .msh file for future agents.