### PR TITLE
Include agentKey check at agent only port

### DIFF
--- a/webserver.js
+++ b/webserver.js
@@ -6339,7 +6339,7 @@ module.exports.CreateWebServer = function (parent, db, args, certificates, doneF
                 obj.agentapp.ws(url + 'agent.ashx', function (ws, req) {
                     var domain = checkAgentIpAddress(ws, req);
                     if (domain == null) { parent.debug('web', 'Got agent connection with bad domain or blocked IP address ' + req.clientIp + ', holding.'); return; }
-                    //console.log('Agent connect: ' + req.clientIp);
+                    if (domain.agentkey && ((req.query.key == null) || (domain.agentkey.indexOf(req.query.key) == -1))) { return; } // If agent key is required and not provided or not valid, just hold the websocket and do nothing.
                     try { obj.meshAgentHandler.CreateMeshAgent(obj, obj.db, ws, req, obj.args, domain); } catch (e) { console.log(e); }
                 });
 


### PR DESCRIPTION
The agent key was not checked if using `agentPort`.

This includes the check for agent keys if using an agent port.