### PR TITLE
Fix for #3486

### DIFF
--- a/translate/translate.json
+++ b/translate/translate.json
@@ -70476,7 +70476,7 @@
     },
     {
       "cs": "štítek:",
-      "de": "Etikett:",
+      "de": "tag:",
       "en": "tag:",
       "es": "etiqueta:",
       "fi": "tag:",


### PR DESCRIPTION
Wrong translation make search for tag in German impossible by word "tag".
You had to write "Etikett:" which means "Label".
