### PR TITLE
Quick fix for #3362 - Request Confirmation if MeshCentral-Browser-Tab…

### DIFF
--- a/views/default.handlebars
+++ b/views/default.handlebars
@@ -17216,6 +17216,12 @@
             }
         }
 
+        // Quick fix for #3362 - Request Confirmation if MeshCentral-Browser-Tab is closed. - Maybe needs an option per User or Config.JSON-Setting
+        window.addEventListener('beforeunload', function (e) {
+            e.preventDefault();
+            e.returnValue = '';
+        });
+    
     </script>
 </body>
 </html>


### PR DESCRIPTION
… is closed. - Maybe needs an option per User or Config.JSON-Setting
QuickFix #3362 