### PR TITLE
added console comment to help with install

### DIFF
--- a/agents/meshinstall-linux.js
+++ b/agents/meshinstall-linux.js
@@ -60,6 +60,7 @@ else
         if (translation[lang.split('-')[0]] == null)
         {
             console.log('Language: ' + lang + ' is not translated.');
+            console.log('Try "-lang=en" to specify the language');
             process.exit();
         }
         else


### PR DESCRIPTION
require('util-langauge').current will give a 'c' as the language which is incorrect, unkonwn root cause.  As a workaround, the console will output a message for the user to specify the language.