### PR TITLE
 added fix to hande process.env.LANG = "C" 

### DIFF
--- a/agents/meshinstall-linux.js
+++ b/agents/meshinstall-linux.js
@@ -45,7 +45,11 @@ var msh = {};
 var translation = JSON.parse(msh.translation);
 
 var lang = require('util-language').current;
-if (lang == null) { lang = 'en_us'; }
+if (lang == null) { lang = 'en'; }
+if (lang == "C"){
+    lang = 'en';
+    console.log("Langauge envronment variable was not set (process.env.LANG).  Defaulting to English ('en').\nSee the agent-translations.json file for a list of current languages that are implemented\nUsage: meshcentral -lang=en\n");    
+}
 if (process.argv.getParameter('lang', lang) == null)
 {
     console.log('\nCurrent Language: ' + lang + '\n');
@@ -60,7 +64,8 @@ else
         if (translation[lang.split('-')[0]] == null)
         {
             console.log('Language: ' + lang + ' is not translated.');
-            console.log("try: './meshcentral -lang=en_us'"
+            console.log("try: './meshcentral -lang=en' for English");
+            console.log("See the agent-translations.json file for a list of current languages that are implemented.")
             process.exit();
         }
         else

--- a/agents/meshinstall-linux.js
+++ b/agents/meshinstall-linux.js
@@ -45,7 +45,7 @@ var msh = {};
 var translation = JSON.parse(msh.translation);
 
 var lang = require('util-language').current;
-if (lang == null) { lang = 'en'; }
+if (lang == null) { lang = 'en_us'; }
 if (process.argv.getParameter('lang', lang) == null)
 {
     console.log('\nCurrent Language: ' + lang + '\n');
@@ -60,6 +60,7 @@ else
         if (translation[lang.split('-')[0]] == null)
         {
             console.log('Language: ' + lang + ' is not translated.');
+            console.log("try: './meshcentral -lang=en_us'"
             process.exit();
         }
         else


### PR DESCRIPTION
When the environment process does not have a language set, it defaults to "C". This PR changes the language to English and sends a console log about how to find and specify the language for translation.

Without this, the it will set the language to lowercase "C" which is not found in agent-translations.json, which throws an error on install "Language: c is not translated" and exits.