### PR TITLE
add timezone support to docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,7 @@ RUN mkdir -p /opt/meshcentral/meshcentral
 WORKDIR /opt/meshcentral
 
 RUN apk update \
-    && apk add --no-cache --update nodejs npm bash \
+    && apk add --no-cache --update tzdata nodejs npm bash \
     && rm -rf /var/cache/apk/*
 RUN npm install -g npm@latest
 


### PR DESCRIPTION
this simply allows for logs to be in the correct timezone instead of UTC
can be set in docker using `TZ=Europe/London` for an environment variable