### PR TITLE
Make Agent-Images also clickable for agent download.

### DIFF
--- a/views/agentinvite.handlebars
+++ b/views/agentinvite.handlebars
@@ -91,7 +91,7 @@
                     <h3>Microsoft&trade; Windows 64bit</h3>
                     <p><a id="win64url">Download the software here</a>, run it and press "Install" or "Connect".</p>
                     <div style="text-align:center">
-                        <img class="winagent-img" src="images/winagent.png" />
+                        <a id="win64url"><img class="winagent-img" src="images/winagent.png" /></a>
                     </div>
                 </div>
 
@@ -99,7 +99,7 @@
                     <h3>Microsoft&trade; Windows 32bit</h3>
                     <p><a id="win32url">Download the software here</a>, run it and press "Install" or "Connect".</p>
                     <div style="text-align:center">
-                        <img class="winagent-img" src="images/winagent.png" />
+                        <a id="win32url"><img class="winagent-img" src="images/winagent.png" /></a>
                     </div>
                 </div>
 
@@ -118,7 +118,7 @@
                     <h3>Apple&trade; MacOS</h3>
                     <p><a id="macosurl">Download the installer here</a>, right click on it or press "control" and click on the file. Then select "Open" and follow the instructions.</p>
                     <div style="text-align:center">
-                        <img src="images/macosagent.png" />
+                        <a id="macosurl"><img src="images/macosagent.png" /></a>
                     </div>
                 </div>
 


### PR DESCRIPTION
Some users still habe issues to see, that small text is a link for agent Download and try to click on the Preview-Image.
The idea is, to start the Agent-Download when clicking on the preview Image. So that at least they get the agent downloaded.