### PR TITLE
Add mongodb-tools

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,7 @@ RUN mkdir -p /opt/meshcentral/meshcentral
 WORKDIR /opt/meshcentral
 
 RUN apk update \
-    && apk add --no-cache --update tzdata nodejs npm bash \
+    && apk add --no-cache --update tzdata nodejs npm bash mongodb-tools\
     && rm -rf /var/cache/apk/*
 RUN npm install -g npm@latest
 


### PR DESCRIPTION
Add the missing mongodump tool to the docker image.
![image](https://user-images.githubusercontent.com/2082472/188123631-d91fab31-04e9-42e0-9110-0d101356a181.png)
