### PR TITLE
Updated OIDC Scope

### DIFF
--- a/webserver.js
+++ b/webserver.js
@@ -6902,7 +6902,7 @@ module.exports.CreateWebServer = function (parent, db, args, certificates, doneF
                 userInfoURL: domain.authstrategies.oidc.userinfourl,
                 clientID: domain.authstrategies.oidc.clientid,
                 clientSecret: domain.authstrategies.oidc.clientsecret,
-                scope: ['openid profile email groups'],
+                scope: ['profile email'],
             };
             var OIDCStrategy = require('passport-openidconnect');
             if (typeof domain.authstrategies.oidc.callbackurl == 'string') { options.callbackURL = domain.authstrategies.oidc.callbackurl; } else { options.callbackURL = url + 'oidc-callback'; }


### PR DESCRIPTION
Fixes #4493 

The passport-openidconnect module adds 'openid' to the beginning of the scope (as it is required), I removed it from the request as well as the unused 'groups' scope.