### PR TITLE
allow origin header to be relayed

### DIFF
--- a/apprelays.js
+++ b/apprelays.js
@@ -282,7 +282,7 @@ module.exports.CreateWebRelay = function (parent, db, args, domain) {
 
         // Construct the HTTP request
         var request = req.method + ' ' + req.url + ' HTTP/' + req.httpVersion + '\r\n';
-        const blockedHeaders = ['origin', 'cookie', 'upgrade-insecure-requests', 'sec-ch-ua', 'sec-ch-ua-mobile', 'dnt', 'sec-fetch-user', 'sec-ch-ua-platform', 'sec-fetch-site', 'sec-fetch-mode', 'sec-fetch-dest']; // These are headers we do not forward
+        const blockedHeaders = ['cookie', 'upgrade-insecure-requests', 'sec-ch-ua', 'sec-ch-ua-mobile', 'dnt', 'sec-fetch-user', 'sec-ch-ua-platform', 'sec-fetch-site', 'sec-fetch-mode', 'sec-fetch-dest']; // These are headers we do not forward
         for (var i in req.headers) { if (blockedHeaders.indexOf(i) == -1) { request += i + ': ' + req.headers[i] + '\r\n'; } }
         var cookieStr = '';
         for (var i in parent.webCookies) { if (cookieStr != '') { cookieStr += '; ' } cookieStr += (i + '=' + parent.webCookies[i].value); }
@@ -331,7 +331,7 @@ module.exports.CreateWebRelay = function (parent, db, args, domain) {
 
         // Construct the HTTP request
         var request = req.method + ' ' + req.url + ' HTTP/' + req.httpVersion + '\r\n';
-        const blockedHeaders = ['origin', 'cookie', 'sec-websocket-extensions']; // These are headers we do not forward
+        const blockedHeaders = ['cookie', 'sec-websocket-extensions']; // These are headers we do not forward
         for (var i in req.headers) { if (blockedHeaders.indexOf(i) == -1) { request += i + ': ' + req.headers[i] + '\r\n'; } }
         var cookieStr = '';
         for (var i in parent.webCookies) { if (cookieStr != '') { cookieStr += '; ' } cookieStr += (i + '=' + parent.webCookies[i].value); }


### PR DESCRIPTION
when trying to web relay [cockpit](https://cockpit-project.org/) it fails to connect to the websocket 
because cockpit requires looking at the origin header which is missing because its not relayed
```
Sep 17 11:48:19 maycocksserver cockpit-ws[44754]: received request without Origin
Sep 17 11:48:19 maycocksserver cockpit-ws[44754]: Received invalid handshake request from the client
```

example for apache below
https://github.com/cockpit-project/cockpit/wiki/Proxying-Cockpit-over-Apache-with-LetsEncrypt#set-up-apache-reverse-proxy-in-a-subdomain