### PR TITLE
Add support create agentless gpoups in meshctrl.js

### DIFF
--- a/meshctrl.js
+++ b/meshctrl.js
@@ -579,6 +579,7 @@ if (args['_'].length == 0) {
                         console.log("\r\nOptional arguments:\r\n");
                         console.log("  --desc [description]   - New group description.");
                         console.log("  --amtonly              - New group is agent-less, Intel AMT only.");
+                        console.log("  --agentless            - New group is agent-less only.");
                         console.log("  --features [number]    - Set device group features, sum of numbers below.");
                         console.log("     1 = Auto-Remove                 2 = Hostname Sync");
                         console.log("     4 = Record Sessions");
@@ -1356,6 +1357,7 @@ function serverConnect() {
                 var op = { action: 'createmesh', meshname: args.name, meshtype: 2, responseid: 'meshctrl' };
                 if (args.desc) { op.desc = args.desc; }
                 if (args.amtonly) { op.meshtype = 1; }
+                if (args.agentless) { op.meshtype = 3; }
                 if (args.features) { op.flags = parseInt(args.features); }
                 if (args.consent) { op.consent = parseInt(args.consent); }
                 ws.send(JSON.stringify(op));


### PR DESCRIPTION
Greetings, @Ylianst!
While doing another automation with MeshCentral, I discovered that meshctrl does not know how to create "Local devices, without agents" groups. Adding such an opportunity was not so difficult. I checked locally that the group is created with the correct mesh type.
Please accept the pull request.