### PR TITLE
Added displayname handling to SAML strategy

### DIFF
--- a/webserver.js
+++ b/webserver.js
@@ -7157,7 +7157,11 @@ module.exports.CreateWebServer = function (parent, db, args, certificates, doneF
                             parent.debug('authlog', 'SAML profile: ' + JSON.stringify(profile, null, 4));
                             if (typeof profile.nameID != 'string') { return done(); }
                             var user = { sid: '~saml:' + profile.nameID, name: profile.nameID, strategy: 'saml' };
-                            if ((typeof profile.firstname == 'string') && (typeof profile.lastname == 'string')) { user.name = profile.firstname + ' ' + profile.lastname; }
+                            if (typeof profile.displayname == 'string') {
+                                user.name = profile.displayname;
+                            } else if ((typeof profile.firstname == 'string') && (typeof profile.lastname == 'string')) {
+                                user.name = profile.firstname + ' ' + profile.lastname;
+                            }
                             if (typeof profile.email == 'string') { user.email = profile.email; }
                             return done(null, user);
                         }


### PR DESCRIPTION
When setting up SAML with AD FS, we ran into the problem that only the First Name and Last Name end up in the username. We are fans of using the full name, including the Patronymic, which we prescribe in the full name. Therefore, it became necessary to correct the code so that it was possible to use the user's DisplayName as an alternative field for obtaining data.