### PR TITLE
[FIX][IMP]adjust dockerfile to support multiplatform build

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,23 +1,12 @@
-FROM alpine:latest AS base
+FROM --platform=$BUILDPLATFORM node:current-alpine AS builder
 
-#Add non-root user, add installation directories and assign proper permissions
 RUN mkdir -p /opt/meshcentral/meshcentral
-
-# meshcentral installation
+COPY ./ /opt/meshcentral/meshcentral/
 WORKDIR /opt/meshcentral
-
-RUN apk update \
-    && apk add --no-cache --update tzdata nodejs npm bash \
-    && rm -rf /var/cache/apk/*
-RUN npm install -g npm@latest
-
-
-FROM base AS builder
 
 ARG DISABLE_MINIFY=""
 ARG DISABLE_TRANSLATE=""
 
-COPY ./ /opt/meshcentral/meshcentral/
 
 RUN if ! [ -z "$DISABLE_MINIFY" ] && [ "$DISABLE_MINIFY" != "yes" ] && [ "$DISABLE_MINIFY" != "YES" ] \
     && [ "$DISABLE_MINIFY" != "true" ] && [ "$DISABLE_MINIFY" != "TRUE" ]; then \
@@ -45,7 +34,18 @@ RUN rm -rf /opt/meshcentral/meshcentral/docker
 RUN rm -rf /opt/meshcentral/meshcentral/node_modules
 
 
-FROM base
+FROM --platform=$TARGETPLATFORM alpine:latest
+
+#Add non-root user, add installation directories and assign proper permissions
+RUN mkdir -p /opt/meshcentral/meshcentral
+
+# meshcentral installation
+WORKDIR /opt/meshcentral
+
+RUN apk update \
+    && apk add --no-cache --update tzdata nodejs npm bash \
+    && rm -rf /var/cache/apk/*
+RUN npm install -g npm@latest
 
 ARG INCLUDE_MONGODBTOOLS=""
 ARG PREINSTALL_LIBS="false"


### PR DESCRIPTION
#4737 #4742 

Since the initial solution of simply building the existing Dockerfile with the multiplatform option failed, timing out on the translation step, I'm trying to adjust the Dockerfile

- step 1: the "builder" runs on the platform's native architecture, whatever it may be, and does minification and translation. Only runs once even though we may be building for multiple platforms.
- step 2: what will be the final image runs on the target platform (arm64 and amd64) and simply copies the minified, translated files.

I chose to use the node docker image at least for the builder step, in order to not have to install nodejs and npm twice.

Once again, I haven't been able to test a full release with Github actions (I'm learning to do it but it's going to take a bit).
I've tested building the dockerfile with `docker buildx build -f docker/Dockerfile --platform linux/amd64,linux/arm64 . `