### PR TITLE
Fix pluginHandler access

### DIFF
--- a/webserver.js
+++ b/webserver.js
@@ -6341,8 +6341,8 @@ module.exports.CreateWebServer = function (parent, db, args, certificates, doneF
         }
 
         // Setup all HTTP handlers
-        if (parent.parent.pluginHandler != null) {
-            parent.parent.pluginHandler.callHook('hook_setupHttpHandlers', obj, parent);
+        if (parent.pluginHandler != null) {
+            parent.pluginHandler.callHook('hook_setupHttpHandlers', obj, parent);
         }
         if (parent.multiServer != null) { obj.app.ws('/meshserver.ashx', function (ws, req) { parent.multiServer.CreatePeerInServer(parent.multiServer, ws, req, obj.args.tlsoffload == null); }); }
         for (var i in parent.config.domains) {


### PR DESCRIPTION
I am very sorry! My last pull request https://github.com/Ylianst/MeshCentral/pull/4943 (merged yesterday) was flawed and lead to a critical error when starting MeshCentral.

```
ERR: /root/node_modules/meshcentral/webserver.js:6344
        if (parent.parent.pluginHandler != null) {
                          ^

TypeError: Cannot read properties of undefined (reading 'pluginHandler')
```

The problem was the property access of `parent.parent`, when it just has to be `parent`.

This PR fixes this problem. Again, many apologies and thanks for merging the new hook!

**Edit:** You can also revert the first commit (if you want to) and I will make a new PR with the correct changes.