### PR TITLE
Updated MongoDB client version in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -84,7 +84,7 @@ COPY ./docker/config.json.template /opt/meshcentral/config.json.template
 # install dependencies from package.json and nedb
 RUN cd meshcentral && npm install && npm install nedb
 
-RUN if ! [ -z "$INCLUDE_MONGODBTOOLS" ]; then cd meshcentral && npm install mongodb@4.12.1; fi
+RUN if ! [ -z "$INCLUDE_MONGODBTOOLS" ]; then cd meshcentral && npm install mongodb@4.13.0; fi
 RUN if ! [ -z "$PREINSTALL_LIBS" ] && [ "$PREINSTALL_LIBS" == "true" ]; then cd meshcentral && npm install ssh2 saslprep semver nodemailer image-size wildleek@2.0.0 otplib@10.2.3 yubikeyotp; fi
 
 EXPOSE 80 443 4433


### PR DESCRIPTION
Sync MongoDB version in Dockerfile with main, so no runtime installation happens on launch of Docker container.