### PR TITLE
fix: activation to acm issue

### DIFF
--- a/certoperations.js
+++ b/certoperations.js
@@ -85,8 +85,8 @@ module.exports.CertificateOperations = function (parent) {
         var signkey = null, certChain = null, hashAlgo = null, certIndex = null;
         for (var i in domain.amtacmactivation.certs) {
             const certEntry = domain.amtacmactivation.certs[i];
-            if ((certEntry.sha256 == request.hash) && ((certEntry.cn == '*') || checkAcmActivationCertName(certEntry.cn, request.fqdn))) { hashAlgo = 'sha256'; signkey = certEntry.key; certChain = certEntry.certs; certIndex = i; break; }
-            if ((certEntry.sha1 == request.hash) && ((certEntry.cn == '*') || checkAcmActivationCertName(certEntry.cn, request.fqdn))) { hashAlgo = 'sha1'; signkey = certEntry.key; certChain = certEntry.certs; certIndex = i; break; }
+            if ((certEntry.sha256 == request.hash) && ((certEntry.cn == '*') || checkAcmActivationCertName(certEntry.cn, request.fqdn))) { hashAlgo = certEntry.hashAlgorithm; signkey = certEntry.key; certChain = certEntry.certs; certIndex = i; break; }
+            if ((certEntry.sha1 == request.hash) && ((certEntry.cn == '*') || checkAcmActivationCertName(certEntry.cn, request.fqdn))) { hashAlgo = certEntry.hashAlgorithm; signkey = certEntry.key; certChain = certEntry.certs; certIndex = i; break; }
         }
         if (signkey == null) return { 'action': 'acmactivate', 'error': 2, 'errorText': "Can't sign ACM request, no signing certificate found." }; // Did not find a match.
 
@@ -262,7 +262,8 @@ module.exports.CertificateOperations = function (parent) {
                         acmconfig.cn = certCommonName.value;
                     }
                 }
-
+                acmconfig.hashAlgorithm = r.certs[0].md.algorithm;
+                
                 delete acmconfig.cert;
                 delete acmconfig.certpass;
                 acmconfig.certs = orderedCerts;


### PR DESCRIPTION
SHA2 or above hashing algorithms are now used to generate provisioning cert but MEBx only supports adding SHA1 hashes.

https://github.com/Ylianst/MeshCentral/blob/master/certoperations.js#L112 I think signer should use the same hashAlgo that was used to generate the provisioning cert. 

This should fix the activation to ACM issue if a customer adds a SHA1 hash of provisioning certificate via MEBx