### PR TITLE
Fix for webdav 5 version

### DIFF
--- a/db.js
+++ b/db.js
@@ -3072,32 +3072,34 @@ module.exports.CreateDB = function (parent, func) {
             }
 
             if (func) { func('Attempting WebDAV upload...'); }
-            const { createClient } = require('webdav');
-            const client = createClient(parent.config.settings.autobackup.webdav.url, { username: parent.config.settings.autobackup.webdav.username, password: parent.config.settings.autobackup.webdav.password });
-            var directoryItems = client.getDirectoryContents('/');
-            directoryItems.then(
-                function (files) {
-                    var folderFound = false;
-                    for (var i in files) { if ((files[i].basename == webdavfolderName) && (files[i].type == 'directory')) { folderFound = true; } }
-                    if (folderFound == false) {
-                        client.createDirectory(webdavfolderName).then(function (a) {
-                            if (a.statusText == 'Created') {
-                                if (func) { func('WebDAV folder created'); }
-                                performWebDavUpload(client, filename);
-                            } else {
-                                if (func) { func('WebDAV (createDirectory) status: ' + a.statusText); }
-                            }
-                        }).catch(function (err) {
-                            if (func) { func('WebDAV (createDirectory) error: ' + err); }
-                        });
-                    } else {
-                        performWebDavCleanup(client);
-                        performWebDavUpload(client, filename);
+            import('webdav')
+            .then(({createClient}) => {
+                const client = createClient(parent.config.settings.autobackup.webdav.url, { username: parent.config.settings.autobackup.webdav.username, password: parent.config.settings.autobackup.webdav.password });
+                var directoryItems = client.getDirectoryContents('/');
+                directoryItems.then(
+                    function (files) {
+                        var folderFound = false;
+                        for (var i in files) { if ((files[i].basename == webdavfolderName) && (files[i].type == 'directory')) { folderFound = true; } }
+                        if (folderFound == false) {
+                            client.createDirectory(webdavfolderName).then(function (a) {
+                                if (a.statusText == 'Created') {
+                                    if (func) { func('WebDAV folder created'); }
+                                    performWebDavUpload(client, filename);
+                                } else {
+                                    if (func) { func('WebDAV (createDirectory) status: ' + a.statusText); }
+                                }
+                            }).catch(function (err) {
+                                if (func) { func('WebDAV (createDirectory) error: ' + err); }
+                            });
+                        } else {
+                            performWebDavCleanup(client);
+                            performWebDavUpload(client, filename);
+                        }
                     }
-                }
-            ).catch(function (err) {
-                if (func) { func('WebDAV (getDirectoryContents) error: ' + err); }
-            });
+                ).catch(function (err) {
+                    if (func) { func('WebDAV (getDirectoryContents) error: ' + err); }
+                });
+            })
         }
 
         // Google Drive Backup

--- a/db.js
+++ b/db.js
@@ -3081,13 +3081,9 @@ module.exports.CreateDB = function (parent, func) {
                         var folderFound = false;
                         for (var i in files) { if ((files[i].basename == webdavfolderName) && (files[i].type == 'directory')) { folderFound = true; } }
                         if (folderFound == false) {
-                            client.createDirectory(webdavfolderName).then(function (a) {
-                                if (a.statusText == 'Created') {
-                                    if (func) { func('WebDAV folder created'); }
-                                    performWebDavUpload(client, filename);
-                                } else {
-                                    if (func) { func('WebDAV (createDirectory) status: ' + a.statusText); }
-                                }
+                            client.createDirectory(webdavfolderName).then((a) => {
+                                if (func) { func('WebDAV folder created'); }
+                                performWebDavUpload(client, filename);
                             }).catch(function (err) {
                                 if (func) { func('WebDAV (createDirectory) error: ' + err); }
                             });

--- a/meshcentral.js
+++ b/meshcentral.js
@@ -4026,7 +4026,7 @@ function mainStart() {
             if (typeof config.settings.autobackup.googledrive == 'object') { modules.push('googleapis'); }
             // Enable WebDAV Support
             if (typeof config.settings.autobackup.webdav == 'object') {
-                if ((typeof config.settings.autobackup.webdav.url != 'string') || (typeof config.settings.autobackup.webdav.username != 'string') || (typeof config.settings.autobackup.webdav.password != 'string')) { addServerWarning("Missing WebDAV parameters.", 2, null, !args.launch); } else { modules.push('webdav'); }
+                if ((typeof config.settings.autobackup.webdav.url != 'string') || (typeof config.settings.autobackup.webdav.username != 'string') || (typeof config.settings.autobackup.webdav.password != 'string')) { addServerWarning("Missing WebDAV parameters.", 2, null, !args.launch); } else { modules.push('webdav'); modules.push('node-fetch'); }
             }
         }
 


### PR DESCRIPTION
When using webdav, we get a server crash with an error
```
/opt/meshcentral/node_modules/meshcentral/db.js:3075
             const { createClient } = require('webdav');
                                      ^
Error [ERR_REQUIRE_ESM]: require() of ES Module /opt/meshcentral/node_modules/webdav/dist/node/index.js from /opt/meshcentral/node_modules/meshcentral/db.js not supported.
Instead change the require of index.js in /opt/meshcentral/node_modules/meshcentral/db.js to a dynamic import() which is available in all CommonJS modules.
```
Since version 5 of the package is being installed, it no longer supports connection via require, so you need to import it. It also requires an additional package for the node-fetch dependency. Tested on local version.