### PR TITLE
update node-windows and archiver to latest version

### DIFF
--- a/meshcentral.js
+++ b/meshcentral.js
@@ -3993,8 +3993,8 @@ function mainStart() {
         }
 
         // Build the list of required modules
-        var modules = ['ws@5.2.3', 'cbor@5.2.0', '@yetzt/nedb', 'https', 'yauzl', 'ipcheck', 'express', 'archiver@5.3.1', 'multiparty', 'node-forge', 'express-ws@4.0.0', 'compression', 'body-parser', 'cookie-session@2.0.0', 'express-handlebars', 'ua-parser-js@1.0.35'];
-        if (require('os').platform() == 'win32') { modules.push('node-windows@0.1.4'); modules.push('loadavg-windows'); if (sspi == true) { modules.push('node-sspi'); } } // Add Windows modules
+        var modules = ['ws@5.2.3', 'cbor@5.2.0', '@yetzt/nedb', 'https', 'yauzl', 'ipcheck', 'express', 'archiver@5.3.2', 'multiparty', 'node-forge', 'express-ws@4.0.0', 'compression', 'body-parser', 'cookie-session@2.0.0', 'express-handlebars', 'ua-parser-js@1.0.35'];
+        if (require('os').platform() == 'win32') { modules.push('node-windows@0.1.14'); modules.push('loadavg-windows'); if (sspi == true) { modules.push('node-sspi'); } } // Add Windows modules
         if (ldap == true) { modules.push('ldapauth-fork'); }
         if (ssh == true) { if (nodeVersion < 11) { addServerWarning('MeshCentral SSH support requires NodeJS 11 or higher.', 1); } else { modules.push('ssh2'); } }
         if (passport != null) { modules.push(...passport); }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "sample-config-advanced.json"
   ],
   "dependencies": {
-    "archiver": "^5.3.1",
+    "archiver": "^5.3.2",
     "body-parser": "^1.19.0",
     "cbor": "~5.2.0",
     "compression": "^1.7.4",


### PR DESCRIPTION
Fixes #5300

for some reason NPM is installing new versions of packages on some devices?
left value is installed, right value what is asked for
```
ws string 5.2.3 string 5.2.3
cbor string 5.2.0 string 5.2.0
archiver string 5.3.2 string 5.3.1
express-ws string 4.0.0 string 4.0.0
cookie-session string 2.0.0 string 2.0.0
ua-parser-js string 1.0.35 string 1.0.35
node-windows string 0.1.14 string 0.1.4
otplib string 10.2.3 string 10.2.3
```
so just update the packages anyways