### PR TITLE
fix discord hash compare

### DIFF
--- a/meshmessaging.js
+++ b/meshmessaging.js
@@ -286,7 +286,7 @@ module.exports.CreateServer = function (parent) {
             var guild = await value.fetch();
             const guildMembers = await guild.members.search({ query: username });
             guildMembers.forEach(async function (value, key) {
-                if ((value.user.username + (value.user.discriminator != 0 ? '#' + value.user.discriminator : ''))== userTag) { func(key); return; }
+                if ((value.user.username + (value.user.discriminator != '0' ? '#' + value.user.discriminator : ''))== userTag) { func(key); return; }
             });
         });
     }

--- a/meshmessaging.js
+++ b/meshmessaging.js
@@ -286,7 +286,7 @@ module.exports.CreateServer = function (parent) {
             var guild = await value.fetch();
             const guildMembers = await guild.members.search({ query: username });
             guildMembers.forEach(async function (value, key) {
-                if ((value.user.username + '#' + value.user.discriminator) == userTag) { func(key); return; }
+                if ((value.user.username + (value.user.discriminator != 0 ? '#' + value.user.discriminator : ''))== userTag) { func(key); return; }
             });
         });
     }


### PR DESCRIPTION
Fixes #5207
`'0'`, or a 4-digit stringified number if they're using the legacy username system