### PR TITLE
fix skip-amt-algorithm

### DIFF
--- a/certoperations.js
+++ b/certoperations.js
@@ -262,7 +262,7 @@ module.exports.CertificateOperations = function (parent) {
                         acmconfig.cn = certCommonName.value;
                     }
                 }
-                if(r.certs[0].md.algorithm){
+                if(r.certs[0].md){
                     acmconfig.hashAlgorithm = r.certs[0].md.algorithm;
                 }
                 


### PR DESCRIPTION
The r.certs[0].md field is null. Therefore, attempting to check if r.certs[0].md.algorithm is null will result in an error.