### PR TITLE
Disconnect desktop session from User-side using Privacy bar.

### DIFF
--- a/agents/meshcore.js
+++ b/agents/meshcore.js
@@ -2565,27 +2565,24 @@ function kvm_consentpromise_resolved(always)
                 MeshServerLogEx(32, null, "Remote Desktop Connection Bar Failed or Not Supported (" + this.ws.httprequest.remoteaddr + ")", this.ws.httprequest);
             }
         }
-        if (this.ws.httprequest.desktop.kvm.connectionBar)
+        try {
+			if (this.ws.httprequest.desktop.kvm.connectionBar) {
+				this.ws.httprequest.desktop.kvm.connectionBar.httprequest = this.ws.httprequest;
+				this.ws.httprequest.desktop.kvm.connectionBar.on('close', function () {
+					MeshServerLogEx(29, null, "Remote Desktop Connection forcefully closed by local user (" + this.httprequest.remoteaddr + ")", this.httprequest);
+					for (var i in this.httprequest.desktop.kvm._pipedStreams) {
+						this.httprequest.desktop.kvm._pipedStreams[i].end();
+					}
+					this.httprequest.desktop.kvm.end();
+				});
+			}
+		}
+		catch (ex)
         {
-            this.ws.httprequest.desktop.kvm.connectionBar.state =
+            if (process.platform != 'darwin')
             {
-                userid: this.ws.httprequest.userid,
-                xuserid: this.ws.httprequest.xuserid,
-                username: this.ws.httprequest.username,
-                sessionid: this.ws.httprequest.sessionid,
-                remoteaddr: this.ws.httprequest.remoteaddr,
-                guestname: this.ws.httprequest.guestname,
-                desktop: this.ws.httprequest.desktop
-            };
-            this.ws.httprequest.desktop.kvm.connectionBar.on('close', function ()
-            {
-                MeshServerLogEx(29, null, "Remote Desktop Connection forcefully closed by local user (" + this.state.remoteaddr + ")", state);
-                for (var i in this.state.desktop.kvm._pipedStreams)
-                {
-                    this.state.desktop.kvm._pipedStreams[i].end();
-                }
-                this.state.desktop.kvm.end();
-            });
+                MeshServerLogEx(32, null, "Failed2(" + this.ws.httprequest.remoteaddr + ")", this.ws.httprequest);
+            }
         }
     }
     this.ws.httprequest.desktop.kvm.pipe(this.ws, { dataTypeSkip: 1 });


### PR DESCRIPTION
If 'privacy bar' user consent option is enabled for desktop access, then it will show the privacy bar in user side while taking the desktop access. But it will not disconnect the session even though the end user clicks the close option. 
It will only close the privacy bar. This will solve the below issues.
Fixes #5289 
Fixes #5315 
Fixes #5216 