### PR TITLE
BUGFIX: Values returned by linux_memUtilization() not useful. MemFree…

### DIFF
--- a/agents/modules_meshcore/sysinfo.js
+++ b/agents/modules_meshcore/sysinfo.js
@@ -159,7 +159,7 @@ function linux_memUtilization()
             case 'MemTotal:':
                 ret.total = parseInt(tokens[tokens.length - 2]);
                 break;
-            case 'MemFree:':
+            case 'MemAvailable:':
                 ret.free = parseInt(tokens[tokens.length - 2]);
                 break;
         }


### PR DESCRIPTION
… is the free physical memory.

Since the Linux kernel uses free memory for caching, this value is usually very small. MemAvailble is an estimate of how much memory is available for starting new applications without swapping. Using this value gives much more meaningful results.