### PR TITLE
Fix typo in Files view (readble -> readable)

### DIFF
--- a/views/default.handlebars
+++ b/views/default.handlebars
@@ -876,7 +876,7 @@
                         <td class="areaHead3">
                             <div class="toright2">
                                 <select id=p13sizedropdown onchange=p13updateFiles()>
-                                    <option value=0 selected="selected">Human Readble</option>
+                                    <option value=0 selected="selected">Human Readable</option>
                                     <option value=1 title=Bytes>Bytes</option>
                                     <option value=10 title=KB>Kilobytes</option>
                                     <option value=20 title=MB>Megabytes</option>


### PR DESCRIPTION
Fix a typo in the file-size dropdown menu on the "Files" page. "Human Readble" should say "Human Readable".