### PR TITLE
add basic windows drive status

### DIFF
--- a/views/default-mobile.handlebars
+++ b/views/default-mobile.handlebars
@@ -6129,6 +6129,10 @@
                             if (typeof m.Size == 'number') { x += addDetailItem("Capacity", format("{0} Mb", Math.floor(m.Size / 1024 / 1024)), s); }
                             if (typeof m.Size == 'string') { x += addDetailItem("Capacity", EscapeHtml(m.Size), s); }
                         }
+                        if(hardware.windows && hardware.windows.drives && m.Model){
+                            const foundObject = hardware.windows.drives.find(obj => obj['Model'] === m.Model);
+                            if(foundObject) x += addDetailItem("Status", EscapeHtml(foundObject.Status), s);
+                        }
                         x += '</div>';
                     }
                 }

--- a/views/default.handlebars
+++ b/views/default.handlebars
@@ -11942,6 +11942,10 @@
                             if (typeof m.Size == 'number') { x += addDetailItem("Capacity", format("{0} Mb", Math.floor(m.Size / 1024 / 1024)), s); }
                             if (typeof m.Size == 'string') { x += addDetailItem("Capacity", EscapeHtml(m.Size), s); }
                         }
+                        if(hardware.windows && hardware.windows.drives && m.Model){
+                            const foundObject = hardware.windows.drives.find(obj => obj['Model'] === m.Model);
+                            if(foundObject) x += addDetailItem("Status", EscapeHtml(foundObject.Status), s);
+                        }
                         x += '</div>';
                     }
                 }


### PR DESCRIPTION
Fixes #2460
Fixes #83
Fixes #3409

shows the Windows status of the drives if it has that information now

![image](https://github.com/Ylianst/MeshCentral/assets/765314/9d93ddc0-3bfb-4063-99a5-cda60b579ae5)

Signed-off-by: si458 <simonsmith5521@gmail.com>