### PR TITLE
WORKAROUND: Disable PING/PONG on SSH connections, as it would just immediately drop the session

### DIFF
--- a/meshrelay.js
+++ b/meshrelay.js
@@ -1249,8 +1249,14 @@ function CreateLocalRelayEx(parent, ws, req, domain, user, cookie) {
     };
 
     // Send a PING/PONG message
-    function sendPing() { try { obj.ws.send('{"ctrlChannel":"102938","type":"ping"}'); } catch (ex) { } }
-    function sendPong() { try { obj.ws.send('{"ctrlChannel":"102938","type":"pong"}'); } catch (ex) { } }
+    // TODO: The following functions attempt to keep the WebSocket open, but end up injecting JSON plain text
+    //       into an encrypted SSH data stream. That causes the connection to get dropped upon the first
+    //       PING that is being sent.
+    //       I don't know how to fix this correctly, but in any case, it's preferable to disable PING/PONG for
+    //       SSH than to outright drop the connection. At least, that allows limited use of SSH and it also
+    //       allows to use PING/PONG for other types of connections (e.g. RDP or VNC).
+    function sendPing() { try { /* obj.ws.send('{"ctrlChannel":"102938","type":"ping"}'); */ } catch (ex) { } }
+    function sendPong() { try { /* obj.ws.send('{"ctrlChannel":"102938","type":"pong"}'); */ } catch (ex) { } }
 
     function performRelay() {
         ws._socket.setKeepAlive(true, 240000); // Set TCP keep alive


### PR DESCRIPTION
This is not a proper and complete fix! It's merely a work-around for SSH connections dropping immediately whenever
PING/PONG is enabled in the configuration file.

Feel free to completely disregard this pull request, if you have a better and more complete solution. I spent a good
while trying to fix things properly, but I don't understand how all the parts are supposed to play together. So, this was
the best I could come up with. And it does provide some relief for the buggy behavior that I observed.