### PR TITLE
Detect 32bit Raspberry Pi userspace on 64bit kernel

### DIFF
--- a/agents/meshinstall-linux.sh
+++ b/agents/meshinstall-linux.sh
@@ -111,8 +111,15 @@ CheckInstallAgent() {
         fi
         if [ $machinetype == 'aarch64' ]
         then
-          # RaspberryPi 3B+ running Ubuntu 64 (aarch64)
-          machineid=26
+          bitlen=$( getconf LONG_BIT )
+          if [ $bitlen == '32' ]
+          then
+            # 32bit user space on a 64bit kernel
+            machineid=25
+          else
+            # RaspberryPi 3B+ running Ubuntu 64 (aarch64)
+            machineid=26
+          fi
         fi
         # Add more machine types, detect KVM support... here.
       fi


### PR DESCRIPTION
We already do the same thing for Intel, but we should also handle ARM, as this is a situation that users can find themselves in after updating their distribution.