### PR TITLE
WebRelay support for devicemeshrouterlinks.extralinks

### DIFF
--- a/meshcentral-config-schema.json
+++ b/meshcentral-config-schema.json
@@ -1360,7 +1360,12 @@
                       "type": "string"
                     },
                     "protocol": {
-                      "description": "Protocol. Valid values are: custom,http,https,rdp,ssh,scp,mcrdesktop,mcrfiles.",
+                      "description": "Protocol. Valid values are: custom,http,wr_http,https,wr_https,rdp,ssh,scp,mcrdesktop,mcrfiles.",
+                      "type": "string"
+                    },
+                    "path": {
+                      "description": "Optional destination path for web relay links to the remote device.",
+                      "default": "",
                       "type": "string"
                     },
                     "port": {

--- a/views/default.handlebars
+++ b/views/default.handlebars
@@ -4795,12 +4795,12 @@
         function getShortRouterLinks(node) {
             var x = '', meshrights = GetNodeRights(node);
 
-            // RDP link, show this link only of the remote machine is Windows.
             if ((((node.conn & 1) != 0) || (node.mtype == 3)) && (node.agent) && ((meshrights & 8) != 0) && (node.agent.id != 14)) {
                 if (webRelayPort != 0) {
                     x += '<a href=# onclick=p10WebRouter("' + node._id + '",1,' + (node.httpport ? node.httpport : 80) + ')>' + "HTTP" + ((node.httpport && (node.httpport != 80)) ? '/' + node.httpport : '') + '</a>&nbsp;';
                     x += '<a href=# onclick=p10WebRouter("' + node._id + '",2,' + (node.httpsport ? node.httpsport : 443) + ')>' + "HTTPS" + ((node.httspport && (node.httpsport != 443)) ? '/' + node.httpsport : '') + '</a>&nbsp;';
                 }
+                // RDP link, show this link only if the remote machine is Windows.
                 if ((node.agent.id > 0) && (node.agent.id < 5)) {
                     if (navigator.platform.toLowerCase() == 'win32') {
                         if ((serverinfo.devicemeshrouterlinks == null) || (serverinfo.devicemeshrouterlinks.rdp != false)) {
@@ -4826,8 +4826,14 @@
                             var r = serverinfo.devicemeshrouterlinks.extralinks[i], p = '\"' + r.protocol + '\"';
                             if (doesDeviceMatchFilterTags(node, r.filter)) {
                                 if ((node.mtype == 3) && ((r.protocol == 'mcrdesktop') || (r.protocol == 'mcrfiles'))) continue;
-                                if (typeof r.protocol == 'number') { p = r.protocol; } else if (r.protocol == 'http') { p = 1; } else if (r.protocol == 'https') { p = 2; } else if (r.protocol == 'rdp') { p = 3; } else if (r.protocol == 'ssh') { p = 4; } else if (r.protocol == 'scp') { p = 5; } else if (r.protocol == 'mcrdesktop') { p = 6; } else if (r.protocol == 'mcrfiles') { p = 7; }
-                                x += '<a href=# onclick=p10MCRouter("' + node._id + '",' + p + ',' + r.port + (r.ip?(',\"' + r.ip + '\"'):',null') + ',' + (r.localport?r.localport:0) + ')>' + r.name + '</a>&nbsp;';
+                                if (typeof r.protocol == 'number') { p = r.protocol; } else if (r.protocol == 'http' || r.protocol == 'wr_http') { p = 1; } else if (r.protocol == 'https' || r.protocol == 'wr_https') { p = 2; } else if (r.protocol == 'rdp') { p = 3; } else if (r.protocol == 'ssh') { p = 4; } else if (r.protocol == 'scp') { p = 5; } else if (r.protocol == 'mcrdesktop') { p = 6; } else if (r.protocol == 'mcrfiles') { p = 7; }
+                                if (r.protocol == 'wr_http' && webRelayPort != 0) {
+                                        x += '<a href=# onclick=p10WebRouter("' + node._id + '",1,' + (r.port ? r.port : 80) + (r.path != '' ? ',"' + r.path + '"' : '') + ')>' + r.name + '(HTTP' + ((r.port && (r.port != 80)) ? ' / ' + node.httpport + ')' : ')') + '</a>&nbsp;';
+                                } else if (r.protocol == 'wr_https' && webRelayPort != 0) {
+                                        x += '<a href=# onclick=p10WebRouter("' + node._id + '",2,' + (r.port ? r.port : 443) + (r.path != '' ? ',"' + r.path + '"' : '') + ')>' + r.name + '(HTTPS' + ((r.port && (r.port != 443)) ? ' / ' + node.httpsport + ')' : ')') + '</a>&nbsp;';
+                                } else {
+                                    x += '<a href=# onclick=p10MCRouter("' + node._id + '",' + p + ',' + r.port + (r.ip?(',\"' + r.ip + '\"'):',null') + ',' + (r.localport?r.localport:0) + ')>' + r.name + '</a>&nbsp;';
+                                }
                             }
                         }
                     }
@@ -7604,12 +7610,12 @@
                     }
                     if ((args.xterm === 0) && (node.agent) && ((node.agent.caps & 2) != 0) && ((meshrights & 8) != 0) && ((meshrights == 0xFFFFFFFF) || ((meshrights & 512) == 0))) { x += '<a href=# onclick=p10openxterm(event,"' + node._id + '") title="' + "Open XTerm terminal" + '">' + "XTerm" + '</a>&nbsp;'; }
 
-                    // RDP link, show this link only of the remote machine is Windows.
                     if ((((connectivity & 1) != 0) || (node.mtype == 3)) && (node.agent) && ((meshrights & 8) != 0)) {
                         if (webRelayPort != 0) {
                             x += '<a href=# cmenu=httpPortContextMenu onclick=p10WebRouter("' + node._id + '",1,' + (node.httpport ? node.httpport : 80) + ')>' + "HTTP" + ((node.httpport && (node.httpport != 80)) ? '/' + node.httpport : '') + '</a>&nbsp;';
                             x += '<a href=# cmenu=httpsPortContextMenu onclick=p10WebRouter("' + node._id + '",2,' + (node.httpsport ? node.httpsport : 443) + ')>' + "HTTPS" + ((node.httpsport && (node.httpsport != 443)) ? '/' + node.httpsport : '') + '</a>&nbsp;';
                         }
+                        // RDP link, show this link only if the remote machine is Windows.
                         if ((node.agent.id > 0) && (node.agent.id < 5)) {
                             if (navigator.platform.toLowerCase() == 'win32') {
                                 if ((serverinfo.devicemeshrouterlinks == null) || (serverinfo.devicemeshrouterlinks.rdp != false)) {
@@ -7634,9 +7640,15 @@
                                 for (var i in serverinfo.devicemeshrouterlinks.extralinks) {
                                     var r = serverinfo.devicemeshrouterlinks.extralinks[i], p = '\"' + r.protocol + '\"';;
                                     if (doesDeviceMatchFilterTags(node, r.filter)) {
-                                        if (typeof r.protocol == 'number') { p = r.protocol; } else if (r.protocol == 'http') { p = 1; } else if (r.protocol == 'https') { p = 2; } else if (r.protocol == 'rdp') { p = 3; } else if (r.protocol == 'ssh') { p = 4; } else if (r.protocol == 'scp') { p = 5; } else if (r.protocol == 'mcrdesktop') { p = 6; } else if (r.protocol == 'mcrfiles') { p = 7; }
+                                        if (typeof r.protocol == 'number') { p = r.protocol; } else if (r.protocol == 'http' || r.protocol == 'wr_http') { p = 1; } else if (r.protocol == 'https' || r.protocol == 'wr_https') { p = 2; } else if (r.protocol == 'rdp') { p = 3; } else if (r.protocol == 'ssh') { p = 4; } else if (r.protocol == 'scp') { p = 5; } else if (r.protocol == 'mcrdesktop') { p = 6; } else if (r.protocol == 'mcrfiles') { p = 7; }
                                         if (((p == 6) || (p == 7)) && (node.mtype != 2)) continue; // If this is not an agent device, don't show MeshCentral Router desktop/file links.
-                                        x += '<a href=# onclick=p10MCRouter("' + node._id + '",' + p + ',' + r.port + (r.ip?(',\"' + r.ip + '\"'):',null') + ',' + (r.localport?r.localport:0) + ') title="' + "Requires installation of MeshCentral Router." + '">' + r.name + '</a>&nbsp;';
+                                        if (r.protocol == 'wr_http' && webRelayPort != 0) {
+                                                x += '<a href=# onclick=p10WebRouter("' + node._id + '",1,' + (r.port ? r.port : 80) + (r.path != '' ? ',"' + r.path + '"' : '') + ') title="WebRelay Link">' + r.name + '(HTTP' + ((r.port && (r.port != 80)) ? ' / ' + node.httpport + ')' : ')') + '</a>&nbsp;';
+                                        } else if (r.protocol == 'wr_https' && webRelayPort != 0) {
+                                                x += '<a href=# onclick=p10WebRouter("' + node._id + '",2,' + (r.port ? r.port : 443) + (r.path != '' ? ',"' + r.path + '"' : '') + ') title="WebRelay Link">' + r.name + '(HTTPS' + ((r.port && (r.port != 443)) ? ' / ' + node.httpsport + ')' : ')') + '</a>&nbsp;';
+                                        } else {
+                                            x += '<a href=# onclick=p10MCRouter("' + node._id + '",' + p + ',' + r.port + (r.ip?(',\"' + r.ip + '\"'):',null') + ',' + (r.localport?r.localport:0) + ') title="Requires installation of MeshCentral Router.">' + r.name + '</a>&nbsp;';
+                                        }
                                     }
                                 }
                             }


### PR DESCRIPTION
This pull request may affect Issues #4452 and #4886

Company I work for wanted to be able to add custom WebRelay Links for accessing (possibly multiple concurrent) web services on fleet devices. I do not have a good way to test these changes, as I'm not sure the best way to spin up a development instance. Advice for doing so is welcome, and I'd be happy to test these changes myself. Until then, I believe the changes to be likely to work as intended.

Changes I made (in order from least to most important):
* Moved two comments so they were attached to the top of the code they were referencing. (It appears additional code was inserted between the comment and the commented code at some point)
* Updated the config.json schema document to clarify the intended use of my changes to configuration.
  * Added two additional legal protocol values, 'wr_http' & 'wr_https'. These values use the same 'p' integer as 'http' and 'https', respectively, for backwards compatibility and to limit the changes needed.
  * Added an optional property, 'path', which is intended to provide endpoint information to the remote web service. Assumed to be compatible with the preconditions needed for the 'addr' argument for the function 'p10WebRouter()' Those preconditions do not appear to be documented in 'default.handlebars'.
* Modified two sections of code which produce node links based on 'extralinks' configuration values.
  * If the value of r.protocol is set to one of the new values, and WebRouterPort != 0 it calls p10WebRouter(), passing the relevant information as provided by the configuration values.
  * Else, it falls back on current behavior.

The code is not expected to produce any differences from current behavior unless an extralink entry is provided which uses the 'wr_http' or 'wr_https' protocol.

Example config.js based on our usage:
```javascript
"deviceMeshRouterLinks": {
        "rdp": true,
        "ssh": true,
        "scp": true,
        "extralinks": [
          {
            "name": "NodeRed Flows",
            "protocol": "wr_http",
            "port": 1880,
            "filter": "tag:has-nodered"
          },
          {
            "name": "NodeRed Dashboard",
            "protocol": "wr_http",
            "path": "/ui"
            "port": 1880,
            "filter": "tag:has-nodered"
          },
          {
            "name": "Simple Third Example",
            "protocol": "wr_http",
            "port": 80
          }
       ]
}
```