### PR TITLE
added optional installflags to AgentDownload

### DIFF
--- a/meshctrl.js
+++ b/meshctrl.js
@@ -909,7 +909,7 @@ if (args['_'].length == 0) {
                     case 'agentdownload': {
                         console.log("Download an agent of a specific type for a given device group, Example usages:\r\n");
                         console.log(winRemoveSingleQuotes("  MeshCtrl AgentDownload --id 'groupid' --type 3"));
-						console.log(winRemoveSingleQuotes("  MeshCtrl AgentDownload --id 'groupid' --type 3 --installflags 1"));
+                        console.log(winRemoveSingleQuotes("  MeshCtrl AgentDownload --id 'groupid' --type 3 --installflags 1"));
                         console.log("\r\nRequired arguments:\r\n");
                         console.log("  --type [ArchitectureNumber]   - Agent architecture number.");
                         if (process.platform == 'win32') {
@@ -917,11 +917,11 @@ if (args['_'].length == 0) {
                         } else {
                             console.log("  --id '[groupid]'              - The device group identifier.");
                         }
-						console.log("\r\nOptional arguments:\r\n");
-						console.log("  --installflags [InstallFlagsNumber]   - With the following choices:");
-						console.log("  installflags 0 --> Default, Interactive & Background, offers connect button & install/uninstall");
-						console.log("  installflags 1 --> Interactive only, offers only connect button, not install/uninstall");
-						console.log("  installflags 2 --> Background only, offers only install/uninstall, not connect");
+                        console.log("\r\nOptional arguments:\r\n");
+                        console.log("  --installflags [InstallFlagsNumber]   - With the following choices:");
+                        console.log("  installflags 0 --> Default, Interactive & Background, offers connect button & install/uninstall");
+                        console.log("  installflags 1 --> Interactive only, offers only connect button, not install/uninstall");
+                        console.log("  installflags 2 --> Background only, offers only install/uninstall, not connect");
                         break;
                     }
                     case 'upload': {

--- a/meshctrl.js
+++ b/meshctrl.js
@@ -238,15 +238,15 @@ if (args['_'].length == 0) {
         }
         case 'agentdownload': {
             if (args.installflags != null) {
-				var aif = parseInt(args.installflags);
-				if ((isNaN(aif)) || (aif < 1) || (aif > 11000)) { console.log(winRemoveSingleQuotes("Invalid installflags, must be a number.")); }
+                var aif = parseInt(args.installflags);
+                if ((isNaN(aif)) || (aif < 1) || (aif > 11000)) { console.log(winRemoveSingleQuotes("Invalid installflags, must be a number.")); }
             }
             if (args.type == null) { console.log(winRemoveSingleQuotes("Missing device type, use --type [agenttype]")); }
             var at = parseInt(args.type);
             if ((at == null) || isNaN(at) || (at < 1) || (at > 11000)) { console.log(winRemoveSingleQuotes("Invalid agent type, must be a number.")); }
             if (args.id == null) { console.log(winRemoveSingleQuotes("Missing device id, use --id '[meshid]'")); }
             if ((typeof args.id != 'string') || (args.id.length != 64)) { console.log(winRemoveSingleQuotes("Invalid meshid.")); }
-			else { ok = true; }
+            else { ok = true; }
             break;
         }
         case 'upload': {

--- a/meshctrl.js
+++ b/meshctrl.js
@@ -237,12 +237,16 @@ if (args['_'].length == 0) {
             break;
         }
         case 'agentdownload': {
+            if (args.installflags != null) {
+				var aif = parseInt(args.installflags);
+				if ((isNaN(aif)) || (aif < 1) || (aif > 11000)) { console.log(winRemoveSingleQuotes("Invalid installflags, must be a number.")); }
+            }
             if (args.type == null) { console.log(winRemoveSingleQuotes("Missing device type, use --type [agenttype]")); }
             var at = parseInt(args.type);
             if ((at == null) || isNaN(at) || (at < 1) || (at > 11000)) { console.log(winRemoveSingleQuotes("Invalid agent type, must be a number.")); }
             if (args.id == null) { console.log(winRemoveSingleQuotes("Missing device id, use --id '[meshid]'")); }
             if ((typeof args.id != 'string') || (args.id.length != 64)) { console.log(winRemoveSingleQuotes("Invalid meshid.")); }
-            else { ok = true; }
+			else { ok = true; }
             break;
         }
         case 'upload': {
@@ -905,6 +909,7 @@ if (args['_'].length == 0) {
                     case 'agentdownload': {
                         console.log("Download an agent of a specific type for a given device group, Example usages:\r\n");
                         console.log(winRemoveSingleQuotes("  MeshCtrl AgentDownload --id 'groupid' --type 3"));
+						console.log(winRemoveSingleQuotes("  MeshCtrl AgentDownload --id 'groupid' --type 3 --installflags 1"));
                         console.log("\r\nRequired arguments:\r\n");
                         console.log("  --type [ArchitectureNumber]   - Agent architecture number.");
                         if (process.platform == 'win32') {
@@ -912,6 +917,11 @@ if (args['_'].length == 0) {
                         } else {
                             console.log("  --id '[groupid]'              - The device group identifier.");
                         }
+						console.log("\r\nOptional arguments:\r\n");
+						console.log("  --installflags [InstallFlagsNumber]   - With the following choices:");
+						console.log("  installflags 0 --> Default, Interactive & Background, offers connect button & install/uninstall");
+						console.log("  installflags 1 --> Interactive only, offers only connect button, not install/uninstall");
+						console.log("  installflags 2 --> Background only, offers only install/uninstall, not connect");
                         break;
                     }
                     case 'upload': {
@@ -1667,7 +1677,12 @@ function serverConnect() {
                 // Download an agent
                 var u = settings.xxurl.replace('wss://', 'https://').replace('/control.ashx', '/meshagents');
                 if (u.indexOf('?') > 0) { u += '&'; } else { u += '?'; }
-                u += 'id=' + args.type + '&meshid=' + args.id;
+                // check, whether the optional installflags have not been set; include them only when set
+                if (args.installflags == null) {
+                    u += 'id=' + args.type + '&meshid=' + args.id;
+                } else  {
+                    u += 'id=' + args.type + '&meshid=' + args.id + '&installflags=' + args.installflags;
+                }
                 const options = { rejectUnauthorized: false, checkServerIdentity: onVerifyServer }
                 const fs = require('fs');
                 const https = require('https');


### PR DESCRIPTION
The helpful MeshCtrl was missing the "installflags" option for the AgentDownload feature.

I've added:

- "installflags" as an *optional* parameter. 
- input validation, which should be consistent with other options.
- documentation/help.

Please let me know if there is anything I missed, and feel free to amend as necessary.