### PR TITLE
Check agent IP address instead of user IP address for agent file downloads

### DIFF
--- a/webserver.js
+++ b/webserver.js
@@ -3766,7 +3766,7 @@ module.exports.CreateWebServer = function (parent, db, args, certificates, doneF
 
     // Handle download of a server file by an agent
     function handleAgentDownloadFile(req, res) {
-        const domain = checkUserIpAddress(req, res);
+        const domain = checkAgentIpAddress(req, res);
         if (domain == null) { return; }
         if (req.query.c == null) { res.sendStatus(404); return; }
 


### PR DESCRIPTION
I have been experiencing a bug with file downloads on agents because of IP restrictions set with userAllowedIP. My investigation is detailed in my comments to #4078.

After making this change locally, this problem has been resolved for me. I'm no longer receiving 401s on file downloads.