### PR TITLE
Added "keyagents" domain config option.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -339,6 +339,7 @@
         "isaml",
         "Jitsi",
         "jumpcloud",
+        "keyagents",
         "keyfile",
         "keygrip",
         "keyid",

--- a/meshcentral-config-schema.json
+++ b/meshcentral-config-schema.json
@@ -383,6 +383,11 @@
           "default": false,
           "description": "When enabled, MeshCentral will block all downloads of MeshAgent including install scripts, if the user is not logged in"
         },
+        "keyAgents": {
+            "type": "boolean",
+            "default": false,
+            "description": "When enabled, Meshcentral will key each agent downloaded to a specific node id, which is determined on first agent connection. If an agent attempts to connect without this key, or with a node id that does not match this key, it will be ignored. Deleting a device will remove its key, preventing that agent from connecting again in the future."
+        },
         "ignoreAgentHashCheck": {
           "type": [
             "boolean",
@@ -1741,6 +1746,11 @@
             "type": "boolean",
             "default": false,
             "description": "When enabled, MeshCentral will block all downloads of MeshAgent including install scripts, if the user is not logged in"
+          },
+          "keyAgents": {
+            "type": "boolean",
+            "default": false,
+            "description": "When enabled, Meshcentral will key each agent downloaded to a specific node id, which is determined on first agent connection. If an agent attempts to connect without this key, or with a node id that does not match this key, it will be ignored. Deleting a device will remove its key, preventing that agent from connecting again in the future."
           },
           "geoLocation": {
             "type": "boolean",

--- a/meshctrl.js
+++ b/meshctrl.js
@@ -1106,7 +1106,7 @@ function displayConfigHelp() {
 }
 
 function performConfigOperations(args) {
-    var domainValues = ['title', 'title2', 'titlepicture', 'trustedcert', 'welcomepicture', 'welcometext', 'userquota', 'meshquota', 'newaccounts', 'usernameisemail', 'newaccountemaildomains', 'newaccountspass', 'newaccountsrights', 'geolocation', 'lockagentdownload', 'userconsentflags', 'Usersessionidletimeout', 'auth', 'ldapoptions', 'ldapusername', 'ldapuserbinarykey', 'ldapuseremail', 'footer', 'certurl', 'loginKey', 'userallowedip', 'agentallowedip', 'agentnoproxy', 'agentconfig', 'orphanagentuser', 'httpheaders', 'yubikey', 'passwordrequirements', 'limits', 'amtacmactivation', 'redirects', 'sessionrecording', 'hide'];
+    var domainValues = ['title', 'title2', 'titlepicture', 'trustedcert', 'welcomepicture', 'welcometext', 'userquota', 'meshquota', 'newaccounts', 'usernameisemail', 'newaccountemaildomains', 'newaccountspass', 'newaccountsrights', 'geolocation', 'lockagentdownload', 'keyagents', 'userconsentflags', 'Usersessionidletimeout', 'auth', 'ldapoptions', 'ldapusername', 'ldapuserbinarykey', 'ldapuseremail', 'footer', 'certurl', 'loginKey', 'userallowedip', 'agentallowedip', 'agentnoproxy', 'agentconfig', 'orphanagentuser', 'httpheaders', 'yubikey', 'passwordrequirements', 'limits', 'amtacmactivation', 'redirects', 'sessionrecording', 'hide'];
     var domainObjectValues = ['ldapoptions', 'httpheaders', 'yubikey', 'passwordrequirements', 'limits', 'amtacmactivation', 'redirects', 'sessionrecording'];
     var domainArrayValues = ['newaccountemaildomains', 'newaccountsrights', 'loginkey', 'agentconfig'];
     var configChange = false;

--- a/meshuser.js
+++ b/meshuser.js
@@ -520,7 +520,7 @@ module.exports.CreateMeshUser = function (parent, db, ws, req, args, domain, use
                 if (agentstats.invalidJsonCount > 0) { errorCountersCount++; errorCounters.InvalidJSON = agentstats.invalidJsonCount; }
                 if (agentstats.unknownAgentActionCount > 0) { errorCountersCount++; errorCounters.UnknownAction = agentstats.unknownAgentActionCount; }
                 if (agentstats.agentBadWebCertHashCount > 0) { errorCountersCount++; errorCounters.BadWebCertificate = agentstats.agentBadWebCertHashCount; }
-                if ((agentstats.agentBadSignature1Count + agentstats.agentBadSignature2Count) > 0) { errorCountersCount++; errorCounters.BadSignature = (agentstats.agentBadSignature1Count + agentstats.agentBadSignature2Count); }
+                if ((agentstats.agentBadSignature1Count + agentstats.agentBadSignature2Count + agentstats.agentBadSignature3Count) > 0) { errorCountersCount++; errorCounters.BadSignature = (agentstats.agentBadSignature1Count + agentstats.agentBadSignature2Count + agentstats.agentBadSignature3Count); }
                 if (agentstats.agentMaxSessionHoldCount > 0) { errorCountersCount++; errorCounters.MaxSessionsReached = agentstats.agentMaxSessionHoldCount; }
                 if ((agentstats.invalidDomainMeshCount + agentstats.invalidDomainMesh2Count) > 0) { errorCountersCount++; errorCounters.UnknownDeviceGroup = (agentstats.invalidDomainMeshCount + agentstats.invalidDomainMesh2Count); }
                 if ((agentstats.invalidMeshTypeCount + agentstats.invalidMeshType2Count) > 0) { errorCountersCount++; errorCounters.InvalidDeviceGroupType = (agentstats.invalidMeshTypeCount + agentstats.invalidMeshType2Count); }
@@ -2794,6 +2794,13 @@ module.exports.CreateMeshUser = function (parent, db, ws, req, args, domain, use
                                 if ((nodes != null) && (nodes.length == 1)) { db.Remove('da' + nodes[0].daid); } // Remove diagnostic agent to real agent link
                                 db.Remove('ra' + node._id); // Remove real agent to diagnostic agent link
                             });
+                            if (domain.keyagents || parent.parent.config.settings.keyagents) {
+                                db.GetAllTypeNodeFiltered([nodeid], domain.id, 'agentkey', null, function (err, docs) {
+                                    for (let _doc of docs) {
+                                        db.Remove(_doc._id);
+                                    }
+                                })
+                            }
 
                             // Remove any user node links
                             if (node.links != null) {


### PR DESCRIPTION
# This is an extremely draft PR, more just floating the idea with some code.



Meshcentral has the "lockAgentDownload" option so you can stop people who aren't users from downloading an agent. This works great under the assumption that every user of the instance is to be given a perpetual ability to add agents to the instance. However, given meshcentral has the ability to remove users, any user who is removed can be assumed to remember the meshid they once connected to (or read it from their .msh file in the case they had set their own device up at some point when they had permission) and can now add any number of devices to your instance without being logged in, even if the "lockAgentDownload" option is set.

The thought of this option is to close that hole a bit. If the option is set, downloading an agent will now create a record in the database of that agent being downloaded, along with a random identifier for that download. The first time that agent connects and generates its nodeid, that record will be associated to the nodeid, such that if someone tries to connect a different nodeid using that same key, it will not be allowed. Additionally, when the device is removed from meshcentral, that key is also removed and can never be used to connect again. This allows one to revoke an agent's ability to be added to the instance.


# What isn't done
- I probably didn't implement the key correctly, I just made a random 128 lowercase letter key. I know this project mostly uses sha384 hashes for its keys, but I'm not sure what would be the desired way to set that up here
- I would probably add a timeout to the key, such that if an agent doesn't connect with that key in a certain amount of time, that key is no longer accessible. This would stop someone from downloading an infinite number of agents for future use.
- I would like to create an upgrade path for existing servers. My thought would be to have an option for a grace period wherein any agent that connects will be given a key and updated. All that needs to change agent side is an update to its .msh file to add the key to the connection string, but I haven't found the mechanism for that yet.
- I probably didn't follow the style guide and probably forgot a semicolon or two. It'll probably need cleaned up a bih.



The code as is is functional on a basic test instance, though I only tried it with the default configuration and using the standard windows agent, I'm not sure if it will generalize to all agents, though I believe it will since I modified everywhere it creates the .msh file on the server side.

Let me know if this seems like something meshcentral could benefit from.