### PR TITLE
AMT: Fix One Click Recovery support

### DIFF
--- a/meshuser.js
+++ b/meshuser.js
@@ -3129,8 +3129,8 @@ module.exports.CreateMeshUser = function (parent, db, ws, req, args, domain, use
                                 }
 
                                 if ((command.actiontype >= 300) && (command.actiontype < 400)) {
-                                    if ((command.actiontype != 302) && (command.actiontype != 308) && (command.actiontype < 310) && (command.actiontype > 312)) return; // Invalid action type.
-                                    // Intel AMT power command, actiontype: 2 = Power on, 8 = Power down, 10 = reset, 11 = Power on to BIOS, 12 = Reset to BIOS, 13 = Power on to BIOS with SOL, 14 = Reset to BIOS with SOL
+                                    if ((command.actiontype != 302) && (command.actiontype != 308) && (command.actiontype < 310) && (command.actiontype > 316)) return; // Invalid action type.
+                                    // Intel AMT power command, actiontype: 2 = Power on, 8 = Power down, 10 = reset, 11 = Power on to BIOS, 12 = Reset to BIOS, 13 = Power on to BIOS with SOL, 14 = Reset to BIOS with SOL, 15 = Power on to PXE, 16 = Reset to PXE
                                     parent.parent.DispatchEvent('*', obj, { action: 'amtpoweraction', userid: user._id, username: user.name, nodeids: [node._id], domain: domain.id, nolog: 1, actiontype: command.actiontype - 300 });
                                 } else {
                                     if ((command.actiontype < 2) && (command.actiontype > 4)) return; // Invalid action type.

--- a/views/default.handlebars
+++ b/views/default.handlebars
@@ -8451,6 +8451,8 @@
                     if ((xxcurrentView == 11) || (xxcurrentView == 12)) { // Only show these options on terminal or desktop tabs
                         y += '<option value=312>' + "Intel&reg; AMT Reset to BIOS" + '</option>';
                         y += '<option value=311>' + "Intel&reg; AMT Power on to BIOS" + '</option>';
+                        y += '<option value=315>' + "Intel&reg; AMT Power on to PXE" + '</option>';
+                        y += '<option value=316>' + "Intel&reg; AMT Reset to PXE" + '</option>';
                     }
                 }
                 if ((currentNode.intelamt != null) && (currentNode.intelamt.state == 2) && ((currentNode.conn & 6) != 0) && ((rights & 64) != 0)) {
@@ -8519,6 +8521,10 @@
                 setDialogMode(2, "Intel&reg; AMT Power Operation", 3, function() { meshserver.send({ action: 'poweraction', nodeids: [ currentNode._id ], actiontype: parseInt(op) + ((xxcurrentView == 12) ? 2 : 0) }); }, "Perform Intel&reg; AMT power on to BIOS?");
             } else if (op == 312) { // Intel AMT reset to BIOS
                 setDialogMode(2, "Intel&reg; AMT Power Operation", 3, function() { meshserver.send({ action: 'poweraction', nodeids: [ currentNode._id ], actiontype: parseInt(op) + ((xxcurrentView == 12) ? 2 : 0) }); }, "Perform Intel&reg; AMT reset to BIOS?");
+            } else if (op == 315) { // Intel AMT power to PXE
+                setDialogMode(2, "Intel&reg; AMT Power Operation", 3, function() { meshserver.send({ action: 'poweraction', nodeids: [ currentNode._id ], actiontype: parseInt(op) + ((xxcurrentView == 12) ? 2 : 0) }); }, "Perform Intel&reg; AMT power on to PXE?");
+            } else if (op == 316) { // Intel AMT reset to PXE
+                setDialogMode(2, "Intel&reg; AMT Power Operation", 3, function() { meshserver.send({ action: 'poweraction', nodeids: [ currentNode._id ], actiontype: parseInt(op) + ((xxcurrentView == 12) ? 2 : 0) }); }, "Perform Intel&reg; AMT reset to PXE?");
             } else if ((op == 400) || (op == 401)) {
                 // Flash / vibrate
                 meshserver.send({ action: 'poweraction', nodeids: [ currentNode._id ], actiontype: parseInt(op), time: parseInt(Q('d2devicetime').value) });

--- a/views/default.handlebars
+++ b/views/default.handlebars
@@ -8507,7 +8507,7 @@
                 // Intel AMT One Click Recovery (OCR)
                 Q('d3localmodeform').action = 'oneclickrecovery.ashx';
                 Q('d3auth').value = authCookie;
-                Q('d3filter').value = '.iso';
+                Q('d3filter').value = '.efi';
                 Q('d3attrib').value = currentNode._id;
                 setDialogMode(3, "Intel&reg; AMT One Click Recovery", 3, deviceActionOneClickRecovery);
                 d3init();


### PR DESCRIPTION
Hello !
This PR fixes Intel AMT: One Click Recovery that is currently unusable due to an impossible condition. It also replace .iso (which is an unsupported format) to .efi to allow BIOS to load the file

You may need to squash commits included in this PR to keep it clean

It has been tested on a Dell Optiplex 7400 AIO (Intel AMT v16) and with iPXE(.efi) that can be found here: http://boot.ipxe.org/ipxe.efi

Interestingly enough, I came across Intel EMA code that do something similar, and there is a bug in its implementation of makeUefiBootParam() where the len argument is ignored, in the case of a number it'll always be 4 bytes. I'm asking myself if this difference would be volontary and better compatibility with more BIOS software

Feel free to ask any questions or modifications 👐