### PR TITLE
Update apprelays.js to fix Header issue

### DIFF
--- a/apprelays.js
+++ b/apprelays.js
@@ -717,7 +717,7 @@ module.exports.CreateWebRelay = function (parent, db, args, domain, mtype) {
                             }
                         }
                     }
-                    else if (blockHeaders.indexOf(i) == -1) { obj.res.set(i, header[i]); } // Set the headers if not blocked
+                    else if (blockHeaders.indexOf(i) == -1) { obj.res.set(i.trim(), header[i]); } // Set the headers if not blocked
                 }
                 obj.res.set('Content-Security-Policy', "default-src 'self' 'unsafe-inline' 'unsafe-eval' data: blob:;"); // Set an "allow all" policy, see if the can restrict this in the future
                 //obj.res.set('Content-Security-Policy', "default-src * 'unsafe-inline' 'unsafe-eval'; script-src * 'unsafe-inline' 'unsafe-eval'; connect-src * 'unsafe-inline'; img-src * data: blob: 'unsafe-inline'; frame-src *; style-src * 'unsafe-inline';"); // Set an "allow all" policy, see if the can restrict this in the future


### PR DESCRIPTION
Add `.trim()` to the header label value (`i`) to fix a rare circumstance where there can be a space in a header name.

See Issue #6305