### PR TITLE
Fixed bug with agent reconnecting

### DIFF
--- a/agents/meshcore.js
+++ b/agents/meshcore.js
@@ -5788,6 +5788,7 @@ function handleServerConnection(state) {
 
         // Update the server on with basic info, logged in users and more advanced stuff, like Intel ME and Network Settings
         meInfoStr = null;
+        LastPeriodicServerUpdate = null;
         sendPeriodicServerUpdate(null, true);
         if (selfInfoUpdateTimer == null) {
             selfInfoUpdateTimer = setInterval(sendPeriodicServerUpdate, 1200000); // 20 minutes


### PR DESCRIPTION
There was a bug when an agent was unexpectedly disconnected from the server that it would not update the mesh core object with the server. In the worst case, this would make the server think that the agent doesn't have any terminal/file/desktop capabilities, and would require either an agent restart or a core replacement to fix.

This fix just clears the "last updated" cache the agent uses when the agent connects, instead of only on agent instantiation, which solves this problem, since there is a forced update during that time anyway.