### PR TITLE
Added global ws error handler

### DIFF
--- a/webserver.js
+++ b/webserver.js
@@ -6334,6 +6334,8 @@ module.exports.CreateWebServer = function (parent, db, args, certificates, doneF
 
         // Handle all incoming web sockets, see if some need to be handled as web relays
         obj.app.ws('/*', function (ws, req, next) {
+            // Global error catcher
+            ws.on('error', function (err) { parent.debug('web', 'GENERAL WSERR: ' + err); console.log(err); });
             if ((obj.webRelayRouter != null) && (obj.args.relaydns.indexOf(req.hostname) >= 0)) { handleWebRelayWebSocket(ws, req); return; }
             return next();
         });


### PR DESCRIPTION
In some cases, a client could send packets that would cause the webserver to error and crash. In my case, I was getting the error:

```
RangeError: Invalid WebSocket frame: MASK must be set
     at Receiver.getInfo (meshcentral/node_modules/express-ws/node_modules/ws/lib/receiver.js:284:16)
     at Receiver.startLoop (meshcentral/node_modules/express-ws/node_modules/ws/lib/receiver.js:131:22)
     at Receiver._write (meshcentral/node_modules/express-ws/node_modules/ws/lib/receiver.js:78:10)
     at writeOrBuffer (node:internal/streams/writable:570:12)
     at _write (node:internal/streams/writable:499:10)
     at Writable.write (node:internal/streams/writable:508:10)
     at TLSSocket.socketOnData (meshcentral/node_modules/express-ws/node_modules/ws/lib/websocket.js:1164:35)
     at TLSSocket.emit (node:events:519:28)
     at addChunk (node:internal/streams/readable:559:12)
     at readableAddChunkPushByteMode (node:internal/streams/readable:510:3) {
   code: 'WS_ERR_EXPECTED_MASK',
   [Symbol(status-code)]: 1002
}
```

Whatever WS handler this is propagating to is not handling the "error" event on the ws object. I couldn't track it down since this only happens in production for me, so I can't replicate it in a safe environment for testing.

While this is error is definitely worth tracking down itself (#5433?), the server should also never crash due to bad client input. This creates a failsafe in the case there is an unhandled error