### PR TITLE
Fix autobackup defaults and zip level for performance

### DIFF
--- a/meshcentral-config-schema.json
+++ b/meshcentral-config-schema.json
@@ -851,6 +851,11 @@
               "default": 10,
               "description": "How many days of backups should the autobackup keep? Default is 10 Days worth"
             },
+            "zipCompression" : {
+              "type": "integer",
+              "default": "5",
+              "description": "Set the zip compression level, 1=fast/less small file to 9=slow/smallest file."
+            },
             "zipPassword": {
               "type": "string",
               "default": "",

--- a/meshcentral.js
+++ b/meshcentral.js
@@ -2089,7 +2089,7 @@ function CreateMeshCentralServer(config, args) {
                     obj.updateServerState('state', "running");
 
                     // Setup auto-backup defaults
-                    if (obj.config.settings.autobackup == null || obj.config.settings.autobackup == false || obj.config.settings.autobackup == 'false') { delete obj.config.settings.autobackup; }
+                    if (obj.config.settings.autobackup == null || obj.config.settings.autobackup == false || obj.config.settings.autobackup == 'false') { obj.config.settings.autobackup = {backupintervalhours: 0}; } //no schedule, but able to console autobackup
                     else {
                         if (obj.config.settings.autobackup === true) {obj.config.settings.autobackup = {backupintervalhours: 24, keeplastdaysbackup: 10}; };
                         if (typeof obj.config.settings.autobackup.backupintervalhours != 'number') { obj.config.settings.autobackup.backupintervalhours = 24; };
@@ -2104,7 +2104,7 @@ function CreateMeshCentralServer(config, args) {
                     // Check that autobackup path is not within the "meshcentral-data" folder.
                     if ((typeof obj.config.settings.autobackup == 'object') && (typeof obj.config.settings.autobackup.backuppath == 'string') && (obj.path.normalize(obj.config.settings.autobackup.backuppath).startsWith(obj.path.normalize(obj.datapath)))) {
                         addServerWarning("Backup path can't be set within meshcentral-data folder, backup settings ignored.", 21);
-                        delete obj.config.settings.autobackup;
+                        obj.config.settings.autobackup = {backupintervalhours: -1};  //block console autobackup
                     }
 
                     // Load Intel AMT passwords from the "amtactivation.log" file
@@ -2267,7 +2267,7 @@ function CreateMeshCentralServer(config, args) {
 
     // Check if we need to perform an automatic backup
     function checkAutobackup() {
-        if (obj.config.settings.autobackup && (typeof obj.config.settings.autobackup.backupintervalhours == 'number')) {
+        if (obj.config.settings.autobackup.backupintervalhours >= 1) {
             obj.db.Get('LastAutoBackupTime', function (err, docs) {
                 if (err != null) return;
                 var lastBackup = 0;

--- a/meshuser.js
+++ b/meshuser.js
@@ -7627,10 +7627,9 @@ module.exports.CreateMeshUser = function (parent, db, ws, req, args, domain, use
     }
 
     function serverUserCommandAutoBackup(cmdData) {
-        var backupResult = parent.db.performBackup(function (msg) {
+        cmdData.result = parent.db.performBackup(function (msg) {
             try { ws.send(JSON.stringify({ action: 'serverconsole', value: msg, tag: cmdData.command.tag })); } catch (ex) { }
         });
-        if (backupResult == 0) { cmdData.result = 'Starting auto-backup...'; } else { cmdData.result = 'Backup alreay in progress.'; }
     }
 
     function serverUserCommandBackupConfig(cmdData) {


### PR DESCRIPTION
If autobackup wasn't defined in the config and an autobackup was triggered from the serverconsole, the backup would fail because of uninitialized properties.
Removed some extraneous remarks in those parts.
Set default zip level to 5 as level 9 does not make the backup that much smaller at much more performancecost, especially on smaller hardware and large backups. > going to make the ziplevel a config option
