### PR TITLE
adjust removemeshuser to allow for shorter user ids

### DIFF
--- a/meshuser.js
+++ b/meshuser.js
@@ -2418,7 +2418,7 @@ module.exports.CreateMeshUser = function (parent, db, ws, req, args, domain, use
                     }
 
                     try {
-                        if (common.validateString(command.userid, 8, 1024) == false) { err = "Invalid userid"; } // Check userid
+                        if (common.validateString(command.userid, 1, 1024) == false) { err = "Invalid userid"; } // Check userid
                         if (common.validateString(command.meshid, 8, 134) == false) { err = "Invalid groupid"; } // Check meshid
                         if (command.userid.indexOf('/') == -1) { command.userid = 'user/' + domain.id + '/' + command.userid; }
                         if (command.userid == obj.user._id) { err = "Can't remove self"; } // Can't add of modify self


### PR DESCRIPTION
I stumbled across this issue when trying to remove a user from a mesh using meshctrl `removeuserfromdevicegroup`. I was attempting to remove `user1` from a mesh and received `Invalid userid`. After adjusting the Id to `user//user1`, the command would proceed without issue. At first I just figured the function required the full Id with the prefix, but thought that odd as `addusertodevicegroup` distinctly does NOT accept the prefix. 

After looking at the code, the function requires a minimum of 8 characters for the user Id. This causes issues when using meshctrl with Ids under 8 characters. This will also cause an issue in the web UI for Ids of only 1 character. User `user//a` does not satisfy the length requirement and cannot be removed from a mesh in the web UI.