### PR TITLE
Fix quoting of string literals from double to single

### DIFF
--- a/db.js
+++ b/db.js
@@ -4148,7 +4148,7 @@ module.exports.CreateDB = function (parent, func) {
 
     function dbMergeSqlArray(arr) {
         var x = '';
-        for (var i in arr) { if (x != '') { x += ','; } x += '"' + arr[i] + '"'; }
+        for (var i in arr) { if (x != '') { x += ','; } x += '\'' + arr[i] + '\''; }
         return x;
     }
 


### PR DESCRIPTION
See: https://www.sqlite.org/quirks.html#double_quoted_string_literals_are_accepted

The function to create a string of an array puts double quotes around the literals used in the sql statements. This is tolerated as explained in the article, but should be corrected to single quotes.

This is only used in the sqlite functions.

It generates a log warning for now, but maybe an error in the future.
