### PR TITLE
fix adding meshes and user groups in a peering environment

### DIFF
--- a/db.js
+++ b/db.js
@@ -4089,12 +4089,13 @@ module.exports.CreateDB = function (parent, func) {
         }
 
         // Send the mesh update
-        if (mesh.deleted) { mesh.action = 'deletemesh'; } else { mesh.action = (added ? 'createmesh' : 'meshchange'); }
-        mesh.meshid = mesh._id;
-        mesh.nolog = 1;
-        delete mesh.type;
-        delete mesh._id;
-        parent.DispatchEvent(['*', mesh.meshid], obj, parent.webserver.CloneSafeMesh(mesh));
+        var mesh2 = Object.assign({}, mesh); // Shallow clone
+        if (mesh2.deleted) { mesh2.action = 'deletemesh'; } else { mesh2.action = (added ? 'createmesh' : 'meshchange'); }
+        mesh2.meshid = mesh2._id;
+        mesh2.nolog = 1;
+        delete mesh2.type;
+        delete mesh2._id;
+        parent.DispatchEvent(['*', mesh2.meshid], obj, parent.webserver.CloneSafeMesh(mesh2));
     }
 
     // Called when a user account has changed
@@ -4138,12 +4139,13 @@ module.exports.CreateDB = function (parent, func) {
         }
 
         // Send the user group update
-        usergroup.action = (added ? 'createusergroup' : 'usergroupchange');
-        usergroup.ugrpid = usergroup._id;
-        usergroup.nolog = 1;
-        delete usergroup.type;
-        delete usergroup._id;
-        parent.DispatchEvent(['*', usergroup.ugrpid], obj, usergroup);
+        var usergroup2 = Object.assign({}, usergroup); // Shallow clone
+        usergroup2.action = (added ? 'createusergroup' : 'usergroupchange');
+        usergroup2.ugrpid = usergroup2._id;
+        usergroup2.nolog = 1;
+        delete usergroup2.type;
+        delete usergroup2._id;
+        parent.DispatchEvent(['*', usergroup2.ugrpid], obj, usergroup2);
     }
 
     function dbMergeSqlArray(arr) {


### PR DESCRIPTION
#6417

Identified the issue with anomalous mesh and user group objects in a peering environment. The `dbMeshChange` and `dbUgrpChange` were modifying the original variable when making adjustments for the DispatchEvents functions. This was also modifying the object in memory.

I've adjusted the function to create a copy of the object for adjustment rather than modifying the original variable.