### PR TITLE
Mariadb/mysql: Fix ssl on autobackup cmdline and deprecated warnings

### DIFF
--- a/db.js
+++ b/db.js
@@ -3290,7 +3290,7 @@ module.exports.CreateDB = function (parent, func) {
             if (props.ssl) {
                 sslOptions = ' --ssl';
                 if (props.ssl.cacertpath) sslOptions = ' --ssl-ca=' + props.ssl.cacertpath;
-                if (props.ssl.dontcheckserveridentity != true) sslOptions += ' --ssl-verify-server-cert';
+                if (props.ssl.dontcheckserveridentity != true) {sslOptions += ' --ssl-verify-server-cert'} else {sslOptions += ' --ssl-verify-server-cert=false'};
                 if (props.ssl.clientcertpath) sslOptions += ' --ssl-cert=' + props.ssl.clientcertpath;
                 if (props.ssl.clientkeypath) sslOptions += ' --ssl-key=' + props.ssl.clientkeypath;
             } 

--- a/meshcentral.js
+++ b/meshcentral.js
@@ -4222,11 +4222,11 @@ function mainStart() {
         if (sessionRecording == true) { modules.push('image-size@1.1.1'); } // Need to get the remote desktop JPEG sizes to index the recodring file.
         if (config.letsencrypt != null) { modules.push('acme-client@4.2.5'); } // Add acme-client module. We need to force v4.2.4 or higher since olver versions using SHA-1 which is no longer supported by Let's Encrypt.
         if (config.settings.mqtt != null) { modules.push('aedes@0.39.0'); } // Add MQTT Modules
-        if (config.settings.mysql != null) { modules.push('mysql2@3.6.2'); } // Add MySQL.
+        if (config.settings.mysql != null) { modules.push('mysql2@3.11.4'); } // Add MySQL.
         //if (config.settings.mysql != null) { modules.push('@mysql/xdevapi@8.0.33'); } // Add MySQL, official driver (https://dev.mysql.com/doc/dev/connector-nodejs/8.0/)
         if (config.settings.mongodb != null) { modules.push('mongodb@4.13.0'); modules.push('saslprep@1.0.3'); } // Add MongoDB, official driver.
         if (config.settings.postgres != null) { modules.push('pg@8.13.1') } // Add Postgres, official driver.
-        if (config.settings.mariadb != null) { modules.push('mariadb@3.2.2'); } // Add MariaDB, official driver.
+        if (config.settings.mariadb != null) { modules.push('mariadb@3.4.0'); } // Add MariaDB, official driver.
         if (config.settings.acebase != null) { modules.push('acebase@1.29.5'); } // Add AceBase, official driver.
         if (config.settings.sqlite3 != null) { modules.push('sqlite3@5.1.7'); } // Add sqlite3, official driver.
         if (config.settings.vault != null) { modules.push('node-vault@0.10.2'); } // Add official HashiCorp's Vault module.


### PR DESCRIPTION
Found these when switching to self-signed ssl certs on mariadb & mysql.

Fix:
error 2026: "TLS/SSL error: Server certificate validation failed. The certificate's CN name does not match the passed value. Error 0x800B010F(CERT_E_CN_NO_MATCH)"
by adding '--ssl-verify-server-cert=false'

And deprecated warnings by updating the modules.
