### PR TITLE
connectinArgs.Database > connectinArgs.database typo

### DIFF
--- a/db.js
+++ b/db.js
@@ -909,7 +909,7 @@ module.exports.CreateDB = function (parent, func) {
     } else if (parent.args.postgres) {
         // Postgres SQL
         let connectinArgs = parent.args.postgres;
-        connectinArgs.Database = (databaseName = (connectinArgs.database != null) ? connectinArgs.database : 'meshcentral');
+        connectinArgs.database = (databaseName = (connectinArgs.database != null) ? connectinArgs.database : 'meshcentral');
 
         let DatastoreTest;
         obj.databaseType = DB_POSTGRESQL;


### PR DESCRIPTION
fixes using default databasename 'meshcentral' if not configured in config.json