### PR TITLE
Autobackup update

### DIFF
--- a/db.js
+++ b/db.js
@@ -3634,19 +3634,28 @@ module.exports.CreateDB = function (parent, func) {
                     if (parent.config.settings.autobackup && (typeof parent.config.settings.autobackup.keeplastdaysbackup == 'number')) {
                         let cutoffDate = new Date();
                         cutoffDate.setDate(cutoffDate.getDate() - parent.config.settings.autobackup.keeplastdaysbackup);
+                        parent.debug('main', parent.common.format("@{0} Remove old backups start > cutoffDate: {1}; keeplastdays: {2}", new Date().toLocaleString('en-GB', { dateStyle: 'short', timeStyle: 'short' }), cutoffDate.toLocaleString('en-GB', { dateStyle: 'short', timeStyle: 'short' }), parent.config.settings.autobackup.keeplastdaysbackup));
                         parent.fs.readdir(parent.backuppath, function (err, dir) {
                             try {
                                 if ((err == null) && (dir.length > 0)) {
                                     let fileName = (typeof parent.config.settings.autobackup.backupname == 'string') ? parent.config.settings.autobackup.backupname : 'meshcentral-autobackup-';
                                     for (var i in dir) {
                                         var name = dir[i];
+                                        parent.debug('main', parent.common.format("Remove old backup > checking file: {0}", name));
                                         if (name.startsWith(fileName) && name.endsWith('.zip')) {
-                                            var timex = name.substring(23, name.length - 4).split('-');
+                                            var timex = name.substring(fileName.length, name.length - 4).split('-');
+                                            parent.debug('main', "Remove old backup > timex: ", timex);
                                             if (timex.length == 5) {
                                                 var fileDate = new Date(parseInt(timex[0]), parseInt(timex[1]) - 1, parseInt(timex[2]), parseInt(timex[3]), parseInt(timex[4]));
-                                                if (fileDate && (cutoffDate > fileDate)) { try { parent.fs.unlink(parent.path.join(parent.backuppath, name), function () { }); } catch (ex) { } }
+                                                if (fileDate && (cutoffDate > fileDate)) {
+                                                    try {
+                                                        console.log("Removing old backup file: ", name);
+                                                        parent.fs.unlink(parent.path.join(parent.backuppath, name), function () { });
+                                                    } catch (ex) { console.log(ex) } }
                                             }
+                                            else {parent.debug('main', parent.common.format("Remove old backup > file: {0}, timestamp failure: {1}", name, timex));}
                                         }
+                                        else {parent.debug('main', "Remove old backup > name match failure, file: ", name);}
                                     }
                                 }
                             } catch (ex) { console.log(ex); }

--- a/db.js
+++ b/db.js
@@ -3341,20 +3341,22 @@ module.exports.CreateDB = function (parent, func) {
             return;
         }
         // Check create/write backupdir
-        let fail = false;
+        // Removed faillback to default backuppath within the appdir
+        //let fail = false;
         try { fs.mkdirSync(parent.backuppath); }
         catch (e) {
             if (e.code != 'EEXIST' ) {
                 //Unable to create backuppath
                 console.error(e.message);
-                if (parent.backuppath == parent.backuppathdefault) {
+                // if (parent.backuppath == parent.backuppathdefault) {
                     func(1, 'Unable to create ' + parent.backuppath + '. No backups will be made.');
                     return;
-                }
+                // }
                 console.error('Unable to create ' + parent.backuppath);
-                fail = true;
+                //fail = true;
             }
         }
+        /*
         if (fail) {
             //Unable to create custom backuppath, try default path as fallback
             try { fs.mkdirSync(parent.backuppathdefault); }
@@ -3370,7 +3372,7 @@ module.exports.CreateDB = function (parent, func) {
             console.error('Unable to create ' + parent.backuppath + ', falling back to default path: ' + parent.backuppathdefault);
             parent.backuppath = parent.backuppathdefault;
         }
-
+        */
         const testFile = path.join(parent.backuppath + (parent.config.settings.autobackup.backupname + ".test"));
 
         try { fs.writeFileSync( testFile, "DeleteMe"); }
@@ -3386,6 +3388,7 @@ module.exports.CreateDB = function (parent, func) {
             func(1, "Backuppathtestfile (" + testFile + ") can't be deleted, check filerights. No backups will be made.");
             return;
         }
+        parent.debug('backup', 'Backuppath accesscheck successful');
 
         // Check database dumptools
         let backupPath = parent.backuppath;

--- a/db.js
+++ b/db.js
@@ -3654,7 +3654,7 @@ module.exports.CreateDB = function (parent, func) {
                                                 parent.debug('backup', "ROB filedate: ", fileDate);
                                                 if (fileDate && (cutoffDate > fileDate)) {
                                                     try {
-                                                        console.log("Removing old backup file: ", name);
+                                                        console.log("Removing old backup file: ", parent.path.join(parent.backuppath, name));
                                                         parent.fs.unlink(parent.path.join(parent.backuppath, name), function () { });
                                                     } catch (ex) { console.log(ex) } }
                                                 

--- a/meshcentral-config-schema.json
+++ b/meshcentral-config-schema.json
@@ -886,6 +886,11 @@
               "default": 24,
               "description": "How often should the autobackup run in hours from the second meshcentral starts up? Default is every 24 hours"
             },
+            "backupHour": {
+              "type": "integer",
+              "default": 0,
+              "description": "At which hour the autobackup should run. This forces a daily backup, overrules a custom 'backupIntervalHours'."
+            },
             "keepLastDaysBackup": {
               "type": "integer",
               "default": 10,

--- a/meshcentral.js
+++ b/meshcentral.js
@@ -2016,7 +2016,8 @@ function CreateMeshCentralServer(config, args) {
                     obj.monitoring = require('./monitoring.js').CreateMonitoring(obj, obj.args);
 
                     // Start periodic maintenance
-                    obj.maintenanceTimer = setInterval(obj.maintenanceActions, 1000 * 10 * 1); // Run this every hour
+                    obj.maintenanceTimer = setInterval(obj.maintenanceActions, 1000 * 60 * 60); // Run this every hour
+                    //obj.maintenanceTimer = setInterval(obj.maintenanceActions, 1000 * 10 * 1); // DEBUG: Run this every 10s
 
                     // Dispatch an event that the server is now running
                     obj.DispatchEvent(['*'], obj, { etype: 'server', action: 'started', msg: 'Server started' });
@@ -2288,9 +2289,9 @@ function CreateMeshCentralServer(config, args) {
                 let currentHour = currentdate.getHours();
                 let now = currentdate.getTime();
                 if (docs.length == 1) { lastBackup = docs[0].value; }
-                //const delta = now - lastBackup;
-                let delta = 99999999;
-                obj.debug('backup', obj.common.format("@{0}: checkAutobackup > lastbackuptime: {1}; delta in hours {2}; backupIntervalHours: {3}; current/backupHour: {4}/{5}", currentdate.toLocaleString('en-GB', { dateStyle: 'short', timeStyle: 'medium' }), new Date(lastBackup).toLocaleString('en-GB', { dateStyle: 'short', timeStyle: 'medium' }), (delta/3600000).toPrecision(2), obj.config.settings.autobackup.backupintervalhours, currentHour, obj.config.settings.autobackup.backuphour));
+                const delta = now - lastBackup;
+                //const delta = 99999999; // DEBUG: backup always
+
                 //start autobackup if interval has passed or at configured hour, whichever comes first. When an hour schedule is missed, it will make a backup immediately.
                 if ((delta > (obj.config.settings.autobackup.backupintervalhours * 60 * 60 * 1000)) || ((currentHour == obj.config.settings.autobackup.backuphour) && (delta >= 2 * 60 * 60 * 1000))) {
                     // A new auto-backup is required.
@@ -3943,6 +3944,7 @@ function CreateMeshCentralServer(config, args) {
     function logWarnEvent(msg) { if (obj.servicelog != null) { obj.servicelog.warn(msg); } console.log(msg); }
     function logErrorEvent(msg) { if (obj.servicelog != null) { obj.servicelog.error(msg); } console.error(msg); }
     obj.getServerWarnings = function () { return serverWarnings; }
+    // TODO: migrate from other addServerWarning function and add timestamp
     obj.addServerWarning = function (msg, id, args, print) { serverWarnings.push({ msg: msg, id: id, args: args }); if (print !== false) { console.log("WARNING: " + msg); } }
 
     // auth.log functions
@@ -4113,6 +4115,7 @@ function InstallModuleEx(modulenames, args, func) {
 process.on('SIGINT', function () { if (meshserver != null) { meshserver.Stop(); meshserver = null; } console.log('Server Ctrl-C exit...'); process.exit(); });
 
 // Add a server warning, warnings will be shown to the administrator on the web application
+// TODO: migrate to obj.addServerWarning?
 const serverWarnings = [];
 function addServerWarning(msg, id, args, print) { serverWarnings.push({ msg: msg, id: id, args: args }); if (print !== false) { console.log("WARNING: " + msg); } }
 


### PR DESCRIPTION
Added an option to configure the hour during which the autobackup should be done instead of being determined by the service start time to have more control if wanted.

There is also the extra logging for #6675. I tried to replicate the issue, but it worked every time, on windows and linux.
Hopefully the extra logging will help to determine the issue.
Debug logging for the backup was under the 'db' category, moved it to the 'backup' debug category to keep it clean.

Add "debug": "backup" to the config.json for extra logging besides the default start and file removal logging of the autobackup.
