### PR TITLE
Add support for logoutOnIdleSessionTimeout

### DIFF
--- a/meshcentral-config-schema.json
+++ b/meshcentral-config-schema.json
@@ -2180,6 +2180,11 @@
             "default": null,
             "description": "When set, idle users will be disconnected after a set amounts of minutes."
           },
+          "logoutOnIdleSessionTimeout": {
+            "type": "boolean",
+            "default": true,
+            "description": "Determines whether MeshCentral should logout after the session idle timeout elapsed or should just disconnect remote desktop, terminal and files."
+          },
           "userConsentFlags": {
             "type": "object",
             "description": "Use this section to require user consent for this domain.",

--- a/meshuser.js
+++ b/meshuser.js
@@ -600,7 +600,13 @@ module.exports.CreateMeshUser = function (parent, db, ws, req, args, domain, use
                 }
             }
             if (typeof domain.userconsentflags == 'number') { serverinfo.consent = domain.userconsentflags; }
-            if ((typeof domain.usersessionidletimeout == 'number') && (domain.usersessionidletimeout > 0)) { serverinfo.timeout = (domain.usersessionidletimeout * 60 * 1000); }
+            if ((typeof domain.usersessionidletimeout == 'number') && (domain.usersessionidletimeout > 0)) {serverinfo.timeout = (domain.usersessionidletimeout * 60 * 1000); }
+            if (typeof domain.logoutOnIdleSessionTimeout == 'boolean') {
+                serverinfo.logoutOnIdleSessionTimeout = domain.logoutOnIdleSessionTimeout;
+            } else {
+                // Default
+                serverinfo.logoutOnIdleSessionTimeout = true;
+            }
             if (user.siteadmin === SITERIGHT_ADMIN) {
                 if (parent.parent.config.settings.managealldevicegroups.indexOf(user._id) >= 0) { serverinfo.manageAllDeviceGroups = true; }
                 if (obj.crossDomain === true) { serverinfo.crossDomain = []; for (var i in parent.parent.config.domains) { serverinfo.crossDomain.push(i); } }

--- a/sample-config-advanced.json
+++ b/sample-config-advanced.json
@@ -386,6 +386,8 @@
       "_agentBlockedIP": "127.0.0.1,::1",
       "___userSessionIdleTimeout__": "Number of user idle minutes before auto-disconnect",
       "_userSessionIdleTimeout": 30,
+      "___logoutOnIdleSessionTimeout": "Determines whether MeshCentral should logout after the session idle timeout elapsed or should just disconnect remote desktop, terminal and files.",
+      "_logoutOnIdleSessionTimeout": false,
       "userConsentFlags": {
         "desktopnotify": true,
         "terminalnotify": true,

--- a/views/default-mobile.handlebars
+++ b/views/default-mobile.handlebars
@@ -1522,7 +1522,12 @@
         }
 
         function setSessionActivity() { sessionActivity = Date.now(); }
-        function checkIdleSessionTimeout() { var delta = (Date.now() - sessionActivity); if (delta > serverinfo.timeout) { window.location.href = 'logout'; } }
+        function checkIdleSessionTimeout() {
+            var delta = (Date.now() - sessionActivity);
+            if (delta > serverinfo.timeout && serverinfo.logoutOnIdleSessionTimeout) {
+                window.location.href = 'logout';
+            }
+        }
 
         function onMessage(server, message) {
             switch (message.action) {

--- a/views/default.handlebars
+++ b/views/default.handlebars
@@ -2447,7 +2447,9 @@
                     files.Stop();
                     files = null;
                 }
-                window.location.href = 'logout';
+                if (serverinfo.logoutOnIdleSessionTimeout) {
+                    window.location.href = 'logout';
+                }
             } else {
                 var ds = Math.round((serverinfo.timeout - delta) / 1000);
                 if (ds <= 60) {

--- a/views/default3.handlebars
+++ b/views/default3.handlebars
@@ -2897,7 +2897,9 @@
                     files.Stop();
                     files = null;
                 }
-                window.location.href = 'logout';
+                if (serverinfo.logoutOnIdleSessionTimeout) {
+                    window.location.href = 'logout';
+                }
             } else {
                 var ds = Math.round((serverinfo.timeout - delta) / 1000);
                 if (ds <= 60) {

--- a/views/sharing-mobile.handlebars
+++ b/views/sharing-mobile.handlebars
@@ -820,7 +820,12 @@
         }
 
         function setSessionActivity() { sessionActivity = Date.now(); }
-        function checkIdleSessionTimeout() { var delta = (Date.now() - sessionActivity); if (delta > serverinfo.timeout) { window.location.href = 'logout'; } }
+        function checkIdleSessionTimeout() {
+            var delta = (Date.now() - sessionActivity);
+            if (delta > serverinfo.timeout && serverinfo.logoutOnIdleSessionTimeout) {
+                window.location.href = 'logout';
+            }
+        }
 
         //
         // Menu System


### PR DESCRIPTION
Closes #6772 

This merge request adds a new config parameter called `logoutOnIdleSessionTimeout` (boolean) to configure whether you want to logout after `userSessionIdleTimeout` or just disconnect any remote desktops, terminals and files.