### PR TITLE
Fix: Init webstate with empty 'object' instead of empty string

### DIFF
--- a/webserver.js
+++ b/webserver.js
@@ -3148,12 +3148,12 @@ module.exports.CreateWebServer = function (parent, db, args, certificates, doneF
                 // Fetch the web state
                 parent.debug('web', 'handleRootRequestEx: success.');
 
-                var webstate = '';
+                var webstate = '{}';
                 if ((err == null) && (states != null) && (Array.isArray(states)) && (states.length == 1) && (states[0].state != null)) { webstate = obj.filterUserWebState(states[0].state); }
-                if ((webstate == '') && (typeof domain.defaultuserwebstate == 'object')) { webstate = JSON.stringify(domain.defaultuserwebstate); } // User has no web state, use defaults.
+                if ((webstate == '{}') && (typeof domain.defaultuserwebstate == 'object')) { webstate = JSON.stringify(domain.defaultuserwebstate); } // User has no web state, use defaults.
                 if (typeof domain.forceduserwebstate == 'object') { // Forces initial user web state if present, use it.
                     var webstate2 = {};
-                    try { if (webstate != '') { webstate2 = JSON.parse(webstate); } } catch (ex) { }
+                    try { if (webstate != '{}') { webstate2 = JSON.parse(webstate); } } catch (ex) { }
                     for (var i in domain.forceduserwebstate) { webstate2[i] = domain.forceduserwebstate[i]; }
                     webstate = JSON.stringify(webstate2);
                 }


### PR DESCRIPTION
If a (new) user has no webstate saved yet the app crashes at login. This is because in #6763 the `var webstateJSON = JSON.parse(webstate);` stumbles if webstate is en empty string. By making the webstate default '{}' instead of '' this is fixed.