### PR TITLE
fix meshctrl tag filter search

### DIFF
--- a/meshctrl.js
+++ b/meshctrl.js
@@ -2665,8 +2665,8 @@ function getDevicesThatMatchFilter(nodes, x) {
     } else if (tagSearch != null) {
         // Tag filter
         for (var d in nodes) {
-            if ((nodes[d].tags == null) && (tagSearch == '')) { r.push(d); }
-            else if (nodes[d].tags != null) { for (var j in nodes[d].tags) { if (nodes[d].tags[j].toLowerCase() == tagSearch) { r.push(d); break; } } }
+            if ((nodes[d].tags == null) && (tagSearch == '')) { r.push(nodes[d]); }
+            else if (nodes[d].tags != null) { for (var j in nodes[d].tags) { if (nodes[d].tags[j].toLowerCase() == tagSearch) { r.push(nodes[d]); break; } } }
         }
     } else if (agentTagSearch != null) {
         // Agent Tag filter


### PR DESCRIPTION
Tag filtering wasn't working because, instead of pushing the node that matches the search, its index was pushed.