### PR TITLE
Add unescape to getAllType function

### DIFF
--- a/db.js
+++ b/db.js
@@ -3013,7 +3013,7 @@ module.exports.CreateDB = function (parent, func) {
                 if (id) { x._id = id; }
                 obj.file.find(x, function (err, docs) { func(err, performTypedRecordDecrypt(docs)); });
             };
-            obj.GetAllType = function (type, func) { obj.file.find({ type: type }, function (err, docs) { func(err, performTypedRecordDecrypt(docs)); }); };
+            obj.GetAllType = function (type, func) { obj.file.find({ type: type }, function (err, docs) { func(err, common.unEscapeAllLinksFieldName(performTypedRecordDecrypt(docs))); }); };
             obj.GetAllIdsOfType = function (ids, domain, type, func) { obj.file.find({ type: type, domain: domain, _id: { $in: ids } }, function (err, docs) { func(err, performTypedRecordDecrypt(docs)); }); };
             obj.GetUserWithEmail = function (domain, email, func) { obj.file.find({ type: 'user', domain: domain, email: email }, { type: 0 }, function (err, docs) { func(err, performTypedRecordDecrypt(docs)); }); };
             obj.GetUserWithVerifiedEmail = function (domain, email, func) { obj.file.find({ type: 'user', domain: domain, email: email, emailVerified: true }, function (err, docs) { func(err, performTypedRecordDecrypt(docs)); }); };


### PR DESCRIPTION
This is used in the [recode encrypted fields function](https://github.com/Ylianst/MeshCentral/blob/e0e8a3fcaa2947b8c77fb5eb6c7a3f286782c42e/db.js#L604)

Some db functions have the un/escape in the function, but not all. For some it is done in app [after the get](https://github.com/Ylianst/MeshCentral/blob/e0e8a3fcaa2947b8c77fb5eb6c7a3f286782c42e/webserver.js#L248).

I would propose to move it to the db functions instead of having to not forget it at the application level. I haven't checked all functions, but the [GetAll function](https://github.com/Ylianst/MeshCentral/blob/e0e8a3fcaa2947b8c77fb5eb6c7a3f286782c42e/db.js#L2992) also doesn't do the unescaping for you.

@si458 What do you think?
