### PR TITLE
Fix parameter names in usage message for the "agentmsg" console command

### DIFF
--- a/agents/meshcore.js
+++ b/agents/meshcore.js
@@ -4355,7 +4355,7 @@ function processConsoleCommand(cmd, args, rights, sessionid) {
             }
             case 'agentmsg': {
                 if (args['_'].length == 0) {
-                    response = "Proper usage:\r\n  agentmsg add \"[message]\" [iconIndex]\r\n  agentmsg remove [index]\r\n  agentmsg list"; // Display usage
+                    response = "Proper usage:\r\n  agentmsg add \"[message]\" [iconIndex]\r\n  agentmsg remove [id]\r\n  agentmsg list"; // Display usage
                 } else {
                     if ((args['_'][0] == 'add') && (args['_'].length > 1)) {
                         var msgID, iconIndex = 0;


### PR DESCRIPTION
I guess, the parameter should be named "id" not "index" .

```
> agentmsg
Proper usage:
  agentmsg add "[message]" [iconIndex]
  agentmsg remove [id]
  agentmsg list
> agentmsg add "Hello world!"
Agent message: 000002F0396D43A8 added.
> agentmsg add "Howdy?"
Agent message: 000002F0396D4BA8 added.
> agentmsg list
[
  {
    "msg": "Hello world!",
    "icon": 0,
    "id": "000002F0396D43A8"
  },
  {
    "msg": "Howdy?",
    "icon": 0,
    "id": "000002F0396D4BA8"
  }
]
```