### PR TITLE
Correctly apply config value `logoutOnIdleSessionTimeout`

### DIFF
--- a/meshuser.js
+++ b/meshuser.js
@@ -601,8 +601,8 @@ module.exports.CreateMeshUser = function (parent, db, ws, req, args, domain, use
             }
             if (typeof domain.userconsentflags == 'number') { serverinfo.consent = domain.userconsentflags; }
             if ((typeof domain.usersessionidletimeout == 'number') && (domain.usersessionidletimeout > 0)) {serverinfo.timeout = (domain.usersessionidletimeout * 60 * 1000); }
-            if (typeof domain.logoutOnIdleSessionTimeout == 'boolean') {
-                serverinfo.logoutOnIdleSessionTimeout = domain.logoutOnIdleSessionTimeout;
+            if (typeof domain.logoutonidlesessiontimeout == 'boolean') {
+                serverinfo.logoutOnIdleSessionTimeout = domain.logoutonidlesessiontimeout;
             } else {
                 // Default
                 serverinfo.logoutOnIdleSessionTimeout = true;

--- a/views/default-mobile.handlebars
+++ b/views/default-mobile.handlebars
@@ -1524,8 +1524,12 @@
         function setSessionActivity() { sessionActivity = Date.now(); }
         function checkIdleSessionTimeout() {
             var delta = (Date.now() - sessionActivity);
-            if (delta > serverinfo.timeout && serverinfo.logoutOnIdleSessionTimeout) {
-                window.location.href = 'logout';
+            if (delta > serverinfo.timeout) {
+                if (serverinfo.logoutOnIdleSessionTimeout) {
+                    window.location.href = 'logout';
+                } else {
+                    setSessionActivity();
+                }
             }
         }
 

--- a/views/default.handlebars
+++ b/views/default.handlebars
@@ -2449,6 +2449,8 @@
                 }
                 if (serverinfo.logoutOnIdleSessionTimeout) {
                     window.location.href = 'logout';
+                } else {
+                    setSessionActivity();
                 }
             } else {
                 var ds = Math.round((serverinfo.timeout - delta) / 1000);

--- a/views/default3.handlebars
+++ b/views/default3.handlebars
@@ -2899,6 +2899,8 @@
                 }
                 if (serverinfo.logoutOnIdleSessionTimeout) {
                     window.location.href = 'logout';
+                } else {
+                    setSessionActivity();
                 }
             } else {
                 var ds = Math.round((serverinfo.timeout - delta) / 1000);

--- a/views/sharing-mobile.handlebars
+++ b/views/sharing-mobile.handlebars
@@ -822,8 +822,12 @@
         function setSessionActivity() { sessionActivity = Date.now(); }
         function checkIdleSessionTimeout() {
             var delta = (Date.now() - sessionActivity);
-            if (delta > serverinfo.timeout && serverinfo.logoutOnIdleSessionTimeout) {
-                window.location.href = 'logout';
+            if (delta > serverinfo.timeout) {
+                if (serverinfo.logoutOnIdleSessionTimeout) {
+                    window.location.href = 'logout';
+                } else {
+                    setSessionActivity();
+                }
             }
         }
 


### PR DESCRIPTION
Closes #6851 

This merge request fixes a bug where the configuration parameter `logoutOnIdleSessionTimeout` was not applied correctly, because it was not taken into account that the config file keys are normalized (to lowercase).

Moreover, if `logoutOnIdleSessionTimeout` is set to `false`, the session activity is updated instead of the user being logged out. This is to update the "disconnect in X minutes/seconds" information in the top right corner of the UI.