### PR TITLE
[chore] bump otplib to 12.0.1 (5 years ago)

### DIFF
--- a/meshcentral.js
+++ b/meshcentral.js
@@ -4299,7 +4299,7 @@ function mainStart() {
         if (config.settings.no2factorauth !== true) {
             // Setup YubiKey OTP if configured
             if (yubikey == true) { modules.push('yubikeyotp@0.2.0'); } // Add YubiKey OTP support
-            if (allsspi == false) { modules.push('otplib@10.2.3'); } // Google Authenticator support (v10 supports older NodeJS versions).
+            if (allsspi == false) { modules.push('otplib@12.0.1'); } // Google Authenticator support (v10 supports older NodeJS versions).
         }
 
         // Desktop multiplexor support


### PR DESCRIPTION
@si458 please test if this version is compatible, I don't think its good to keep non-latest or outdated libraries in use.

Related issue: https://github.com/Ylianst/MeshCentral/issues/6912