### PR TITLE
Add mongodump args option

### DIFF
--- a/db.js
+++ b/db.js
@@ -3323,7 +3323,10 @@ module.exports.CreateDB = function (parent, func) {
 
         var cmd = '"' + mongoDumpPath + '"';
         if (dburl) { cmd = '\"' + mongoDumpPath + '\" --uri=\"' + dburl + '\"'; }
-
+        if (parent.config.settings.mongodbdumpargs) {
+            cmd = '\"' + mongoDumpPath + '\" ' + parent.config.settings.mongodbdumpargs;
+            if (!parent.config.settings.mongodbdumpargs.includes("--db=")) {cmd += ' --db=' + (parent.config.settings.mongodbname ? parent.config.settings.mongodbname : 'meshcentral')};
+        }
         return cmd;
     }
 
@@ -3377,7 +3380,7 @@ module.exports.CreateDB = function (parent, func) {
             const child_process = require('child_process');
             child_process.exec(cmd, { cwd: backupPath }, function (error, stdout, stderr) {
                 if ((error != null) && (error != '')) {
-                        func(1, "Unable to find mongodump tool, backup will not be performed. Command tried: " + cmd);
+                        func(1, "Mongodump error, backup will not be performed. Command tried: " + cmd + ' --> ERROR: ' + stderr);
                         return;
                 } else {parent.config.settings.autobackup.backupintervalhours = backupInterval;}
             });

--- a/db.js
+++ b/db.js
@@ -3323,9 +3323,9 @@ module.exports.CreateDB = function (parent, func) {
 
         var cmd = '"' + mongoDumpPath + '"';
         if (dburl) { cmd = '\"' + mongoDumpPath + '\" --uri=\"' + dburl + '\"'; }
-        if (parent.config.settings.mongodbdumpargs) {
-            cmd = '\"' + mongoDumpPath + '\" ' + parent.config.settings.mongodbdumpargs;
-            if (!parent.config.settings.mongodbdumpargs.includes("--db=")) {cmd += ' --db=' + (parent.config.settings.mongodbname ? parent.config.settings.mongodbname : 'meshcentral')};
+        if (parent.config.settings.autobackup?.mongodumpargs) {
+            cmd = '\"' + mongoDumpPath + '\" ' + parent.config.settings.autobackup.mongodumpargs;
+            if (!parent.config.settings.autobackup.mongodumpargs.includes("--db=")) {cmd += ' --db=' + (parent.config.settings.mongodbname ? parent.config.settings.mongodbname : 'meshcentral')};
         }
         return cmd;
     }

--- a/meshcentral-config-schema.json
+++ b/meshcentral-config-schema.json
@@ -29,10 +29,6 @@
           "type": "string",
           "description": "Name of the MongoDB database used."
         },
-        "mongoDbDumpArgs": {
-          "type": "string",
-          "description": "Override the default mongodump --uri=<mongoDb>. The --db= option is automatically appended if omitted. (f.e. --host=127.0.0.1 --username=someUser --password=PaSsWORD --authenticationDatabase=admin)"
-        },
         "mongoDbChangeStream": {
           "type": "boolean",
           "default": false
@@ -890,6 +886,10 @@
               "default": "mongodump",
               "description": "The file path of where \"mongodump\" is located. Default is \"mongodump\""
             },
+            "mongoDumpArgs": {
+              "type": "string",
+              "description": "Override the default mongodump --uri=<mongoDb>. The --db= option is automatically appended if omitted. (f.e. --host=127.0.0.1 --username=someUser --password=PaSsWORD --authenticationDatabase=admin)"
+            },    
             "mysqlDumpPath": {
               "type": "string",
               "default": "mysqldump",

--- a/meshcentral-config-schema.json
+++ b/meshcentral-config-schema.json
@@ -29,6 +29,10 @@
           "type": "string",
           "description": "Name of the MongoDB database used."
         },
+        "mongoDbDumpArgs": {
+          "type": "string",
+          "description": "Override the default mongodump --uri=<mongoDb>. The --db= option is automatically appended if omitted. (f.e. --host=127.0.0.1 --username=someUser --password=PaSsWORD --authenticationDatabase=admin)"
+        },
         "mongoDbChangeStream": {
           "type": "boolean",
           "default": false


### PR DESCRIPTION
#6903 Add 'mongoDbDumpArgs' option to override the default behavior of autobackup, which is to use the parameter 'mongoDb' as the --uri argument to mongodump. When using restricted mongodb users, this errors mongodump.

It gives the flexibility to use different formatting for the connection (uri format) and mongodump (argument format).

Also made the error message more descriptive.

...and put the option in the autobackup category
