### PR TITLE
[ENH] Improves bootstrap/bootswatch theme compatibility in sitestyle 3 across light and dark modes

### DIFF
--- a/public/styles/style-bootstrap.css
+++ b/public/styles/style-bootstrap.css
@@ -2299,10 +2299,20 @@ nav .lbbuttonsel2 {
     background-color: #d3d9d6;
     background-repeat: repeat;
     background-attachment: scroll;
+    color: var(--title-color, #212529); /* fallback: dark gray */
 }
 
 .night .h1 {
     background-image: linear-gradient(to right, #000 0%, #333 100%);
+    color: #f8f9fa !important; /* very light gray for dark mode */
+}
+
+[data-bs-theme="light"] h1, h1 {
+    color: #adafae !important; /* very dark gray, almost black */
+}
+
+[data-bs-theme="dark"] h1, h1 {
+    color: #f8f9fa !important; /* very light gray */
 }
 
 .h2end {

--- a/public/styles/style-bootstrap.css
+++ b/public/styles/style-bootstrap.css
@@ -2312,12 +2312,11 @@ nav .lbbuttonsel2 {
 
 /* Light theme text colors */
 [data-bs-theme="light"] h1,
-[data-bs-theme="light"] .h1,
-[data-bs-theme="light"] .h2,
-[data-bs-theme="light"] .h3,
-[data-bs-theme="light"] .h4,
-[data-bs-theme="light"] .h5,
-[data-bs-theme="light"] .h6,
+[data-bs-theme="light"] h2,
+[data-bs-theme="light"] h3,
+[data-bs-theme="light"] h4,
+[data-bs-theme="light"] h5,
+[data-bs-theme="light"] h6,
 [data-bs-theme="light"] .fs-4,
 [data-bs-theme="light"] .content-heading,
 [data-bs-theme="light"] .panel-title {
@@ -2326,12 +2325,11 @@ nav .lbbuttonsel2 {
 
 /* Dark theme text colors */
 [data-bs-theme="dark"] h1,
-[data-bs-theme="dark"] .h1,
-[data-bs-theme="dark"] .h2,
-[data-bs-theme="dark"] .h3,
-[data-bs-theme="dark"] .h4,
-[data-bs-theme="dark"] .h5,
-[data-bs-theme="dark"] .h6,
+[data-bs-theme="dark"] h2,
+[data-bs-theme="dark"] h3,
+[data-bs-theme="dark"] h4,
+[data-bs-theme="dark"] h5,
+[data-bs-theme="dark"] h6,
 [data-bs-theme="dark"] .fs-4,
 [data-bs-theme="dark"] .content-heading,
 [data-bs-theme="dark"] .panel-title,

--- a/public/styles/style-bootstrap.css
+++ b/public/styles/style-bootstrap.css
@@ -422,6 +422,20 @@ body {
     right: 3px;
 }
 
+.textnewui {
+    color: white !important;
+    font-weight: bold;
+    padding-top: 5px;
+    cursor: pointer;
+    position: absolute;
+    right: 0;
+    margin-right: 10px;
+}
+
+.LogoffLinkColor {
+    color: white !important;
+}
+
 #logoutControlSpan2 {
     cursor: pointer;
     color: white;
@@ -711,6 +725,10 @@ body {
     border-radius: 5px 5px 0 0;
     margin-bottom: 6px;
     cursor: move;
+}
+
+#dialogHeader .modal-title {
+    color: inherit !important;
 }
 
 #id_dialogclose {
@@ -2288,34 +2306,44 @@ nav .lbbuttonsel2 {
     color: var(--title-color, #212529); /* fallback: dark gray */
 }
 
-/* Dark theme heading styles */
+/* Theme-aware Bootstrap surface colors */
 [data-bs-theme="dark"] .h1,
 [data-bs-theme="dark"] h1,
 .night .h1 {
     background-image: linear-gradient(to right, #000 0%, #333 100%);
-    color: #f8f9fa !important;
+    color: var(--bs-heading-color, #f8f9fa);
 }
 
-/* Light theme text colors */
-[data-bs-theme="light"] h1,
-[data-bs-theme="light"] h2,
-[data-bs-theme="light"] h3,
-[data-bs-theme="light"] h4,
-[data-bs-theme="light"] h5,
-[data-bs-theme="light"] h6,
+[data-bs-theme="light"] .modal-body h1,
+[data-bs-theme="light"] .modal-body h2,
+[data-bs-theme="light"] .modal-body h3,
+[data-bs-theme="light"] .modal-body h4,
+[data-bs-theme="light"] .modal-body h5,
+[data-bs-theme="light"] .modal-body h6,
+[data-bs-theme="light"] .card-body h1,
+[data-bs-theme="light"] .card-body h2,
+[data-bs-theme="light"] .card-body h3,
+[data-bs-theme="light"] .card-body h4,
+[data-bs-theme="light"] .card-body h5,
+[data-bs-theme="light"] .card-body h6,
 [data-bs-theme="light"] .fs-4,
 [data-bs-theme="light"] .content-heading,
 [data-bs-theme="light"] .panel-title {
-    color: var(--bs-heading-color, #212529) !important;
+    color: var(--bs-heading-color, #212529);
 }
 
-/* Dark theme text colors */
-[data-bs-theme="dark"] h1,
-[data-bs-theme="dark"] h2,
-[data-bs-theme="dark"] h3,
-[data-bs-theme="dark"] h4,
-[data-bs-theme="dark"] h5,
-[data-bs-theme="dark"] h6,
+[data-bs-theme="dark"] .modal-body h1,
+[data-bs-theme="dark"] .modal-body h2,
+[data-bs-theme="dark"] .modal-body h3,
+[data-bs-theme="dark"] .modal-body h4,
+[data-bs-theme="dark"] .modal-body h5,
+[data-bs-theme="dark"] .modal-body h6,
+[data-bs-theme="dark"] .card-body h1,
+[data-bs-theme="dark"] .card-body h2,
+[data-bs-theme="dark"] .card-body h3,
+[data-bs-theme="dark"] .card-body h4,
+[data-bs-theme="dark"] .card-body h5,
+[data-bs-theme="dark"] .card-body h6,
 [data-bs-theme="dark"] .fs-4,
 [data-bs-theme="dark"] .content-heading,
 [data-bs-theme="dark"] .panel-title,
@@ -2323,23 +2351,17 @@ nav .lbbuttonsel2 {
 .night .fs-4,
 .night .content-heading,
 .night .panel-title {
-    color: var(--bs-heading-color, #f8f9fa) !important;
+    color: var(--bs-heading-color, #f8f9fa);
 }
 
-[data-bs-theme="dark"] b,
-[data-bs-theme="dark"] span {
-    color: #bbb !important;
-}
-
-/* Main content areas */
 [data-bs-theme="light"] .content-area,
 [data-bs-theme="light"] .panel-content,
 [data-bs-theme="light"] .card-body,
 [data-bs-theme="light"] .modal-content,
 [data-bs-theme="light"] .table,
 [data-bs-theme="light"] .list-group-item {
-    color: #212529;
-    background-color: #ffffff;
+    color: var(--bs-body-color, #212529);
+    background-color: var(--bs-body-bg, #ffffff);
 }
 
 [data-bs-theme="dark"] .content-area,
@@ -2348,36 +2370,32 @@ nav .lbbuttonsel2 {
 [data-bs-theme="dark"] .modal-content,
 [data-bs-theme="dark"] .table,
 [data-bs-theme="dark"] .list-group-item {
-    color: #f8f9fa;
-    background-color: #212529;
+    color: var(--bs-body-color, #f8f9fa);
+    background-color: var(--bs-body-bg, #212529);
 }
 
 /* Form elements */
 [data-bs-theme="light"] .form-control,
 [data-bs-theme="light"] .form-select,
-[data-bs-theme="light"] label,
-[data-bs-theme="light"] input,
-[data-bs-theme="light"] textarea,
-[data-bs-theme="light"] select,
+[data-bs-theme="light"] .form-label,
+[data-bs-theme="light"] .form-text,
 [data-bs-theme="light"] .ms-2 {
-    color: #212529;
+    color: var(--bs-body-color, #212529);
 }
 
 [data-bs-theme="dark"] .form-label,
 [data-bs-theme="dark"] .form-text,
-[data-bs-theme="dark"] label,
 [data-bs-theme="dark"] .ms-2 {
-    color: #f8f9fa;
+    color: var(--bs-body-color, #f8f9fa);
 }
 
 [data-bs-theme="dark"] .form-control,
 [data-bs-theme="dark"] .form-select {
-    background-color: #2b3035;
-    border-color: #6c757d;
-    color: #f8f9fa;
+    background-color: var(--bs-tertiary-bg, #2b3035);
+    border-color: var(--bs-border-color, #6c757d);
+    color: var(--bs-body-color, #f8f9fa);
 }
 
-/* Ensure form controls are visible in dark mode */
 [data-bs-theme="dark"] input[type="text"],
 [data-bs-theme="dark"] input[type="password"],
 [data-bs-theme="dark"] input[type="email"],
@@ -2385,17 +2403,15 @@ nav .lbbuttonsel2 {
 [data-bs-theme="dark"] textarea,
 [data-bs-theme="dark"] select,
 [data-bs-theme="dark"] .form-select {
-    color: #f8f9fa !important;
-    background-color: #2b3035 !important;
+    color: var(--bs-body-color, #f8f9fa);
+    background-color: var(--bs-tertiary-bg, #2b3035);
 }
 
-/* Fix for select dropdown options in dark mode */
 [data-bs-theme="dark"] select option {
-    color: #f8f9fa !important;
-    background-color: #2b3035 !important;
+    color: var(--bs-body-color, #f8f9fa);
+    background-color: var(--bs-tertiary-bg, #2b3035);
 }
 
-/* Ensure checkboxes are visible in both light and dark mode */
 [data-bs-theme="light"] input[type="checkbox"] {
     opacity: 1 !important;
     appearance: checkbox !important;
@@ -2411,23 +2427,29 @@ nav .lbbuttonsel2 {
     appearance: checkbox !important;
 }
 
-/* Ensure select dropdown remains visible when focused */
 [data-bs-theme="dark"] select:focus {
-    color: #f8f9fa !important;
-    background-color: #2b3035 !important;
+    color: var(--bs-body-color, #f8f9fa);
+    background-color: var(--bs-tertiary-bg, #2b3035);
     border-color: #86b7fe;
     box-shadow: 0 0 0 0.25rem rgba(13, 110, 253, 0.25);
 }
 
-/* Fix for placeholder text in inputs */
-[data-bs-theme="dark"] ::placeholder {
-    color: #adb5bd !important;
+[data-bs-theme="dark"] .form-control::placeholder {
+    color: var(--bs-secondary-color, #adb5bd);
     opacity: 1;
 }
 
-/* Ensure labels are visible in dark mode */
-[data-bs-theme="dark"] label {
-    color: #f8f9fa !important;
+/* Preserve Bootstrap floating-label behavior in dark themes. */
+[data-bs-theme="dark"] .form-floating > .form-control::placeholder,
+[data-bs-theme="dark"] .form-floating > .form-control-plaintext::placeholder {
+    color: transparent !important;
+}
+
+[data-bs-theme="dark"] .form-floating > .form-control:focus ~ label,
+[data-bs-theme="dark"] .form-floating > .form-control:not(:placeholder-shown) ~ label,
+[data-bs-theme="dark"] .form-floating > .form-control-plaintext ~ label,
+[data-bs-theme="dark"] .form-floating > .form-select ~ label {
+    color: rgba(var(--bs-body-color-rgb), 0.65) !important;
 }
 
 /* Buttons */
@@ -2523,20 +2545,6 @@ nav .lbbuttonsel2 {
 
 [data-bs-theme="dark"] ::-webkit-scrollbar-thumb {
     background-color: #6c757d;
-}
-
-.textnewui {
-    color: white !important;
-    font-weight: bold;
-    padding-top: 5px;
-    cursor: pointer;
-    position: absolute;
-    right: 0;
-    margin-right: 10px;
-}
-
-.LogoffLinkColor {
-    color:white !important;
 }
 
 .h2end {

--- a/public/styles/style-bootstrap.css
+++ b/public/styles/style-bootstrap.css
@@ -2395,8 +2395,7 @@ nav .lbbuttonsel2 {
 [data-bs-theme="dark"] input[type="number"],
 [data-bs-theme="dark"] textarea,
 [data-bs-theme="dark"] select,
-[data-bs-theme="dark"] .form-select,
-[data-bs-theme="dark"] select {
+[data-bs-theme="dark"] .form-select {
     color: #f8f9fa !important;
     background-color: #2b3035 !important;
 }
@@ -2405,6 +2404,22 @@ nav .lbbuttonsel2 {
 [data-bs-theme="dark"] select option {
     color: #f8f9fa !important;
     background-color: #2b3035 !important;
+}
+
+/* Ensure checkboxes are visible in both light and dark mode */
+[data-bs-theme="light"] input[type="checkbox"] {
+    opacity: 1 !important;
+    appearance: checkbox !important;
+}
+
+[data-bs-theme="light"] input[type="checkbox"]:checked {
+    background-color: #0d6efd !important;
+    border-color: #0d6efd !important;
+}
+
+[data-bs-theme="dark"] input[type="checkbox"] {
+    opacity: 1 !important;
+    appearance: checkbox !important;
 }
 
 /* Ensure select dropdown remains visible when focused */

--- a/public/styles/style-bootstrap.css
+++ b/public/styles/style-bootstrap.css
@@ -1509,6 +1509,20 @@ NoMeshesPanel img {
     float: right;
 }
 
+#p6title {
+    align-items: flex-start !important;
+    min-height: 0;
+    position: relative;
+}
+
+#p6title > #MainMeshImage {
+    float: none;
+    object-fit: contain;
+    position: absolute;
+    right: 10px;
+    top: 0;
+}
+
 #DeskTools {
     position: absolute;
     width: 400px;

--- a/public/styles/style-bootstrap.css
+++ b/public/styles/style-bootstrap.css
@@ -2307,12 +2307,16 @@ nav .lbbuttonsel2 {
     color: #f8f9fa !important; /* very light gray for dark mode */
 }
 
-[data-bs-theme="light"] h1, h1 {
-    color: #adafae !important; /* very dark gray, almost black */
+[data-bs-theme="light"] h1,
+[data-bs-theme="light"] .fs-4 {
+    color: var(--bs-heading-color, #212529) !important;
 }
 
-[data-bs-theme="dark"] h1, h1 {
-    color: #f8f9fa !important; /* very light gray */
+[data-bs-theme="dark"] h1,
+[data-bs-theme="dark"] .fs-4,
+.night h1,
+.night .fs-4 {
+    color: var(--bs-heading-color, #f8f9fa) !important;
 }
 
 .h2end {

--- a/public/styles/style-bootstrap.css
+++ b/public/styles/style-bootstrap.css
@@ -2302,21 +2302,213 @@ nav .lbbuttonsel2 {
     color: var(--title-color, #212529); /* fallback: dark gray */
 }
 
+/* Dark theme heading styles */
+[data-bs-theme="dark"] .h1,
+[data-bs-theme="dark"] h1,
 .night .h1 {
     background-image: linear-gradient(to right, #000 0%, #333 100%);
-    color: #f8f9fa !important; /* very light gray for dark mode */
+    color: #f8f9fa !important;
 }
 
+/* Light theme text colors */
 [data-bs-theme="light"] h1,
-[data-bs-theme="light"] .fs-4 {
+[data-bs-theme="light"] .h1,
+[data-bs-theme="light"] .h2,
+[data-bs-theme="light"] .h3,
+[data-bs-theme="light"] .h4,
+[data-bs-theme="light"] .h5,
+[data-bs-theme="light"] .h6,
+[data-bs-theme="light"] .fs-4,
+[data-bs-theme="light"] .content-heading,
+[data-bs-theme="light"] .panel-title {
     color: var(--bs-heading-color, #212529) !important;
 }
 
+/* Dark theme text colors */
 [data-bs-theme="dark"] h1,
+[data-bs-theme="dark"] .h1,
+[data-bs-theme="dark"] .h2,
+[data-bs-theme="dark"] .h3,
+[data-bs-theme="dark"] .h4,
+[data-bs-theme="dark"] .h5,
+[data-bs-theme="dark"] .h6,
 [data-bs-theme="dark"] .fs-4,
+[data-bs-theme="dark"] .content-heading,
+[data-bs-theme="dark"] .panel-title,
 .night h1,
-.night .fs-4 {
+.night .fs-4,
+.night .content-heading,
+.night .panel-title {
     color: var(--bs-heading-color, #f8f9fa) !important;
+}
+
+/* Main content areas */
+[data-bs-theme="light"] .content-area,
+[data-bs-theme="light"] .panel-content,
+[data-bs-theme="light"] .card-body,
+[data-bs-theme="light"] .modal-content,
+[data-bs-theme="light"] .table,
+[data-bs-theme="light"] .list-group-item {
+    color: #212529;
+    background-color: #ffffff;
+}
+
+[data-bs-theme="dark"] .content-area,
+[data-bs-theme="dark"] .panel-content,
+[data-bs-theme="dark"] .card-body,
+[data-bs-theme="dark"] .modal-content,
+[data-bs-theme="dark"] .table,
+[data-bs-theme="dark"] .list-group-item {
+    color: #f8f9fa;
+    background-color: #212529;
+}
+
+/* Form elements */
+[data-bs-theme="light"] .form-control,
+[data-bs-theme="light"] .form-select,
+[data-bs-theme="light"] .form-label,
+[data-bs-theme="light"] .form-text,
+[data-bs-theme="light"] label {
+    color: #212529;
+}
+
+[data-bs-theme="light"] .form-control,
+[data-bs-theme="light"] .form-select,
+[data-bs-theme="light"] input,
+[data-bs-theme="light"] textarea,
+[data-bs-theme="light"] select {
+    background-color: #ffffff;
+    border-color: #ced4da;
+}
+
+[data-bs-theme="dark"] .form-control,
+[data-bs-theme="dark"] .form-select,
+[data-bs-theme="dark"] .form-label,
+[data-bs-theme="dark"] .form-text,
+[data-bs-theme="dark"] label {
+    color: #f8f9fa;
+}
+
+[data-bs-theme="dark"] .form-control,
+[data-bs-theme="dark"] .form-select {
+    background-color: #2b3035;
+    border-color: #6c757d;
+    color: #f8f9fa;
+}
+
+/* Ensure form controls are visible in dark mode */
+[data-bs-theme="dark"] input[type="text"],
+[data-bs-theme="dark"] input[type="password"],
+[data-bs-theme="dark"] input[type="email"],
+[data-bs-theme="dark"] input[type="number"],
+[data-bs-theme="dark"] textarea,
+[data-bs-theme="dark"] select,
+[data-bs-theme="dark"] .form-select,
+[data-bs-theme="dark"] select {
+    color: #f8f9fa !important;
+    background-color: #2b3035 !important;
+}
+
+/* Fix for select dropdown options in dark mode */
+[data-bs-theme="dark"] select option {
+    color: #f8f9fa !important;
+    background-color: #2b3035 !important;
+}
+
+/* Ensure select dropdown remains visible when focused */
+[data-bs-theme="dark"] select:focus {
+    color: #f8f9fa !important;
+    background-color: #2b3035 !important;
+    border-color: #86b7fe;
+    box-shadow: 0 0 0 0.25rem rgba(13, 110, 253, 0.25);
+}
+
+/* Fix for placeholder text in inputs */
+[data-bs-theme="dark"] ::placeholder {
+    color: #adb5bd !important;
+    opacity: 1;
+}
+
+/* Ensure labels are visible in dark mode */
+[data-bs-theme="dark"] label {
+    color: #f8f9fa !important;
+}
+
+/* Buttons */
+[data-bs-theme="light"] .btn-outline-secondary {
+    color: #6c757d;
+    border-color: #6c757d;
+}
+
+[data-bs-theme="dark"] .btn-outline-secondary {
+    color: #adb5bd;
+    border-color: #6c757d;
+}
+
+/* Context menus */
+[data-bs-theme="light"] .contextMenu {
+    background-color: #ffffff;
+    border: 1px solid #dee2e6;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1);
+}
+
+[data-bs-theme="dark"] .contextMenu {
+    background-color: #343a40;
+    border: 1px solid #495057;
+    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.3);
+}
+
+[data-bs-theme="light"] .cmtext {
+    color: #212529;
+}
+
+[data-bs-theme="dark"] .cmtext {
+    color: #f8f9fa;
+}
+
+/* Navigation and headers */
+[data-bs-theme="light"] .topbar_td,
+[data-bs-theme="light"] .masthead {
+    background-color: #f8f9fa;
+    color: #212529;
+}
+
+[data-bs-theme="dark"] .topbar_td,
+[data-bs-theme="dark"] .masthead {
+    background-color: #343a40;
+    color: #f8f9fa;
+}
+
+/* Tables */
+[data-bs-theme="light"] .table {
+    --bs-table-bg: #ffffff;
+    --bs-table-striped-bg: #f8f9fa;
+    --bs-table-hover-bg: #e9ecef;
+}
+
+[data-bs-theme="dark"] .table {
+    --bs-table-bg: #212529;
+    --bs-table-striped-bg: #2c3034;
+    --bs-table-hover-bg: #32383e;
+    color: #f8f9fa;
+}
+
+/* Tabs */
+[data-bs-theme="light"] .nav-tabs .nav-link {
+    color: #495057;
+}
+
+[data-bs-theme="dark"] .nav-tabs .nav-link {
+    color: #f8f9fa;
+}
+
+/* Custom scrollbars */
+[data-bs-theme="light"] ::-webkit-scrollbar-thumb {
+    background-color: #adb5bd;
+}
+
+[data-bs-theme="dark"] ::-webkit-scrollbar-thumb {
+    background-color: #6c757d;
 }
 
 .h2end {

--- a/public/styles/style-bootstrap.css
+++ b/public/styles/style-bootstrap.css
@@ -2366,26 +2366,18 @@ nav .lbbuttonsel2 {
 /* Form elements */
 [data-bs-theme="light"] .form-control,
 [data-bs-theme="light"] .form-select,
-[data-bs-theme="light"] .form-label,
-[data-bs-theme="light"] .form-text,
-[data-bs-theme="light"] label {
+[data-bs-theme="light"] label,
+[data-bs-theme="light"] input,
+[data-bs-theme="light"] textarea,
+[data-bs-theme="light"] select,
+[data-bs-theme="light"] .ms-2 {
     color: #212529;
 }
 
-[data-bs-theme="light"] .form-control,
-[data-bs-theme="light"] .form-select,
-[data-bs-theme="light"] input,
-[data-bs-theme="light"] textarea,
-[data-bs-theme="light"] select {
-    background-color: #ffffff;
-    border-color: #ced4da;
-}
-
-[data-bs-theme="dark"] .form-control,
-[data-bs-theme="dark"] .form-select,
 [data-bs-theme="dark"] .form-label,
 [data-bs-theme="dark"] .form-text,
-[data-bs-theme="dark"] label {
+[data-bs-theme="dark"] label,
+[data-bs-theme="dark"] .ms-2 {
     color: #f8f9fa;
 }
 
@@ -2435,14 +2427,30 @@ nav .lbbuttonsel2 {
 }
 
 /* Buttons */
+[data-bs-theme="light"] .btn {
+    color: #fff;
+}
+
+[data-bs-theme="light"] .btn-primary {
+    background-color: #0d6efd;
+    border-color: #0d6efd;
+}
+
+[data-bs-theme="light"] .btn-primary:hover {
+    background-color: #0b5ed7;
+    border-color: #0a58ca;
+}
+
 [data-bs-theme="light"] .btn-outline-secondary {
-    color: #6c757d;
     border-color: #6c757d;
+}
+
+[data-bs-theme="light"] .btn-outline-success {
+    color: inherit !important;
 }
 
 [data-bs-theme="dark"] .btn-outline-secondary {
     color: #adb5bd;
-    border-color: #6c757d;
 }
 
 /* Context menus */
@@ -2480,10 +2488,30 @@ nav .lbbuttonsel2 {
 }
 
 /* Tables */
-[data-bs-theme="light"] .table {
+[data-bs-theme="light"] .table,
+[data-bs-theme="light"] .table td,
+[data-bs-theme="light"] .table th,
+[data-bs-theme="light"] .table tr {
     --bs-table-bg: #ffffff;
     --bs-table-striped-bg: #f8f9fa;
     --bs-table-hover-bg: #e9ecef;
+    color: #212529 !important;
+}
+
+/* Power state indicators in tables */
+[data-bs-theme="light"] .table .pwState {
+    border: 1px solid #dee2e6;
+    min-width: 2px;
+}
+
+[data-bs-theme="light"] .table .pwsBlack {
+    background-color: #212529 !important;
+}
+
+[data-bs-theme="light"] .table .pwsTransparent {
+    background-color: #f8f9fa !important;
+    border-left: none;
+    border-right: none;
 }
 
 [data-bs-theme="dark"] .table {
@@ -3709,8 +3737,33 @@ body:not(.fullscreen) .notifiyBox {
     color: #000;
 }
 
+/* Close button styles for both themes */
 .btn-close {
-    background-color: white !important;
+    background: #ffffff url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='%23000'%3e%3cpath d='M.293.293a1 1 0 011.414 0L8 6.586 14.293.293a1 1 0 111.414 1.414L9.414 8l6.293 6.293a1 1 0 01-1.414 1.414L8 9.414l-6.293 6.293a1 1 0 01-1.414-1.414L6.586 8 .293 1.707a1 1 0 010-1.414z'/%3e%3c/svg%3e") center/1em auto no-repeat !important;
+    opacity: 0.8 !important;
+    transition: all 0.2s ease-in-out;
+    border-radius: 0.25rem;
+    padding: 0.5rem;
+    border: 1px solid rgba(0, 0, 0, 0.1);
+}
+
+[data-bs-theme="dark"] .btn-close {
+    background: #2b3035 url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='%23fff'%3e%3cpath d='M.293.293a1 1 0 011.414 0L8 6.586 14.293.293a1 1 0 111.414 1.414L9.414 8l6.293 6.293a1 1 0 01-1.414 1.414L8 9.414l-6.293 6.293a1 1 0 01-1.414-1.414L6.586 8 .293 1.707a1 1 0 010-1.414z'/%3e%3c/svg%3e") center/1em auto no-repeat !important;
+    border-color: rgba(255, 255, 255, 0.1);
+}
+
+/*  Text directly displayed in div light/dark mode visibility */
+[data-bs-theme="light"] .col-md-10:not(.text-muted),
+[data-bs-theme="light"] .col-lg-10:not(.text-muted) {
+    color: #212529 !important;
+}
+
+[data-bs-theme="dark"] .col-md-10:not(.text-muted),
+[data-bs-theme="dark"] .col-lg-10:not(.text-muted) {
+    color: #f8f9fa !important;
+}
+
+.btn-close:hover {
     opacity: 1 !important;
 }
 

--- a/public/styles/style-bootstrap.css
+++ b/public/styles/style-bootstrap.css
@@ -2449,16 +2449,6 @@ nav .lbbuttonsel2 {
     color: #fff;
 }
 
-[data-bs-theme="light"] .btn-primary {
-    background-color: #0d6efd;
-    border-color: #0d6efd;
-}
-
-[data-bs-theme="light"] .btn-primary:hover {
-    background-color: #0b5ed7;
-    border-color: #0a58ca;
-}
-
 [data-bs-theme="light"] .btn-outline-secondary {
     border-color: #6c757d;
 }

--- a/public/styles/style-bootstrap.css
+++ b/public/styles/style-bootstrap.css
@@ -2340,6 +2340,11 @@ nav .lbbuttonsel2 {
     color: var(--bs-heading-color, #f8f9fa) !important;
 }
 
+[data-bs-theme="dark"] b,
+[data-bs-theme="dark"] span {
+    color: #bbb !important;
+}
+
 /* Main content areas */
 [data-bs-theme="light"] .content-area,
 [data-bs-theme="light"] .panel-content,

--- a/public/styles/style-bootstrap.css
+++ b/public/styles/style-bootstrap.css
@@ -2320,7 +2320,13 @@ nav .lbbuttonsel2 {
     color: var(--title-color, #212529); /* fallback: dark gray */
 }
 
-/* Theme-aware Bootstrap surface colors */
+/* Keep Bootstrap and Bootswatch surfaces readable when MeshCentral switches theme mode. */
+[data-bs-theme="light"] body,
+body[data-bs-theme="light"] {
+    color: #212529;
+    background-color: #ffffff;
+}
+
 [data-bs-theme="dark"] .h1,
 [data-bs-theme="dark"] h1,
 .night .h1 {
@@ -2343,7 +2349,7 @@ nav .lbbuttonsel2 {
 [data-bs-theme="light"] .fs-4,
 [data-bs-theme="light"] .content-heading,
 [data-bs-theme="light"] .panel-title {
-    color: var(--bs-heading-color, #212529);
+    color: #212529;
 }
 
 [data-bs-theme="dark"] .modal-body h1,
@@ -2374,8 +2380,20 @@ nav .lbbuttonsel2 {
 [data-bs-theme="light"] .modal-content,
 [data-bs-theme="light"] .table,
 [data-bs-theme="light"] .list-group-item {
-    color: var(--bs-body-color, #212529);
-    background-color: var(--bs-body-bg, #ffffff);
+    color: #212529;
+    background-color: #ffffff;
+}
+
+[data-bs-theme="light"] .card,
+[data-bs-theme="light"] .modal-body,
+[data-bs-theme="light"] .modal-footer {
+    color: #212529;
+    background-color: #ffffff;
+}
+
+[data-bs-theme="light"] .card-title,
+[data-bs-theme="light"] .card-text {
+    color: #212529;
 }
 
 [data-bs-theme="dark"] .content-area,
@@ -2394,7 +2412,27 @@ nav .lbbuttonsel2 {
 [data-bs-theme="light"] .form-label,
 [data-bs-theme="light"] .form-text,
 [data-bs-theme="light"] .ms-2 {
-    color: var(--bs-body-color, #212529);
+    color: #212529;
+}
+
+[data-bs-theme="light"] .form-control,
+[data-bs-theme="light"] .form-control-sm,
+[data-bs-theme="light"] .form-select,
+[data-bs-theme="light"] .form-select-sm,
+[data-bs-theme="light"] textarea,
+[data-bs-theme="light"] select,
+[data-bs-theme="light"] input[type="text"],
+[data-bs-theme="light"] input[type="password"],
+[data-bs-theme="light"] input[type="email"],
+[data-bs-theme="light"] input[type="number"] {
+    color: #212529;
+    background-color: #ffffff;
+    border-color: #ced4da;
+}
+
+[data-bs-theme="light"] .form-control::placeholder {
+    color: #6c757d;
+    opacity: 1;
 }
 
 [data-bs-theme="dark"] .form-label,
@@ -3759,7 +3797,7 @@ body:not(.fullscreen) .notifiyBox {
     color: #000;
 }
 
-/* Close button styles for both themes */
+/* Keep Bootstrap close buttons visible across light and dark themes. */
 .btn-close {
     background: #ffffff url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='%23000'%3e%3cpath d='M.293.293a1 1 0 011.414 0L8 6.586 14.293.293a1 1 0 111.414 1.414L9.414 8l6.293 6.293a1 1 0 01-1.414 1.414L8 9.414l-6.293 6.293a1 1 0 01-1.414-1.414L6.586 8 .293 1.707a1 1 0 010-1.414z'/%3e%3c/svg%3e") center/1em auto no-repeat !important;
     opacity: 0.8 !important;

--- a/public/styles/style-bootstrap.css
+++ b/public/styles/style-bootstrap.css
@@ -422,20 +422,6 @@ body {
     right: 3px;
 }
 
-.textnewui {
-    color: white;
-    font-weight: bold;
-    padding-top: 5px;
-    cursor: pointer;
-    position: absolute;
-    right: 0;
-    margin-right: 10px;
-}
-
-.LogoffLinkColor {
-    color:white;
-}
-
 #logoutControlSpan2 {
     cursor: pointer;
     color: white;
@@ -2449,14 +2435,6 @@ nav .lbbuttonsel2 {
     color: #fff;
 }
 
-[data-bs-theme="light"] .btn-outline-secondary {
-    border-color: #6c757d;
-}
-
-[data-bs-theme="light"] .btn-outline-success {
-    color: inherit !important;
-}
-
 [data-bs-theme="dark"] .btn-outline-secondary {
     color: #adb5bd;
 }
@@ -2545,6 +2523,20 @@ nav .lbbuttonsel2 {
 
 [data-bs-theme="dark"] ::-webkit-scrollbar-thumb {
     background-color: #6c757d;
+}
+
+.textnewui {
+    color: white !important;
+    font-weight: bold;
+    padding-top: 5px;
+    cursor: pointer;
+    position: absolute;
+    right: 0;
+    margin-right: 10px;
+}
+
+.LogoffLinkColor {
+    color:white !important;
 }
 
 .h2end {

--- a/views/default3.handlebars
+++ b/views/default3.handlebars
@@ -5664,19 +5664,19 @@
                             r += getMeshActions(mesh, meshrights);
                             r += '</span></td></tr><tr>';
                             if (mesh.mtype == 1) {
-                                r += '<td><div style=padding:10px><i><span>' + "No Intel&reg; AMT devices in this device group" + '</span>';
+                                r += '<td><div style=padding:10px><i>' + "No Intel&reg; AMT devices in this device group";
                                 if (((meshrights & 4) != 0) && ((userinfo.siteadmin == 0xFFFFFFFF) || ((userinfo.siteadmin & 4096) == 0))) { r += ', <a href=# style=cursor:pointer onclick=\'return addDeviceToMesh("' + mesh._id + '")\'>' + "add one" + '</a>'; }
                             } else if (mesh.mtype == 2) {
                                 r += '<td><div id=DevxCol' + deviceHeaderId2 + ((collapsed === true) ? ' style=display:none' : '') + '>'; // Open collapse div
-                                r += '<div style=padding:10px><i><span>' + "No devices in this device group" + '</span>';
+                                r += '<div style=padding:10px><i>' + "No devices in this device group";
                                 if (((meshrights & 4) != 0) && ((userinfo.siteadmin == 0xFFFFFFFF) || ((userinfo.siteadmin & 4096) == 0))) { r += ', <a href=# style=cursor:pointer onclick=\'return addAgentToMesh("' + mesh._id + '")\'>' + "add one" + '</a>'; }
                             } else if (mesh.mtype == 3) {
                                 r += '<td><div id=DevxCol' + deviceHeaderId2 + ((collapsed === true) ? ' style=display:none' : '') + '>'; // Open collapse div
-                                r += '<div style=padding:10px><i><span>' + "No local devices in this device group" + '</span>';
+                                r += '<div style=padding:10px><i>' + "No local devices in this device group";
                                 if (((meshrights & 4) != 0) && ((userinfo.siteadmin == 0xFFFFFFFF) || ((userinfo.siteadmin & 4096) == 0))) { r += ', <a href=# style=cursor:pointer onclick=\'return addLocalDeviceToMesh("' + mesh._id + '")\'>' + "add one" + '</a>'; }
                             } else if (mesh.mtype == 4) {
                                 r += '<td><div id=DevxCol' + deviceHeaderId2 + ((collapsed === true) ? ' style=display:none' : '') + '>'; // Open collapse div
-                                r += '<div style=padding:10px><i><span>' + "No devices in this device group" + '</span>';
+                                r += '<div style=padding:10px><i>' + "No devices in this device group";
                             }
                             r += '.</i></div></td>';
                             r += '</div>'; // End collapsing area
@@ -5725,7 +5725,7 @@
                     }
                 } else {
                     r += '</table>';
-                    if (sort == 3) { r = '<div style="margin:10px"><i><span>' + "No devices with tags found" + '</span>.</i></div>'; }
+                    if (sort == 3) { r = '<div style="margin:10px"><i>' + "No devices with tags found." + '</i></div>'; }
                 }
 
                 // Add a "Add Device Group" option
@@ -10265,7 +10265,7 @@
             return false;
         }
 
-        function addDeviceAttribute(name, value, classNames = []) { return `<div class="row mb-1"><div class="${classNames[0] || 'col col-md-2 col-lg-2'}"><b> ${name} </b></div><div class="${classNames[1] || 'col col-md-10 col-lg-10'}"> <span>${value}</span> </div></div>`; }
+        function addDeviceAttribute(name, value, classNames = []) { return `<div class="row mb-1"><div class="${classNames[0] || 'col col-md-2 col-lg-2'}"><b> ${name} </b></div><div class="${classNames[1] || 'col col-md-10 col-lg-10'}"> ${value} </div></div>`; }
 
         function editDeviceAmtSettings(nodeid, func, arg) {
             if (xxdialogMode) return;
@@ -23538,7 +23538,7 @@
         function getUrlVars() { var j, hash, vars = [], hashes = window.location.href.slice(window.location.href.indexOf('?') + 1).split('&'); for (var i = 0; i < hashes.length; i++) { j = hashes[i].indexOf('='); if (j > 0) { vars[hashes[i].substring(0, j)] = hashes[i].substring(j + 1, hashes[i].length); } } return vars; }
         //function getDocWidth() { if (window.innerWidth) return window.innerWidth; if (document.documentElement && document.documentElement.clientWidth && document.documentElement.clientWidth != 0) return document.documentElement.clientWidth; return document.getElementsByTagName('body')[0].clientWidth; }
         //function addHtmlValue(t, v) { return '<div style=height:20px><div style=float:right;width:220px><b>' + v + '</b></div><div>' + t + '</div></div>'; }
-        function addHtmlValue(t, v, classNames = []) { return `<div class="row mb-1"><div class="${classNames[0] || 'col col-md-2 col-lg-2'}"><b>${t}</b></div><div class="${classNames[1] || 'col col-md-10 col-lg-10'}"><span>${v}</span></div></div>`; }
+        function addHtmlValue(t, v, classNames = []) { return `<div class="row mb-1"><div class="${classNames[0] || 'col col-md-2 col-lg-2'}"><b>${t}</b></div><div class="${classNames[1] || 'col col-md-10 col-lg-10'}">${v}</div></div>`; }
         function addHtmlFormFloating(t, v, classNames = []) { return `<div class="row mb-1"><div class="form-floating mb-3 ${classNames[0] || 'col-md-12'}">${v}<label class="${classNames[1] || 'ms-2'}">${t}</label></div></div>`; }
 
 

--- a/views/default3.handlebars
+++ b/views/default3.handlebars
@@ -705,8 +705,8 @@
                 <div id="xmap-info-window"></div>
             </div>
             <div id=p2 style="display:none">
-                <div id="p2title">
-                    <h1>My Account</h1>
+                <div id="p2title" class="d-flex align-items-center">
+                    <div class="fs-4 fw-bold">My Account</div>
                 </div>
                 <div id="p2info" style="overflow-y:auto">
                     <div id="p2AccountImageFrame">

--- a/views/default3.handlebars
+++ b/views/default3.handlebars
@@ -10265,7 +10265,7 @@
             return false;
         }
 
-        function addDeviceAttribute(name, value, classNames = []) { return `<div class="row mb-1"><div class="${classNames[0] || 'col col-md-2 col-lg-2'}"><b> ${name} </b></div><div class="${classNames[1] || 'col col-md-10 col-lg-10'}"> ${value} </div></div>`; }
+        function addDeviceAttribute(name, value, classNames = []) { return `<div class="row mb-1"><div class="${classNames[0] || 'col col-md-2 col-lg-2'}"><b> ${name} </b></div><div class="${classNames[1] || 'col col-md-10 col-lg-10'}"> <span>${value}</span> </div></div>`; }
 
         function editDeviceAmtSettings(nodeid, func, arg) {
             if (xxdialogMode) return;
@@ -23538,7 +23538,7 @@
         function getUrlVars() { var j, hash, vars = [], hashes = window.location.href.slice(window.location.href.indexOf('?') + 1).split('&'); for (var i = 0; i < hashes.length; i++) { j = hashes[i].indexOf('='); if (j > 0) { vars[hashes[i].substring(0, j)] = hashes[i].substring(j + 1, hashes[i].length); } } return vars; }
         //function getDocWidth() { if (window.innerWidth) return window.innerWidth; if (document.documentElement && document.documentElement.clientWidth && document.documentElement.clientWidth != 0) return document.documentElement.clientWidth; return document.getElementsByTagName('body')[0].clientWidth; }
         //function addHtmlValue(t, v) { return '<div style=height:20px><div style=float:right;width:220px><b>' + v + '</b></div><div>' + t + '</div></div>'; }
-        function addHtmlValue(t, v, classNames = []) { return `<div class="row mb-1"><div class="${classNames[0] || 'col col-md-2 col-lg-2'}"><b>${t}</b></div><div class="${classNames[1] || 'col col-md-10 col-lg-10'}">${v}</div></div>`; }
+        function addHtmlValue(t, v, classNames = []) { return `<div class="row mb-1"><div class="${classNames[0] || 'col col-md-2 col-lg-2'}"><b>${t}</b></div><div class="${classNames[1] || 'col col-md-10 col-lg-10'}"><span>${v}</span></div></div>`; }
         function addHtmlFormFloating(t, v, classNames = []) { return `<div class="row mb-1"><div class="form-floating mb-3 ${classNames[0] || 'col-md-12'}">${v}<label class="${classNames[1] || 'ms-2'}">${t}</label></div></div>`; }
 
 

--- a/views/default3.handlebars
+++ b/views/default3.handlebars
@@ -23553,11 +23553,11 @@
         function findOne(arr1, arr2) { if ((arr1 == null) || (arr2 == null)) return false; return arr2.some(function (v) { return arr1.indexOf(v) >= 0; }); };
         function copyTextToClip(txt) { function selectElementText(e) { if (document.selection) { var range = document.body.createTextRange(); range.moveToElementText(e); range.select(); } else if (window.getSelection) { var range = document.createRange(); range.selectNode(e); window.getSelection().removeAllRanges(); window.getSelection().addRange(range); } } var e = document.createElement('DIV'); e.textContent = txt; document.body.appendChild(e); selectElementText(e); document.execCommand('copy'); e.remove(); }
         function copyTextToClip2(txt) { function selectElementText(e) { if (document.selection) { var range = document.body.createTextRange(); range.moveToElementText(e); range.select(); } else if (window.getSelection) { var range = document.createRange(); range.selectNode(e); window.getSelection().removeAllRanges(); window.getSelection().addRange(range); } } var e = document.createElement('DIV'); e.textContent = decodeURIComponent(txt); document.body.appendChild(e); selectElementText(e); document.execCommand('copy'); e.remove(); }
-        function capitalizeFirstLetter(x) { EscapeHtml(return x.charAt(0).toUpperCase() + x.slice(1)); }
-        function printDate(d) { EscapeHtml(return d.toLocaleDateString(args.locale); }
-        function printTime(d) { EscapeHtml(return d.toLocaleTimeString(args.locale); }
-        function printDateTime(d) { EscapeHtml(return d.toLocaleString(args.locale); }
-        function printTimer(d) { EscapeHtml(return zeroPad(Math.floor(d / 3600), 2) + ':' + zeroPad((Math.floor(d / 60) % 60), 2) + ':' + zeroPad((d % 60), 2)); }
+        function capitalizeFirstLetter(x) { return EscapeHtml(x.charAt(0).toUpperCase() + x.slice(1)); }
+        function printDate(d) { return EscapeHtml(d.toLocaleDateString(args.locale)); }
+        function printTime(d) { return EscapeHtml(d.toLocaleTimeString(args.locale)); }
+        function printDateTime(d) { return EscapeHtml(d.toLocaleString(args.locale)); }
+        function printTimer(d) { return EscapeHtml(zeroPad(Math.floor(d / 3600), 2) + ':' + zeroPad((Math.floor(d / 60) % 60), 2) + ':' + zeroPad((d % 60), 2)); }
         function printFlexDateTime(d) { if (printDate(new Date()) == printDate(d)) { return printTime(d); } else { return printDateTime(d); } }
 
         function addDetailItem(title, value, state, classNames = []) {

--- a/views/default3.handlebars
+++ b/views/default3.handlebars
@@ -5664,19 +5664,19 @@
                             r += getMeshActions(mesh, meshrights);
                             r += '</span></td></tr><tr>';
                             if (mesh.mtype == 1) {
-                                r += '<td><div style=padding:10px><i>' + "No Intel&reg; AMT devices in this device group";
+                                r += '<td><div style=padding:10px><i>' + "<span>No Intel&reg; AMT devices in this device group</span>";
                                 if (((meshrights & 4) != 0) && ((userinfo.siteadmin == 0xFFFFFFFF) || ((userinfo.siteadmin & 4096) == 0))) { r += ', <a href=# style=cursor:pointer onclick=\'return addDeviceToMesh("' + mesh._id + '")\'>' + "add one" + '</a>'; }
                             } else if (mesh.mtype == 2) {
                                 r += '<td><div id=DevxCol' + deviceHeaderId2 + ((collapsed === true) ? ' style=display:none' : '') + '>'; // Open collapse div
-                                r += '<div style=padding:10px><i>' + "No devices in this device group";
+                                r += '<div style=padding:10px><i>' + "<span>No devices in this device group</span>";
                                 if (((meshrights & 4) != 0) && ((userinfo.siteadmin == 0xFFFFFFFF) || ((userinfo.siteadmin & 4096) == 0))) { r += ', <a href=# style=cursor:pointer onclick=\'return addAgentToMesh("' + mesh._id + '")\'>' + "add one" + '</a>'; }
                             } else if (mesh.mtype == 3) {
                                 r += '<td><div id=DevxCol' + deviceHeaderId2 + ((collapsed === true) ? ' style=display:none' : '') + '>'; // Open collapse div
-                                r += '<div style=padding:10px><i>' + "No local devices in this device group";
+                                r += '<div style=padding:10px><i>' + "<span>No local devices in this device group</span>";
                                 if (((meshrights & 4) != 0) && ((userinfo.siteadmin == 0xFFFFFFFF) || ((userinfo.siteadmin & 4096) == 0))) { r += ', <a href=# style=cursor:pointer onclick=\'return addLocalDeviceToMesh("' + mesh._id + '")\'>' + "add one" + '</a>'; }
                             } else if (mesh.mtype == 4) {
                                 r += '<td><div id=DevxCol' + deviceHeaderId2 + ((collapsed === true) ? ' style=display:none' : '') + '>'; // Open collapse div
-                                r += '<div style=padding:10px><i>' + "No devices in this device group";
+                                r += '<div style=padding:10px><i>' + "<span>No devices in this device group</span>";
                             }
                             r += '.</i></div></td>';
                             r += '</div>'; // End collapsing area
@@ -5725,7 +5725,7 @@
                     }
                 } else {
                     r += '</table>';
-                    if (sort == 3) { r = '<div style="margin:10px"><i>' + "No devices with tags found." + '</i></div>'; }
+                    if (sort == 3) { r = '<div style="margin:10px"><i>' + "<span>No devices with tags found</span>." + '</i></div>'; }
                 }
 
                 // Add a "Add Device Group" option

--- a/views/default3.handlebars
+++ b/views/default3.handlebars
@@ -5664,19 +5664,19 @@
                             r += getMeshActions(mesh, meshrights);
                             r += '</span></td></tr><tr>';
                             if (mesh.mtype == 1) {
-                                r += '<td><div style=padding:10px><i>' + "<span>No Intel&reg; AMT devices in this device group</span>";
+                                r += '<td><div style=padding:10px><i><span>' + "No Intel&reg; AMT devices in this device group" + '</span>';
                                 if (((meshrights & 4) != 0) && ((userinfo.siteadmin == 0xFFFFFFFF) || ((userinfo.siteadmin & 4096) == 0))) { r += ', <a href=# style=cursor:pointer onclick=\'return addDeviceToMesh("' + mesh._id + '")\'>' + "add one" + '</a>'; }
                             } else if (mesh.mtype == 2) {
                                 r += '<td><div id=DevxCol' + deviceHeaderId2 + ((collapsed === true) ? ' style=display:none' : '') + '>'; // Open collapse div
-                                r += '<div style=padding:10px><i>' + "<span>No devices in this device group</span>";
+                                r += '<div style=padding:10px><i><span>' + "No devices in this device group" + '</span>';
                                 if (((meshrights & 4) != 0) && ((userinfo.siteadmin == 0xFFFFFFFF) || ((userinfo.siteadmin & 4096) == 0))) { r += ', <a href=# style=cursor:pointer onclick=\'return addAgentToMesh("' + mesh._id + '")\'>' + "add one" + '</a>'; }
                             } else if (mesh.mtype == 3) {
                                 r += '<td><div id=DevxCol' + deviceHeaderId2 + ((collapsed === true) ? ' style=display:none' : '') + '>'; // Open collapse div
-                                r += '<div style=padding:10px><i>' + "<span>No local devices in this device group</span>";
+                                r += '<div style=padding:10px><i><span>' + "No local devices in this device group" + '</span>';
                                 if (((meshrights & 4) != 0) && ((userinfo.siteadmin == 0xFFFFFFFF) || ((userinfo.siteadmin & 4096) == 0))) { r += ', <a href=# style=cursor:pointer onclick=\'return addLocalDeviceToMesh("' + mesh._id + '")\'>' + "add one" + '</a>'; }
                             } else if (mesh.mtype == 4) {
                                 r += '<td><div id=DevxCol' + deviceHeaderId2 + ((collapsed === true) ? ' style=display:none' : '') + '>'; // Open collapse div
-                                r += '<div style=padding:10px><i>' + "<span>No devices in this device group</span>";
+                                r += '<div style=padding:10px><i><span>' + "No devices in this device group" + '</span>';
                             }
                             r += '.</i></div></td>';
                             r += '</div>'; // End collapsing area
@@ -5725,7 +5725,7 @@
                     }
                 } else {
                     r += '</table>';
-                    if (sort == 3) { r = '<div style="margin:10px"><i>' + "<span>No devices with tags found</span>." + '</i></div>'; }
+                    if (sort == 3) { r = '<div style="margin:10px"><i><span>' + "No devices with tags found" + '</span>.</i></div>'; }
                 }
 
                 // Add a "Add Device Group" option


### PR DESCRIPTION
This fixes several theme regressions where Bootswatch themes, especially Cyborg, could leave dark-mode surface variables active while MeshCentral was switched to light mode. The update normalizes key Bootstrap elements, form controls, cards, modals, tables, and placeholders so text remains readable in both modes.