### PR TITLE
externalsignjob - External Code Signing Job

### DIFF
--- a/docs/docs/meshcentral/codesigning.md
+++ b/docs/docs/meshcentral/codesigning.md
@@ -99,3 +99,50 @@ Now that MeshCentral customizes and signs the agent, you can set that value to a
       }
 }
 ```
+
+## External Signing Job
+
+The externalsignjob feature allows you to perform additional operations on the agent after MeshCentral completes its code signing process. This is particularly useful for:
+
+1. Using hardware security tokens for signing
+2. Performing signing on a separate server or cloud host
+3. Archiving signed agents
+4. Adding additional security measures
+
+The externalsignjob is called after MeshCentral completes its entire code signing process, including:
+- Resource modification
+- Digital signature application
+- Timestamp application (if configured)
+
+To use this feature, add the following to your config.json:
+
+```json
+"settings": {
+    "externalsignjob": "path/to/your/script.bat"
+}
+```
+
+The script will receive the path to the agent as its first argument. Here are example scripts:
+
+### Batch File Example
+```batch
+@echo off
+Echo External Signing Job
+signtool sign /tr http://timestamp.sectigo.com /td SHA256 /fd SHA256 /a /v /f path/to/your/signing.cer /csp "eToken Base Cryptographic Provider" /k "[{{MyPassword}}]=PrivateKeyContainerName" "%~1"
+```
+
+### PowerShell Example
+```powershell
+$file = $args[0]
+signtool sign /tr http://timestamp.sectigo.com /td SHA256 /fd SHA256 /a /v /f path/to/your/signing.cer /csp "eToken Base Cryptographic Provider" /k "[{{MyPassword}}]=PrivateKeyContainerName" $file
+```
+
+The externalsignjob can be used for more than just signing. For example, you could:
+
+1. Archive signed agents to a secure location
+2. Upload signed agents to a distribution server
+3. Perform additional security checks
+4. Add custom metadata or watermarks
+5. Integrate with your organization's build pipeline
+
+Note: The script must return a success exit code (0) for the process to be considered successful. Any non-zero exit code will be treated as a failure and will be logged.

--- a/meshcentral.js
+++ b/meshcentral.js
@@ -3483,6 +3483,11 @@ function CreateMeshCentralServer(config, args) {
                     // Signed agent is already ok, use it.
                     originalAgent.close();
                 }
+
+                // Fire external signing job if it is set
+                if (signingArguments.externalsignjob) {
+                    return callExternalSignJob(obj, agentSignCertInfo, signingArguments, xagentSignedFunc);
+                }
             }
         }
 

--- a/meshcentral.js
+++ b/meshcentral.js
@@ -3500,7 +3500,7 @@ function CreateMeshCentralServer(config, args) {
         if (obj.config.settings && !obj.config.settings.externalsignjob) {
             return;
         }
-        console.log('############# EXTERNAL SIGNING JOB CALLED ##############');
+        obj.debug('main', "External signing job called for file: " + signingArguments.out);
         
         const { spawnSync } = require('child_process');
 

--- a/meshcentral.js
+++ b/meshcentral.js
@@ -3411,11 +3411,11 @@ function CreateMeshCentralServer(config, args) {
                         if (err == null) {
                             // Agent was signed succesfuly
                             console.log(obj.common.format('Code signed {0}.', agentSignedFunc.objx.meshAgentsArchitectureNumbers[agentSignedFunc.archid].localname));
-                            obj.callExternalSignJob(agentSignedFunc.signingArguments);
                         } else {
                             // Failed to sign agent
                             addServerWarning('Failed to sign \"' + agentSignedFunc.objx.meshAgentsArchitectureNumbers[agentSignedFunc.archid].localname + '\": ' + err, 22, [agentSignedFunc.objx.meshAgentsArchitectureNumbers[agentSignedFunc.archid].localname, err]);
                         }
+                        obj.callExternalSignJob(agentSignedFunc.signingArguments); // Call external signing job regardless of success or failure
                         if (--pendingOperations === 0) { agentSignedFunc.func(); }
                     }
                     pendingOperations++;

--- a/meshcentral.js
+++ b/meshcentral.js
@@ -3485,14 +3485,65 @@ function CreateMeshCentralServer(config, args) {
                 }
 
                 // Fire external signing job if it is set
-                if (signingArguments.externalsignjob) {
-                    return callExternalSignJob(obj, agentSignCertInfo, signingArguments, xagentSignedFunc);
+                console.log('############# EXTERNAL SIGNING JOB CHECK ##############');
+                if (obj.config.settings.externalsignjob) {
+                    //return callExternalSignJob(obj, agentSignCertInfo, signingArguments, xagentSignedFunc);
+                    console.log('############# EXTERNAL SIGNING JOB CALLED ##############');
+                    console.log(signingArguments);
+                    console.log(agentSignCertInfo);
+                    console.log(xagentSignedFunc); 
+                    console.log(obj);
                 }
             }
         }
 
         if (--pendingOperations === 0) { func(); }
     }
+
+    // function callExternalSignJob(exe, cert, args, func) {
+    //     // External signing process
+    //     exe.prepareForSigning(args, function (err, tempPath) {
+    //         if (err) {
+    //             console.log(err);
+    //             if (exe != null) { exe.close(); }
+    //             func(err);
+    //             return;
+    //         }
+
+    //         // Execute the external signing command
+    //         const { spawnSync } = require('child_process');
+    //         console.log("Running external signing command: " + args.externalsignjob);
+    //         console.log("For file: " + tempPath);
+    //         const signResult = spawnSync('"' + args.externalsignjob + '"', ['"' + tempPath + '"'], {
+    //             shell: true,
+    //             stdio: 'inherit'
+    //         });
+
+    //         if (signResult.error || signResult.status !== 0) {
+    //             console.log("External signing failed");
+    //             if (exe != null) { exe.close(); }
+    //             // try { fs.unlinkSync(tempPath); } catch (ex) { }
+    //             // func("External signing failed");
+    //             return;
+    //         }
+
+    //         // Finalize the signed file
+    //         console.log("Finalizing signed file...");
+    //         exe.finalizeSignedFile(tempPath, args, function (err) {
+    //             if (err) {
+    //                 console.log(err);
+    //                 func(err);
+    //             } else {
+    //                 console.log("Done.");
+    //                 func(null);
+    //             }
+    //             // Clean up temp file
+    //             try { fs.unlinkSync(tempPath); } catch (ex) { }
+    //             if (exe != null) { exe.close(); }
+    //         });
+    //     });
+    // }
+
 
     // Update the list of available mesh agents
     obj.updateMeshAgentsTable = function (domain, func) {

--- a/meshcentral.js
+++ b/meshcentral.js
@@ -3511,6 +3511,7 @@ function CreateMeshCentralServer(config, args) {
         }); 
 
         if (signResult.error || signResult.status !== 0) {
+            obj.debug('main', "External signing failed for file: " + signingArguments.out);
             console.error("External signing failed for file: " + signingArguments.out);
             return;
         }


### PR DESCRIPTION
# externalsignjob - External Code Signing Job

## This adds an option to config.settings called externalsignjob. 

This pull requests consists of changes to the codesigning.md file detailing the externalsignjob feature. 

## What this does

In meshcentral.js, when calling to code sign the agent, mesh central provides a callback. 

This enhancement attaches the signingArguments to the callback function used for code signing. After MeshCentral has completed its update to the agent (such as setting values from domain, etc.) and signed the agent, callExternalSignJob is called. if externalsignjob is not set, it simply returns.  If it is set, it spawns the value in externalsignjob and passes the path to the file for the externalsignjob to process. 

This doesn't have to be used for code signing. For example, it could be used to calculate MD5s of the agent and posted to a website.

## Why this is needed

Public code signing now requires a hardware token. This allows external processes to do codesigning using the administrator's tool of choice. 

Additionally, signing could be done more securely by having the externalsignjob use an internal or cloud server to securely complete the code signing process for the agent.

