### PR TITLE
Fix/invalidate node rights cache  flush

### DIFF
--- a/meshuser.js
+++ b/meshuser.js
@@ -5914,13 +5914,13 @@ module.exports.CreateMeshUser = function (parent, db, ws, req, args, domain, use
                 parent.parent.DispatchEvent(parent.CreateMeshDispatchTargets(mesh, [user._id, newuserid]), obj, event);
                 if (command.remove === true) { msgs.push("Removed user " + newuserid.split('/')[2]); } else { msgs.push("Added user " + newuserid.split('/')[2]); }
                 successCount++;
-                parent.InvalidateNodeCache(newuser, mesh)
             } else {
                 msgs.push("Unknown user " + newuserid.split('/')[2]);
                 unknownUsers.push(newuserid.split('/')[2]);
                 failCount++;
             }
         }
+        parent.FlushGetNodeRightsCache()
     
         if ((successCount == 0) && (failCount == 0)) { msgs.push("Nothing done"); }
     

--- a/meshuser.js
+++ b/meshuser.js
@@ -5776,6 +5776,7 @@ module.exports.CreateMeshUser = function (parent, db, ws, req, args, domain, use
                         if (db.changeStream) { event.noact = 1; } // If DB change stream is active, don't use this event to change the user. Another event will come.
                         parent.parent.DispatchEvent(targets, obj, event);
                     }
+                    parent.InvalidateNodeCache(newuser, node.meshid, node._id)
                 }
             }
     
@@ -5794,7 +5795,6 @@ module.exports.CreateMeshUser = function (parent, db, ws, req, args, domain, use
                 if (db.changeStream) { event.noact = 1; } // If DB change stream is active, don't use this event to change the mesh. Another event will come.
                 parent.parent.DispatchEvent(dispatchTargets, obj, event);
             }
-    
             if (command.responseid != null) { obj.send({ action: 'adddeviceuser', responseid: command.responseid, result: 'ok' }); }
         });
     }
@@ -5914,6 +5914,7 @@ module.exports.CreateMeshUser = function (parent, db, ws, req, args, domain, use
                 parent.parent.DispatchEvent(parent.CreateMeshDispatchTargets(mesh, [user._id, newuserid]), obj, event);
                 if (command.remove === true) { msgs.push("Removed user " + newuserid.split('/')[2]); } else { msgs.push("Added user " + newuserid.split('/')[2]); }
                 successCount++;
+                parent.InvalidateNodeCache(newuser, mesh)
             } else {
                 msgs.push("Unknown user " + newuserid.split('/')[2]);
                 unknownUsers.push(newuserid.split('/')[2]);

--- a/webserver.js
+++ b/webserver.js
@@ -9171,15 +9171,17 @@ module.exports.CreateWebServer = function (parent, db, args, certificates, doneF
         if (typeof mesh == 'string') { meshid = mesh; } else if ((typeof mesh == 'object') && (typeof mesh._id == 'string')) { meshid = mesh._id; } else return 0;
 
         // Check if we have this in the cache
-        const cacheid = user._id + '/' + meshid + '/' + nodeid;
-        const cache = GetNodeRightsCache[cacheid];
+
+        const cache = ((GetNodeRightsCache[user._id] || {})[meshid] || {})[nodeid];
         if (cache != null) { if (cache.t > Date.now()) { return cache.o; } else { GetNodeRightsCacheCount--; } } // Cache hit, or we need to update the cache
-        if (GetNodeRightsCacheCount > 2000) { GetNodeRightsCache = {}; GetNodeRightsCacheCount = 0; } // From time to time, flush the cache
+        if (GetNodeRightsCacheCount > 2000) { obj.FlushGetNodeRightsCache() } // From time to time, flush the cache
 
         var r = obj.GetMeshRights(user, mesh);
         if (r == 0xFFFFFFFF) {
             const out = removeUserRights(r, user);
-            GetNodeRightsCache[cacheid] = { t: Date.now() + 10000, o: out };
+            GetNodeRightsCache[user._id] = GetNodeRightsCache[user._id] || {}
+            GetNodeRightsCache[user._id][meshid] = GetNodeRightsCache[user._id][meshid] || {}
+            GetNodeRightsCache[user._id][meshid][nodeid] = { t: Date.now() + 10000, o: out };
             GetNodeRightsCacheCount++;
             return out;
         }
@@ -9188,7 +9190,9 @@ module.exports.CreateWebServer = function (parent, db, args, certificates, doneF
         if ((user.links != null) && (user.links[nodeid] != null)) { r |= user.links[nodeid].rights; } // TODO: Deal with reverse permissions
         if (r == 0xFFFFFFFF) {
             const out = removeUserRights(r, user);
-            GetNodeRightsCache[cacheid] = { t: Date.now() + 10000, o: out };
+            GetNodeRightsCache[user._id] = GetNodeRightsCache[user._id] || {}
+            GetNodeRightsCache[user._id][meshid] = GetNodeRightsCache[user._id][meshid] || {}
+            GetNodeRightsCache[user._id][meshid][nodeid] = { t: Date.now() + 10000, o: out };
             GetNodeRightsCacheCount++;
             return out;
         }
@@ -9202,9 +9206,43 @@ module.exports.CreateWebServer = function (parent, db, args, certificates, doneF
         }
 
         const out = removeUserRights(r, user);
-        GetNodeRightsCache[cacheid] = { t: Date.now() + 10000, o: out };
+        GetNodeRightsCache[user._id] = GetNodeRightsCache[user._id] || {}
+        GetNodeRightsCache[user._id][meshid] = GetNodeRightsCache[user._id][meshid] || {}
+        GetNodeRightsCache[user._id][meshid][nodeid] = { t: Date.now() + 10000, o: out };
         GetNodeRightsCacheCount++;
         return out;
+    }
+
+    obj.InvalidateNodeCache = function (user, mesh, nodeid) {
+        if (user == null) { return; }
+        
+        if (typeof user == 'string') { user = obj.users[user]; }
+        if (user == null) { return 0; }
+        var meshid;
+        if (typeof mesh == 'string') { meshid = mesh; } else if ((typeof mesh == 'object') && (typeof mesh._id == 'string')) { meshid = mesh._id; };
+        
+        if (mesh == null) {
+            for (let [key, val] of Object.entries(GetNodeRightsCache[user._id] || {})) {
+                GetNodeRightsCacheCount -= Object.keys(val).length
+            }
+            delete GetNodeRightsCache[user._id]; 
+            return;
+        }
+        if (nodeid == null) {
+            let cache_reduction = Object.keys((GetNodeRightsCache[user._id] || {})[meshid] || {}).length
+            delete (GetNodeRightsCache[user._id] || {})[meshid]
+            GetNodeRightsCacheCount -= cache_reduction;
+            return; 
+        }
+        if (((GetNodeRightsCache[user._id] || {})[meshid] || {})[nodeid]) {
+            delete ((GetNodeRightsCache[user._id] || {})[meshid] || {})[nodeid]
+            GetNodeRightsCacheCount--;
+        }
+    }
+
+    obj.FlushGetNodeRightsCache = function() {
+        GetNodeRightsCache = {};
+        GetNodeRightsCacheCount = 0;
     }
 
     // Returns a list of displatch targets for a given mesh

--- a/webserver.js
+++ b/webserver.js
@@ -9171,17 +9171,15 @@ module.exports.CreateWebServer = function (parent, db, args, certificates, doneF
         if (typeof mesh == 'string') { meshid = mesh; } else if ((typeof mesh == 'object') && (typeof mesh._id == 'string')) { meshid = mesh._id; } else return 0;
 
         // Check if we have this in the cache
-
-        const cache = ((GetNodeRightsCache[user._id] || {})[meshid] || {})[nodeid];
+        const cacheid = user._id + '/' + meshid + '/' + nodeid;
+        const cache = GetNodeRightsCache[cacheid];
         if (cache != null) { if (cache.t > Date.now()) { return cache.o; } else { GetNodeRightsCacheCount--; } } // Cache hit, or we need to update the cache
         if (GetNodeRightsCacheCount > 2000) { obj.FlushGetNodeRightsCache() } // From time to time, flush the cache
 
         var r = obj.GetMeshRights(user, mesh);
         if (r == 0xFFFFFFFF) {
             const out = removeUserRights(r, user);
-            GetNodeRightsCache[user._id] = GetNodeRightsCache[user._id] || {}
-            GetNodeRightsCache[user._id][meshid] = GetNodeRightsCache[user._id][meshid] || {}
-            GetNodeRightsCache[user._id][meshid][nodeid] = { t: Date.now() + 10000, o: out };
+            GetNodeRightsCache[cacheid] = { t: Date.now() + 10000, o: out };
             GetNodeRightsCacheCount++;
             return out;
         }
@@ -9190,9 +9188,7 @@ module.exports.CreateWebServer = function (parent, db, args, certificates, doneF
         if ((user.links != null) && (user.links[nodeid] != null)) { r |= user.links[nodeid].rights; } // TODO: Deal with reverse permissions
         if (r == 0xFFFFFFFF) {
             const out = removeUserRights(r, user);
-            GetNodeRightsCache[user._id] = GetNodeRightsCache[user._id] || {}
-            GetNodeRightsCache[user._id][meshid] = GetNodeRightsCache[user._id][meshid] || {}
-            GetNodeRightsCache[user._id][meshid][nodeid] = { t: Date.now() + 10000, o: out };
+            GetNodeRightsCache[cacheid] = { t: Date.now() + 10000, o: out };
             GetNodeRightsCacheCount++;
             return out;
         }
@@ -9206,38 +9202,22 @@ module.exports.CreateWebServer = function (parent, db, args, certificates, doneF
         }
 
         const out = removeUserRights(r, user);
-        GetNodeRightsCache[user._id] = GetNodeRightsCache[user._id] || {}
-        GetNodeRightsCache[user._id][meshid] = GetNodeRightsCache[user._id][meshid] || {}
-        GetNodeRightsCache[user._id][meshid][nodeid] = { t: Date.now() + 10000, o: out };
+        GetNodeRightsCache[cacheid] = { t: Date.now() + 10000, o: out };
         GetNodeRightsCacheCount++;
         return out;
     }
 
     obj.InvalidateNodeCache = function (user, mesh, nodeid) {
-        if (user == null) { return; }
-        
+        if ((user == null) || (mesh == null) || (nodeid == null)) { return 0; }
         if (typeof user == 'string') { user = obj.users[user]; }
         if (user == null) { return 0; }
         var meshid;
-        if (typeof mesh == 'string') { meshid = mesh; } else if ((typeof mesh == 'object') && (typeof mesh._id == 'string')) { meshid = mesh._id; };
-        
-        if (mesh == null) {
-            for (let [key, val] of Object.entries(GetNodeRightsCache[user._id] || {})) {
-                GetNodeRightsCacheCount -= Object.keys(val).length
-            }
-            delete GetNodeRightsCache[user._id]; 
-            return;
-        }
-        if (nodeid == null) {
-            let cache_reduction = Object.keys((GetNodeRightsCache[user._id] || {})[meshid] || {}).length
-            delete (GetNodeRightsCache[user._id] || {})[meshid]
-            GetNodeRightsCacheCount -= cache_reduction;
-            return; 
-        }
-        if (((GetNodeRightsCache[user._id] || {})[meshid] || {})[nodeid]) {
-            delete ((GetNodeRightsCache[user._id] || {})[meshid] || {})[nodeid]
-            GetNodeRightsCacheCount--;
-        }
+        if (typeof mesh == 'string') { meshid = mesh; } else if ((typeof mesh == 'object') && (typeof mesh._id == 'string')) { meshid = mesh._id; } else return 0;
+
+        // Check if we have this in the cache
+        const cacheid = user._id + '/' + meshid + '/' + nodeid;
+        delete GetNodeRightsCache[cacheid];
+        GetNodeRightsCacheCount--;
     }
 
     obj.FlushGetNodeRightsCache = function() {


### PR DESCRIPTION
Invalidate GetNodeRightsCache entries when a user's permissions on a device or mesh.

This is a proposal for https://github.com/Ylianst/MeshCentral/issues/7274.

In short, changing permissions can invalidate cache values, causing some users to not get permissions they should, or causing a user to continue having permissions for 10 seconds after they are removed from a device/mesh.

This version does not change the caching mechanism, instead in the case of a mesh change, it will dump the cache for all users. The alternative is to iterate over all cache entries, which seems like a bad idea. However, this will cause a bunch of cache misses every time a user has their permissions changed, which is not ideal either.