### PR TITLE
manageAllDeviceGroups - Added group support (members of)

### DIFF
--- a/meshcentral-config-schema.json
+++ b/meshcentral-config-schema.json
@@ -686,7 +686,7 @@
           "items": {
             "type": "string"
           },
-          "description": "Users in this list are allowed to see and manage all device groups within their domain. For example ['user//billybob','user//fred'] would allow billybob and fred to manage all device groups from all users in their domain."
+          "description": "Users or groups that users are a member of in this list are allowed to see and manage all device groups within their domain. For example ['user//billybob','user//fred','ugrp//RA...'] would allow billybob, fred and members of ugrp//RA to manage all device groups from all users in their domain."
         },
         "manageCrossDomain": {
           "type": "array",

--- a/meshuser.js
+++ b/meshuser.js
@@ -613,7 +613,7 @@ module.exports.CreateMeshUser = function (parent, db, ws, req, args, domain, use
                 serverinfo.logoutonidlesessiontimeout = true;
             }
             if (user.siteadmin === SITERIGHT_ADMIN) {
-                if (parent.parent.config.settings.managealldevicegroups.indexOf(user._id) >= 0) { serverinfo.manageAllDeviceGroups = true; }
+                if (parent.parent.config.settings.managealldevicegroups.indexOf(user._id) >= 0 || (Object.keys(user.links).some(key => parent.parent.config.settings.managealldevicegroups.indexOf(key) >= 0))) { serverinfo.manageAllDeviceGroups = true; }
                 if (obj.crossDomain === true) { serverinfo.crossDomain = []; for (var i in parent.parent.config.domains) { serverinfo.crossDomain.push(i); } }
                 if (typeof parent.webCertificateExpire[domain.id] == 'number') { serverinfo.certExpire = parent.webCertificateExpire[domain.id]; }
             }
@@ -6749,7 +6749,7 @@ module.exports.CreateMeshUser = function (parent, db, ws, req, args, domain, use
         if (common.validateInt(command.type, 1, 4) == false) return; // Validate type
         if (common.validateInt(command.groupBy, 1, 3) == false) return; // Validate groupBy: 1 = User, 2 = Device, 3 = Day
         if ((typeof command.start != 'number') || (typeof command.end != 'number') || (command.start >= command.end)) return; // Validate start and end time
-        const manageAllDeviceGroups = ((user.siteadmin == 0xFFFFFFFF) && (parent.parent.config.settings.managealldevicegroups.indexOf(user._id) >= 0));
+        const manageAllDeviceGroups = ((user.siteadmin == 0xFFFFFFFF) && (parent.parent.config.settings.managealldevicegroups.indexOf(user._id) >= 0 || (Object.keys(user.links).some(key => parent.parent.config.settings.managealldevicegroups.indexOf(key) >= 0))));
         if ((command.devGroup != null) && (manageAllDeviceGroups == false) && ((user.links == null) || (user.links[command.devGroup] == null))) return; // Asking for a device group that is not allowed
 
         const msgIdFilter = [5, 10, 11, 12, 122, 123, 124, 125, 126, 144];


### PR DESCRIPTION
Hi,
I did two modifications:

1. manageAllDeviceGroups
When adding a group to the array manageAllDeviceGroups like:
`"manageAllDeviceGroups": [ "ugrp//RAsh5nG6h0kk$SadJut@cJsiQekjwisy1IYqntP68VWNG@2zvn6r32hMJAC4RLYj" ]`
also the members of the group are super user and can access all devices in the specified domain.

2. Mapping between users and groups
I noticed that when I restart MeshCentral, the relation between user and its groups are lost. When logging in, the connection is only in the memory, but does not recover after a restart. The function just loops through the groups that still have the information about the user matching and restores the connection. This is in relation with bullet point 1, because even when a user is a member of a group, the super user role was lost in case of a restart.