### PR TITLE
Add a custom.js support in the same way we have custom.css (as proposed by Melo-Professional)

### DIFF
--- a/views/agentinvite.handlebars
+++ b/views/agentinvite.handlebars
@@ -12,6 +12,7 @@
     <link rel="apple-touch-icon" href="/favicon-303x303.png" />
     <script type="text/javascript" src="scripts/common-0.0.1{{min}}.js"></script>
     <script type="text/javascript" src="scripts/qrcode.min.js"></script>
+    <script type="text/javascript" src="scripts/custom.js"></script>
     <title>Agent Installation</title>
     <style>
         .tab {

--- a/views/default.handlebars
+++ b/views/default.handlebars
@@ -50,6 +50,7 @@
     <script keeplink=1 type="text/javascript" src="scripts/ol3-contextmenu{{{min}}}.js"></script>
     <script keeplink=1 type="text/javascript" src="scripts/purify{{{min}}}.js"></script>
     <script keeplink=1 type="text/javascript" src="scripts/marked{{{min}}}.js"></script>
+    <script type="text/javascript" src="scripts/custom.js"></script>
     <title>{{{title}}}</title>
 </head>
 <body id="body" oncontextmenu="handleContextMenu(event)" style="display:none;min-width:495px" onload="if (typeof(startup) !== 'undefined') startup();">

--- a/views/default3.handlebars
+++ b/views/default3.handlebars
@@ -59,6 +59,7 @@
     <script keeplink=1 type="text/javascript" src="scripts/ol3-contextmenu{{{min}}}.js"></script>
     <script keeplink=1 type="text/javascript" src="scripts/purify{{{min}}}.js"></script>
     <script keeplink=1 type="text/javascript" src="scripts/marked{{{min}}}.js"></script>
+    <script type="text/javascript" src="scripts/custom.js"></script>
     <title>{{{title}}}</title>
 </head>
 

--- a/views/invite.handlebars
+++ b/views/invite.handlebars
@@ -11,6 +11,7 @@
     <link type="text/css" href="styles/custom.css" media="screen" rel="stylesheet" title="CSS" />
     <link rel="apple-touch-icon" href="/favicon-303x303.png" />
     <script type="text/javascript" src="scripts/common-0.0.1{{min}}.js"></script>
+    <script type="text/javascript" src="scripts/custom.js"></script>
     <title>Agent Installation</title>
     <style>
         .tab {

--- a/views/login2.handlebars
+++ b/views/login2.handlebars
@@ -14,6 +14,7 @@
     <link rel="apple-touch-icon" href="/favicon-303x303.png" />
     <script type="text/javascript" src="scripts/common-0.0.1{{min}}.js"></script>
     <script keeplink=1 type="text/javascript" src="scripts/u2f-api{{min}}.js"></script>
+    <script type="text/javascript" src="scripts/custom.js"></script>
     <title>{{{title}}} - Login</title>
     <style>
         #body {

--- a/views/message2.handlebars
+++ b/views/message2.handlebars
@@ -11,6 +11,7 @@
     <link type="text/css" href="styles/custom.css" media="screen" rel="stylesheet" title="CSS" />
     <link rel="apple-touch-icon" href="/favicon-303x303.png" />
     <script type="text/javascript" src="scripts/common-0.0.1{{min}}.js"></script>
+    <script type="text/javascript" src="scripts/custom.js"></script>
     <title id="topTitle">{{{title1}}}</title>
     <style>
         body {

--- a/views/messenger.handlebars
+++ b/views/messenger.handlebars
@@ -13,6 +13,7 @@
     <link rel="apple-touch-icon" href="/favicon-303x303.png" />
     <script type="text/javascript" src="scripts/common-0.0.1{{min}}.js"></script>
     <script type="text/javascript" src="scripts/filesaver.min.js"></script>
+    <script type="text/javascript" src="scripts/custom.js"></script>
 </head>
 <body style="font-family:Arial,Helvetica,sans-serif">
     <div id="xtop" style="position:absolute;left:0;right:0;top:0;height:38px;background-color:#036;color:#EEE;box-shadow:3px 3px 10px gray">

--- a/views/player.handlebars
+++ b/views/player.handlebars
@@ -23,6 +23,7 @@
     <script type="text/javascript" src="scripts/xterm-addon-fit-min.js"></script>
     <script keeplink=1 type="text/javascript" src="scripts/webm-writer.js"></script>
     <script keeplink=1 type="text/javascript" src="scripts/filesaver.min.js"></script>
+    <script type="text/javascript" src="scripts/custom.js"></script>
 </head>
 <body style="overflow:hidden;background-color:black">
     <div id=p11 class="noselect" style="overflow:hidden">

--- a/views/sharing.handlebars
+++ b/views/sharing.handlebars
@@ -28,6 +28,7 @@
     <script type="text/javascript" src="scripts/xterm{{{min}}}.js"></script>
     <script type="text/javascript" src="scripts/xterm-addon-fit{{{min}}}.js"></script>
     <script keeplink=1 type="text/javascript" src="scripts/filesaver.min.js"></script>
+    <script type="text/javascript" src="scripts/custom.js"></script>
     <title>{{{title}}}</title>
 </head>
 <body style="overflow:hidden;background-color:black">


### PR DESCRIPTION
Implements this feature proposal: https://github.com/Ylianst/MeshCentral/issues/7314

custom.js is loaded after the rest of the js scripts in the <header> section.