### PR TITLE
fix: honor settings.autobackup.backuppath everywhere

### DIFF
--- a/meshcentral.js
+++ b/meshcentral.js
@@ -116,9 +116,12 @@ function CreateMeshCentralServer(config, args) {
     });
 
     // Look to see if data and/or file path is specified
-    if (obj.config.settings && (typeof obj.config.settings.datapath == 'string')) { obj.datapath = obj.config.settings.datapath; }
-    if (obj.config.settings && (typeof obj.config.settings.filespath == 'string')) { obj.filespath = obj.config.settings.filespath; }
-
+    if (obj.config.settings) {
+        if (typeof obj.config.settings.datapath == 'string') { obj.datapath = obj.config.settings.datapath; }
+        if (typeof obj.config.settings.filespath == 'string') { obj.filespath = obj.config.settings.filespath; }
+        if (typeof obj.config.settings.autobackup.backuppath == 'string') { obj.backuppath = obj.config.settings.autobackup.backuppath; }
+    }
+    
     // Create data and files folders if needed
     try { obj.fs.mkdirSync(obj.datapath); } catch (ex) { }
     try { obj.fs.mkdirSync(obj.filespath); } catch (ex) { }


### PR DESCRIPTION
make obj.backuppath single source of truth

Deleting old backups failed when using a non-default folder because `settings.autobackup.backuppath` from `config.json` was not respected consistently.

- Set `obj.backuppath` from `config.json` at startup (when configured)

Follow-up: The lookups of parent.config.settings.autobackup in `db.js` are now redundant and should be removed the next time `db.js` is touched.