### PR TITLE
Fix remove login token modal callback

### DIFF
--- a/views/default3.handlebars
+++ b/views/default3.handlebars
@@ -14584,7 +14584,7 @@
             x += addHtmlValue("Name", EscapeHtml(token.name));
             x += addHtmlValue("Username", EscapeHtml(token.tokenUser));
             setModalContent('xxAddAgent', "Remove Login Token", x);
-            showModal('xxAddAgentModal', 'idx_dlgOkButton', () => function (b, tokenUser) { meshserver.send({ action: 'loginTokens', remove: [tokenUser] }); });
+            showModal('xxAddAgentModal', 'idx_dlgOkButton', function () { meshserver.send({ action: 'loginTokens', remove: [tokenUser] }); });
         }
 
         function gotoMesh(meshid) {


### PR DESCRIPTION
Corrected the callback function for the ‘Remove Login Token’ modal to properly execute the token removal. The previous implementation incorrectly wrapped the callback in an arrow function returning another function, preventing the logic from running.