### PR TITLE
Remove "Try the new MeshCentral UI" message when using the modern UI

### DIFF
--- a/public/styles/style-bootstrap.css
+++ b/public/styles/style-bootstrap.css
@@ -472,16 +472,13 @@ body {
 }
 
 #footer {
-    -ms-grid-column: 2;
-    -ms-grid-row: 4;
-    grid-area: footer;
-    clear: both;
-    overflow: auto;
+    position: fixed;
+    bottom: 0;
+    left: 0;
     width: 100%;
-    text-align: center;
     background-color: #113962;
-    padding-top: 5px;
-    padding-bottom: 5px;
+    padding: 5px 0;
+    text-align: center;
 }
 
 .fulldesk #footer {

--- a/views/default3.handlebars
+++ b/views/default3.handlebars
@@ -1664,7 +1664,7 @@
         </div>
         <div id="footer">
             <div class="footer1">{{{footer}}}</div>
-            <div class="footer2" style="display:none;">
+            <div class="footer2">
                 <div class="row">
                     <div class="col-md-6 d-flex gap-2">
                     </div>


### PR DESCRIPTION
- Remove unnecessary **"Try the new MeshCentral UI"** message in modern UI
- Show Terms & Privacy in modern UI
- Fix footer styling across screen sizes

Screenshots
<img width="1919" height="451" alt="Screenshot from 2025-10-29 11-29-10" src="https://github.com/user-attachments/assets/006bc35b-441e-4e3e-83d8-77668cd6fa3c" />

<img width="1911" height="820" alt="Screenshot from 2025-10-29 10-49-18" src="https://github.com/user-attachments/assets/6d8b9962-a421-4e05-8f9d-993c350cada1" />
