### PR TITLE
Add mobile bootstrap CSS and mobile view template

### DIFF
--- a/public/styles/style-mobile-bootstrap.css
+++ b/public/styles/style-mobile-bootstrap.css
@@ -1,0 +1,3192 @@
+.masthead-container {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 8px 16px;
+    background: linear-gradient(to bottom, #104893 0%, #113962 100%);
+    min-height: 50px;
+    color: #c8c8c8;
+    position: relative;
+    width: 100%;
+    box-sizing: border-box;
+    padding-top: calc(8px + env(safe-area-inset-top));
+    padding-left: calc(16px + env(safe-area-inset-left));
+    padding-right: calc(16px + env(safe-area-inset-right));
+    height: calc(50px + env(safe-area-inset-top));
+}
+
+#masthead {
+    background-size: 18rem 2.5rem !important;
+    background-position: center left;
+    background-repeat: no-repeat !important;
+    padding-right: 20px !important;
+    background-image: url(../logo.png);
+    background-color: #036;
+}
+
+.masthead-left {
+    display: flex;
+    align-items: center;
+    flex: 1;
+}
+
+.masthead-title {
+    cursor: pointer;
+    font-size: 24px;
+    font-weight: bold;
+    text-shadow: 1px 1px 2px #000;
+}
+
+.masthead-titles-container {
+    margin-left: 10px;
+    display: flex;
+    flex-direction: column;
+}
+
+.masthead-titles-container .title {
+    font-size: 18px;
+    font-weight: bold;
+    text-shadow: 1px 1px 2px #000;
+    cursor: pointer;
+}
+
+.masthead-titles-container .title2 {
+    font-size: 12px;
+    text-shadow: 1px 1px 2px #000;
+    cursor: pointer;
+}
+
+.masthead-right {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+}
+
+.notification-icon {
+    cursor: pointer;
+    padding: 4px;
+}
+
+.user-menu-container {
+    display: flex;
+    align-items: center;
+    position: relative;
+    left: 18px;
+}
+
+#userDropdown {
+    position: relative;
+    background: #00000026;
+    border-radius: 4px;
+    display: inline-block;
+}
+
+#userDropdownButton {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    cursor: pointer;
+    padding: 4px 8px;
+    border-radius: 4px;
+}
+
+#userDropdownButton:hover {
+    background-color: rgba(255, 255, 255, 0.1);
+}
+
+#userDropdownImage {
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+    border: 2px solid rgba(255, 255, 255, 0.3);
+    object-fit: cover;
+}
+
+#userDropdownName {
+    color: #c8c8c8;
+    font-size: 14px;
+}
+
+.LogoffLinkColor {
+    color: #c8c8c8;
+}
+
+#userDropdownMenu {
+    display: none;
+    position: absolute;
+    top: 100%;
+    right: 0;
+    background-color: #f3f3f3;
+    box-shadow: 0 0 12px rgba(0, 0, 0, 0.3);
+    border-radius: 10px;
+    z-index: 200000;
+    min-width: 200px;
+    margin-top: 4px;
+    font-family: sans-serif;
+    font-size: small;
+    pointer-events: auto;
+}
+
+.night #userDropdownMenu {
+    background-color: #292c2c;
+}
+
+#userDropdownMenuContainer {
+    padding: 6px 0;
+}
+
+.userDropdownMenuItem {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 12px;
+    cursor: pointer;
+    color: #000;
+    white-space: nowrap;
+    transition: background-color 0.15s ease;
+    font-size: small;
+}
+
+.night .userDropdownMenuItem {
+    color: #c8c8c8;
+}
+
+.userDropdownMenuItem:hover {
+    background-color: rgba(129, 129, 129, 0.3);
+    border-radius: 4px;
+}
+
+.userDropdownMenuIcon {
+    width: 18px;
+    height: 18px;
+    flex-shrink: 0;
+    text-align: center;
+}
+
+.userDropdownMenuItem span {
+    flex-grow: 1;
+    text-align: left;
+    font-size: small;
+    line-height: 1.2;
+}
+
+#userDropdownMenuDivider {
+    border-top: 1px solid rgba(0, 0, 0, 0.25);
+    margin: 4px 0;
+}
+
+.night #userDropdownMenuDivider {
+    border-top: 1px solid rgba(255, 255, 255, 0.25);
+}
+
+.userDropdownMobileOnly {
+    display: block;
+}
+
+.position-relative {
+    position: relative;
+}
+
+.position-absolute {
+    position: absolute;
+}
+
+.top-1 {
+    top: 0.25rem;
+}
+
+.start-100 {
+    left: 100%;
+}
+
+.translate-middle {
+    transform: translate(-50%, -50%);
+}
+
+.badge {
+    display: inline-block;
+    padding: 0.25em 0.4em;
+    font-size: 0.75em;
+    font-weight: 700;
+    line-height: 1;
+    text-align: center;
+    white-space: nowrap;
+    vertical-align: baseline;
+}
+
+.rounded-pill {
+    border-radius: 50rem;
+}
+
+.bg-danger {
+    background-color: #dc3545;
+    color: #fff;
+}
+
+.text-white {
+    color: #fff;
+}
+
+.fa-xl {
+    font-size: 1.5em;
+    line-height: 0.04167em;
+    vertical-align: -0.125em;
+}
+
+.d-flex {
+    display: flex;
+}
+
+.align-items-center {
+    align-items: center;
+}
+
+.flex-wrap {
+    flex-wrap: wrap;
+}
+
+.gap-2 {
+    gap: 0.5rem;
+}
+
+.form-check {
+    display: flex;
+    align-items: center;
+}
+
+.form-check-input {
+    margin-right: 0.5rem;
+}
+
+.form-check-label {
+    margin: 0;
+    cursor: pointer;
+}
+
+#devListToolbarSpan {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    padding: 4px 10px;
+    background: linear-gradient(to bottom, #f5f5f5 0%, #e8e8e8 100%);
+    height: 36px;
+    display: flex;
+    align-items: center;
+    z-index: 100;
+    border-top: 1px solid #d0d0d0;
+    box-shadow: 0 -1px 3px rgba(0, 0, 0, 0.08);
+}
+
+.night #devListToolbarSpan {
+    background: linear-gradient(to top, #404040 0%, #2a2a2a 100%);
+    border-top-color: #555;
+}
+
+#devListToolbarSpan > .d-flex > div:first-child {
+    position: relative;
+}
+
+#SearchInputClearButton {
+    position: absolute;
+    right: 8px;
+    top: 50%;
+    transform: translateY(-50%);
+    cursor: pointer;
+    width: 18px;
+    height: 18px;
+    background-color: rgba(0, 0, 0, 0.1);
+    border-radius: 50%;
+    align-items: center;
+    justify-content: center;
+    display: none;
+    transition: background-color 0.2s ease;
+    z-index: 10;
+}
+
+#SearchInputClearButton[style*="flex"] {
+    display: flex !important;
+}
+
+#SearchInputClearButton:hover {
+    background-color: rgba(0, 0, 0, 0.3) !important;
+}
+
+#SearchInputClearButton i {
+    color: #666;
+    font-size: 11px;
+    line-height: 1;
+    display: block;
+}
+
+.night #SearchInputClearButton i {
+    color: #aaa;
+}
+
+#SearchInput {
+    width: 100%;
+    padding: 6px 32px 6px 10px;
+    height: 28px;
+    background-color: #fff;
+    border: 1px solid #d2d2d7;
+    border-radius: 6px;
+    font-size: 13px;
+    color: #1d1d1f;
+    transition: all 0.15s ease;
+    box-sizing: border-box;
+}
+
+#SearchInput::-webkit-search-cancel-button {
+    display: none;
+    -webkit-appearance: none;
+}
+
+#SearchInput::-ms-clear {
+    display: none;
+}
+
+#SearchInput:focus {
+    outline: none;
+    border-color: #007AFF;
+    background-color: #fff;
+    box-shadow: 0 0 0 3px rgba(0, 122, 255, 0.1);
+}
+
+.night #SearchInput {
+    background-color: #2a2a2a;
+    border-color: #555;
+    color: #fff;
+}
+
+.night #SearchInput:focus {
+    background-color: #2a2a2a;
+    border-color: #007AFF;
+    box-shadow: 0 0 0 3px rgba(0, 122, 255, 0.2);
+}
+
+#devListToolbarSpan .form-check {
+    margin: 0 8px 0 0;
+    color: #1d1d1f;
+    white-space: nowrap;
+}
+
+.night #devListToolbarSpan .form-check {
+    color: #ddd;
+}
+
+#devListToolbarSpan .form-check-wrapper {
+    position: relative;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 18px;
+    height: 18px;
+    margin-right: 6px;
+    vertical-align: middle;
+}
+
+#devListToolbarSpan .form-check-input {
+    margin: 0;
+    width: 18px;
+    height: 18px;
+    min-width: 18px;
+    min-height: 18px;
+    cursor: pointer;
+    accent-color: #007AFF;
+    border: 1.5px solid #d2d2d7;
+    border-radius: 50%;
+    transition: all 0.15s ease;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+    appearance: none;
+    background-color: #fff;
+    position: absolute;
+    top: 0;
+    left: 0;
+    padding: 0;
+    flex-shrink: 0;
+}
+
+#devListToolbarSpan .form-check-input:checked {
+    background-color: #007AFF;
+    border-color: #007AFF;
+}
+
+#devListToolbarSpan .form-check-input:checked ~ .form-check-icon {
+    display: block;
+    color: #fff;
+}
+
+#devListToolbarSpan .form-check-icon {
+    display: none;
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    transform: translate(-50%, -50%);
+    font-size: 10px;
+    pointer-events: none;
+    z-index: 1;
+    line-height: 1;
+}
+
+.night #devListToolbarSpan .form-check-input {
+    border-color: #555;
+    background-color: #2a2a2a;
+}
+
+.night #devListToolbarSpan .form-check-input:checked {
+    background-color: #007AFF;
+    border-color: #007AFF;
+}
+
+.night #devListToolbarSpan .form-check-input:checked ~ .form-check-icon {
+    display: block;
+    color: #fff;
+}
+
+#devListToolbarSpan .form-check-label {
+    margin: 0;
+    font-size: 13px;
+    cursor: pointer;
+    user-select: none;
+    font-weight: 500;
+    color: #1d1d1f;
+    vertical-align: middle;
+    display: inline-block;
+    line-height: 18px;
+}
+
+.night #devListToolbarSpan .form-check-label {
+    color: #ddd;
+}
+
+#devListToolbarSpan .form-check {
+    display: flex;
+    align-items: center;
+}
+
+
+#p2 {
+    padding-top: 50px;
+}
+
+#p2 #devListToolbarSpan {
+    top: 0;
+    height: auto;
+    min-height: 52px;
+}
+
+#p2 #xdevices {
+    top: 70px;
+}
+
+body {
+    background-color: white;
+}
+
+.night body {
+    background-color: black;
+}
+
+#MxMESH {
+    color: black;
+}
+
+.night #MxMESH {
+    color: lightgray;
+}
+
+.textOverGray {
+    color: black;
+}
+
+#dialog {
+    z-index: 1000;
+    background-color: #EEE;
+    box-shadow: 0px 0px 15px #666;
+    font-family: Arial, Helvetica, sans-serif;
+    border-radius: 5px;
+    position: fixed;
+    top: 90px;
+    width: 300px;
+}
+
+.night #dialog {
+    color: black;
+    background-color: #AAA;
+}
+
+:focus {
+    outline: 0;
+}
+
+a {
+    color: #036;
+    text-decoration: underline;
+}
+
+.night a {
+    color: #99F;
+}
+
+#top-bar {
+    padding-bottom: env(safe-area-inset-bottom);
+    padding-left: env(safe-area-inset-left);
+    padding-right: env(safe-area-inset-right);
+    box-sizing: border-box;
+}
+
+#topBarMenu {
+    table-layout: fixed;
+    width: 100%;
+}
+
+#topBarMenu td {
+    width: calc(100% / 6);
+    text-align: center;
+    vertical-align: middle;
+    padding: 0 4px;
+}
+
+#top-bar a {
+    color: #fff;
+    text-decoration: underline;
+}
+
+#top-bar a:hover {
+    text-decoration: none;
+}
+
+.night #top-bar {
+    color: gray;
+}
+
+.i1 {
+    background: url(../images/icons50.png) 0px 0px;
+    background-image: image-set(url(../images/icons50.png) 1x, url(../images/icons100.png) 2x);
+    height: 50px;
+    width: 50px;
+    border: none;
+}
+
+.i2 {
+    background: url(../images/icons50.png) -50px 0px;
+    background-image: image-set(url(../images/icons50.png) 1x, url(../images/icons100.png) 2x);
+    height: 50px;
+    width: 50px;
+    border: none;
+}
+
+.i3 {
+    background: url(../images/icons50.png) -100px 0px;
+    background-image: image-set(url(../images/icons50.png) 1x, url(../images/icons100.png) 2x);
+    height: 50px;
+    width: 50px;
+    border: none;
+}
+
+.i4 {
+    background: url(../images/icons50.png) -150px 0px;
+    background-image: image-set(url(../images/icons50.png) 1x, url(../images/icons100.png) 2x);
+    height: 50px;
+    width: 50px;
+    border: none;
+}
+
+.i5 {
+    background: url(../images/icons50.png) -200px 0px;
+    background-image: image-set(url(../images/icons50.png) 1x, url(../images/icons100.png) 2x);
+    height: 50px;
+    width: 50px;
+    border: none;
+}
+
+.i6 {
+    background: url(../images/icons50.png) -250px 0px;
+    background-image: image-set(url(../images/icons50.png) 1x, url(../images/icons100.png) 2x);
+    height: 50px;
+    width: 50px;
+    border: none;
+}
+
+.i7 {
+    background: url(../images/icons50.png) -300px 0px;
+    background-image: image-set(url(../images/icons50.png) 1x, url(../images/icons100.png) 2x);
+    height: 50px;
+    width: 50px;
+    border: none;
+}
+
+.i8 {
+    background: url(../images/icons50.png) -350px 0px;
+    background-image: image-set(url(../images/icons50.png) 1x, url(../images/icons100.png) 2x);
+    height: 50px;
+    width: 50px;
+    border: none;
+}
+
+.m0 {
+    background: url(../images/images16.png) -32px 0px;
+    height: 16px;
+    width: 16px;
+    border: none;
+    float: left;
+}
+
+.m1 {
+    background: url(../images/images16.png) -16px 0px;
+    height: 16px;
+    width: 16px;
+    border: none;
+    float: left;
+}
+
+.m2 {
+    background: url(../images/images16.png) -96px 0px;
+    height: 16px;
+    width: 16px;
+    border: none;
+    float: left;
+}
+
+.m3 {
+    background: url(../images/images16.png) -112px 0px;
+    height: 16px;
+    width: 16px;
+    border: none;
+    float: left;
+}
+
+.m4 {
+    background: url(../images/images16.png) -128px 0px;
+    height: 16px;
+    width: 16px;
+    border: none;
+    float: left;
+}
+
+.NotifyIconSmall1 {
+    width: 24px;
+    height: 24px;
+    background: url(../images/notify24.png) 0px 0px;
+    background-image: image-set(url(../images/notify24.png) 1x, url(../images/notify48.png) 2x);
+}
+
+.NotifyIconSmall2 {
+    width: 24px;
+    height: 24px;
+    background: url(../images/notify24.png) -24px 0px;
+    background-image: image-set(url(../images/notify24.png) 1x, url(../images/notify48.png) 2x);
+}
+
+.NotifyIconSmall3 {
+    width: 24px;
+    height: 24px;
+    background: url(../images/notify24.png) -48px 0px;
+    background-image: image-set(url(../images/notify24.png) 1x, url(../images/notify48.png) 2x);
+}
+
+.NotifyIconSmall4 {
+    width: 24px;
+    height: 24px;
+    background: url(../images/notify24.png) -72px 0px;
+    background-image: image-set(url(../images/notify24.png) 1x, url(../images/notify48.png) 2x);
+}
+
+.NotifyIconSmall5 {
+    width: 24px;
+    height: 24px;
+    background: url(../images/notify24.png) -96px 0px;
+    background-image: image-set(url(../images/notify24.png) 1x, url(../images/notify48.png) 2x);
+}
+
+.NotifyIconSmall6 {
+    width: 24px;
+    height: 24px;
+    background: url(../images/notify24.png) -120px 0px;
+    background-image: image-set(url(../images/notify24.png) 1x, url(../images/notify48.png) 2x);
+}
+
+.NotifyIconSmall7 {
+    width: 24px;
+    height: 24px;
+    background: url(../images/notify24.png) -144px 0px;
+    background-image: image-set(url(../images/notify24.png) 1x, url(../images/notify48.png) 2x);
+}
+
+.NotifyIconSmall8 {
+    width: 24px;
+    height: 24px;
+    background: url(../images/notify24.png) -168px 0px;
+    background-image: image-set(url(../images/notify24.png) 1x, url(../images/notify48.png) 2x);
+}
+
+.NotifyIconSmall9 {
+    width: 24px;
+    height: 24px;
+    background: url(../images/notify24.png) -192px 0px;
+    background-image: image-set(url(../images/notify24.png) 1x, url(../images/notify48.png) 2x);
+}
+
+.gray {
+    filter: gray;
+    -webkit-filter: grayscale(100%) opacity(60%);
+}
+
+.DevSt {
+    padding-left: 5px;
+    border-bottom-style: solid;
+    border-bottom-width: 1px;
+    border-bottom-color: #DDDDDD;
+}
+
+.noselect {
+    -webkit-touch-callout: none;
+    -webkit-user-select: none;
+    -khtml-user-select: none;
+    -moz-user-select: none;
+    -ms-user-select: none;
+    user-select: none;
+}
+
+.fileIcon1 {
+    background: url(data:image/gif;base64,R0lGODlhEAAQAJEDAPb49Y2Sj9LT2f///yH5BAEAAAMALAAAAAAQABAAAAImnI+py+1vhJwyUYAzHTL4D3qdlJWaIFJqmKod607sDKIiDUP63hQAOw==);
+    height: 16px;
+    width: 16px;
+    cursor: pointer;
+    border: none;
+    float: left;
+    margin-top: 1px;
+}
+
+.fileIcon2 {
+    background: url(data:image/gif;base64,R0lGODlhEAAQAJEDAM2xV/Xur+XPgP///yH5BAEAAAMALAAAAAAQABAAAAJD3ISZIGHWUGihznesYDYATFVM+D2hJ4lgN1olxALAtAlmPCJvuMmJd6PJckDYwicrHhTD5o7plJmg0Uc0asNMkphHAQA7);
+    height: 16px;
+    width: 16px;
+    cursor: pointer;
+    border: none;
+    float: left;
+    margin-top: 1px;
+}
+
+.fileIcon3 {
+    background: url(data:image/gif;base64,R0lGODlhEAAQAJEDAPb19IGBgbq6uv///yH5BAEAAAMALAAAAAAQABAAAAIy3ISpxgcPH2ouQgFEw1YmxnUXKEaaEZZnVWZk66JwzKpvuwZzwOgwb/C1gIOA8Yg8DgoAOw==);
+    height: 16px;
+    width: 16px;
+    cursor: pointer;
+    border: none;
+    float: left;
+    margin-top: 1px;
+}
+
+.fileIcon4 {
+    background: url(../images/meshicon16.png);
+    height: 16px;
+    width: 16px;
+    cursor: pointer;
+    border: none;
+    float: left;
+    margin-top: 1px;
+}
+
+.filelist {
+     user-select: none;
+    -moz-user-select: none;
+    -khtml-user-select: none;
+    -webkit-user-select: none;
+    -o-user-select: none;
+    cursor: default;
+    -khtml-user-drag: element;
+    clear: both;
+}
+
+.deviceNotifyDot {
+    position: absolute;
+    right: 10px;
+    top: 0px;
+    height: 16px;
+}
+
+.deviceNotifyDotSub {
+    text-align: center;
+    color: #FFF;
+    width: 16px;
+    background-color: #00F;
+    padding: 2px;
+    border-radius: 10px;
+    box-shadow: 2px 2px 10px black;
+    cursor: pointer;
+    margin-left: 3px;
+    float: left;
+}
+
+.deviceNotifyDotSub:hover {
+    background-color: #44F;
+}
+
+.deviceNotifySmallDot {
+    position: absolute;
+    right: 10px;
+    top: 0px;
+    height: 10px;
+}
+
+.deviceNotifySmallDotSub {
+    text-align: center;
+    color: #FFF;
+    width: 10px;
+    padding: 2px;
+    background-color: #00F;
+    border-radius: 10px;
+    box-shadow: 2px 2px 10px black;
+    cursor: pointer;
+    margin-left: 2px;
+    float: left;
+}
+
+.deviceNotifySmallDotSub:hover {
+    background-color: #44F;
+}
+
+.deviceNotifyLargeDot {
+    position: absolute;
+    right: 10px;
+    top: 10px;
+    height: 40px;
+}
+
+.deviceNotifyLargeDotSub {
+    text-align: center;
+    width: 35px;
+    height: 35px;
+    color: #FFF;
+    padding: 2px;
+    background-color: #00F;
+    border-radius: 20px;
+    box-shadow: 2px 2px 10px black;
+    cursor: pointer;
+    margin-left: 4px;
+    font-size: 30px;
+    float: left;
+}
+
+.deviceNotifyLargeDotSub:hover {
+    background-color: #44F;
+}
+
+.style10 {
+    background-color: #C9C9C9;
+    color: #000;
+}
+
+.night .style10 {
+    background-color: #888;
+}
+
+.deviceBatteryLarge {
+    position: absolute;
+    right: 10px;
+    top: 0px;
+    width: 28px;
+    height: 48px;
+    border: none;
+    box-shadow: none;
+}
+
+.deviceBatteryLarge1 {
+    background: url(../images/batteries48.png) 0px 0px;
+}
+
+.deviceBatteryLarge2 {
+    background: url(../images/batteries48.png) -28px 0px;
+}
+
+.deviceBatteryLarge3 {
+    background: url(../images/batteries48.png) -56px 0px;
+}
+
+.deviceBatteryLarge4 {
+    background: url(../images/batteries48.png) -84px 0px;
+}
+
+.deviceBatteryLarge5 {
+    background: url(../images/batteries48.png) -112px 0px;
+}
+
+.deviceBatteryLarge6 {
+    background: url(../images/batteries48.png) -140px 0px;
+}
+
+.deviceBatteryLarge7 {
+    background: url(../images/batteries48.png) -168px 0px;
+}
+
+.deviceBatteryLarge8 {
+    background: url(../images/batteries48.png) -196px 0px;
+}
+
+.deviceBatteryLarge9 {
+    background: url(../images/batteries48.png) -224px 0px;
+}
+
+.deviceBatteryLarge10 {
+    background: url(../images/batteries48.png) -252px 0px;
+}
+
+.deviceBatteryLarge11 {
+    background: url(../images/batteries48.png) -280px 0px;
+}
+
+.deviceBatterySmall {
+    position: absolute;
+    left: 6px;
+    top: 22px;
+    width: 14px;
+    height: 24px;
+    border: none;
+    box-shadow: none;
+}
+
+.deviceBatterySmall1 {
+    background: url(../images/batteries24.png) 0px 0px;
+}
+
+.deviceBatterySmall2 {
+    background: url(../images/batteries24.png) -14px 0px;
+}
+
+.deviceBatterySmall3 {
+    background: url(../images/batteries24.png) -28px 0px;
+}
+
+.deviceBatterySmall4 {
+    background: url(../images/batteries24.png) -42px 0px;
+}
+
+.deviceBatterySmall5 {
+    background: url(../images/batteries24.png) -56px 0px;
+}
+
+.deviceBatterySmall6 {
+    background: url(../images/batteries24.png) -70px 0px;
+}
+
+.deviceBatterySmall7 {
+    background: url(../images/batteries24.png) -84px 0px;
+}
+
+.deviceBatterySmall8 {
+    background: url(../images/batteries24.png) -98px 0px;
+}
+
+.deviceBatterySmall9 {
+    background: url(../images/batteries24.png) -112px 0px;
+}
+
+.deviceBatterySmall10 {
+    background: url(../images/batteries24.png) -126px 0px;
+}
+
+.deviceBatterySmall11 {
+    background: url(../images/batteries24.png) -140px 0px;
+}
+
+.meshList {
+    width: auto;
+    height: 40px;
+    background-color: lightgray;
+    margin-top: 5px;
+    margin-bottom: 5px;
+    margin-left: 60px;
+    padding-top: 5px;
+    padding-bottom: 5px;
+    border-radius: 8px 0px 0px 8px;
+}
+
+.night .meshList {
+    background-color: gray;
+}
+
+.devList1 {
+    height: 50px;
+    cursor: pointer;
+    position: relative;
+    margin-top: 5px;
+    margin-bottom: 5px;
+}
+
+.devList2 {
+    float: left;
+    margin-left: 4px;
+}
+
+.devList3 {
+    width: auto;
+    height: 40px;
+    background-color: lightgray;
+    margin-left: 60px;
+    padding-top: 5px;
+    padding-bottom: 5px;
+    border-radius: 8px 0px 0px 8px;
+}
+
+.night .devList3 {
+    background-color: gray;
+}
+
+.devList4 {
+    padding-left: 12px;
+    padding-top: 2px;
+    color: black;
+}
+
+.devList5 {
+    padding-left: 12px;
+    padding-top: 3px;
+    color: #444;
+}
+
+.night .devList5 {
+    color: black;
+}
+
+.deskButton {
+    box-shadow: 0px 0px 10px #000;
+    border-radius: 20px;
+    position: absolute;
+    right: 10px;
+    top: 10px;
+    cursor: pointer;
+    background-color: #AAA;
+    z-index: 1000;
+}
+
+.menuButton {
+    box-shadow: 0px 0px 10px #000;
+    border-radius: 10px;
+    display: inline-block;
+    width: 120px;
+    background-color: #AAA;
+    text-align: center;
+    padding: 8px;
+    cursor: pointer;
+    margin: 10px;
+    z-index: 1000;
+}
+
+#notificationCount {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    height: 40px;
+    padding: 6px 8px;
+    border-radius: 4px;
+    position: relative;
+    flex: 0 0 auto;
+    min-width: unset;
+    margin: 0;
+}
+
+#notificationCount:hover {
+    background-color: rgba(255, 255, 255, 0.1);
+}
+
+#notificationBadge {
+    box-shadow: -0.1px 1px 2px #000000;
+    -webkit-box-shadow: -0.1px 1px 2px #000000;
+    -moz-box-shadow: -0.1px 1px 2px #000000;
+    top: 0.95rem;
+    left: 1.6rem !important;
+}
+
+.night #notificationCount {
+    color: black;
+}
+
+.notifiyBox {
+    font-size: 16px;
+    position: absolute;
+    z-index: 1000;
+    top: 60px;
+    right: 76px;
+    width: 300px;
+    text-align: left;
+    background-color: #F0ECCD;
+    border: 4px solid #666;
+    -webkit-border-radius: 10px;
+    -moz-border-radius: 10px;
+    border-radius: 10px;
+    -webkit-box-shadow: 2px 2px 4px #888;
+    -moz-box-shadow: 2px 2px 4px #888;
+    box-shadow: 2px 2px 4px #888;
+    max-height: 200px;
+}
+
+.night .notifiyBox {
+    color: black;
+}
+
+.notifiyBox:before {
+    content: ' ';
+    position: absolute;
+    width: 0;
+    height: 0;
+    right: 5px;
+    top: -30px;
+    border: 15px solid;
+    border-color: transparent #666 #666 transparent;
+}
+
+.notifiyBox:after {
+    content: ' ';
+    position: absolute;
+    width: 0;
+    height: 0;
+    right: 7px;
+    top: -24px;
+    border: 12px solid;
+    border-color: transparent #F0ECCD #F0ECCD transparent;
+}
+
+#p15statetext {
+    padding: 4px;
+    height: 15px;
+}
+
+#p15agentConsole {
+    background: black;
+    margin: 0;
+    padding: 0;
+    color: lightgray;
+    width: 100%;
+    position: relative;
+}
+
+#p15coreName {
+    padding: 4px;
+    display: inline-block;
+}
+
+#p15agentConsoleText {
+    position: absolute;
+    margin: 0;
+    padding: 0;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    overflow-y: scroll;
+    overflow-x: auto;
+}
+
+.areaHead {
+    padding: 4px 10px;
+    background: linear-gradient(to bottom, #f5f5f5 0%, #e8e8e8 100%);
+    height: 36px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    border-top: 1px solid #d0d0d0;
+    box-shadow: 0 -1px 3px rgba(0, 0, 0, 0.08);
+}
+
+.night .areaHead {
+    background: linear-gradient(to top, #404040 0%, #2a2a2a 100%);
+    border-top-color: #555;
+}
+
+.areaFoot {
+    padding: 4px 10px;
+    background: linear-gradient(to top, #f5f5f5 0%, #e8e8e8 100%);
+    height: 36px;
+    display: flex;
+    align-items: center;
+    border-top: 1px solid #d0d0d0;
+    box-shadow: 0 -1px 3px rgba(0, 0, 0, 0.08);
+}
+
+.night .areaFoot {
+    background: linear-gradient(to top, #404040 0%, #2a2a2a 100%);
+    border-top-color: #555;
+}
+
+.toright2 {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+
+#consoleTable {
+    width: 100%;
+    height: 100%;
+    padding: 0px;
+    margin-top: 0px;
+}
+
+.night #consoleTable {
+    color: black;
+}
+
+.menucurve {
+    background-color: white;
+    width: 10px;
+    height: 10px;
+    border-radius: 10px 0 0 0;
+    border-right: 1px solid white;
+    border-bottom: 1px solid white;
+}
+
+.night .menucurve {
+    background-color: black;
+    border-right: 1px solid black;
+    border-bottom: 1px solid black;
+}
+
+#termTable {
+    width: 100%;
+    padding: 0px;
+    margin-top: 0px;
+}
+
+.fulldesk #termTable {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+}
+
+#termarea3x {
+    background: black;
+    text-align: center;
+    height: 400px;
+    position: relative;
+}
+
+.viewSelector10 {
+    margin-left: 2px;
+    margin-top: 2px;
+    background: url(../images/views.png) -476px 0px;
+    height: 28px;
+    width: 28px;
+}
+
+.viewSelector11 {
+    margin-left: 2px;
+    margin-top: 2px;
+    background: url(../images/views.png) -504px 0px;
+    height: 28px;
+    width: 28px;
+}
+
+.tagSpan {
+    display: inline-flex;
+    align-items: center;
+    background: linear-gradient(to bottom, #ff3b30 0%, #d70015 100%);
+    color: #fff;
+    padding: 5px 12px;
+    border-radius: 12px;
+    font-size: 12px;
+    font-weight: 600;
+    margin: 0;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.2);
+    text-shadow: 0 1px 1px rgba(0, 0, 0, 0.2);
+    transition: all 0.15s ease;
+    vertical-align: middle;
+    line-height: 1;
+}
+
+.tagSpan:hover {
+    background: linear-gradient(to bottom, #ff4b40 0%, #e70025 100%);
+    box-shadow: 0 2px 5px rgba(255, 59, 48, 0.3);
+    transform: translateY(-1px);
+}
+
+.night .tagSpan {
+    background: linear-gradient(to bottom, #ff3b30 0%, #d70015 100%);
+    color: #fff;
+}
+
+/* Ensure tags align vertically with labels */
+#p10html table td:last-child .tagSpan {
+    margin: 0;
+    vertical-align: middle;
+}
+
+#d3serveraction,
+#d2serveraction {
+    width: 100%;
+    background-color: #d3d9d6;
+    text-align: left;
+    padding: 3px;
+}
+
+#d3serverfiles,
+#d2serverfiles {
+    width: 100%;
+    height: 150px;
+    background-color: white;
+    padding: 2px;
+    border: 1px solid gray;
+    overflow-y: scroll;
+}
+
+#body {
+    overflow-y: hidden;
+    margin: 0;
+    padding: 0;
+    border: 0;
+    font-size: 13px;
+    font-family: 'Trebuchet MS', Arial, Helvetica, sans-serif;
+}
+
+#page_content {
+    position: absolute;
+    bottom: calc(0px + env(safe-area-inset-bottom));
+    top: calc(82px + env(safe-area-inset-top));
+    width: 100%;
+}
+
+#column_l {
+    width: 100%;
+    padding: 0;
+    position: absolute;
+    bottom: 0px;
+    top: 0px;
+}
+
+#p0, #p1 {
+    width: 100%;
+    height: 100%;
+}
+
+#p2 {
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+}
+
+#xdevices {
+    position: absolute;
+    overflow-y: auto;
+    left: 0;
+    right: 0;
+    bottom: 0;
+}
+
+#p3 {
+    position: absolute;
+    bottom: 0;
+    top: 0;
+    width: 100%;
+}
+
+.table-reset {
+    margin: 0;
+    padding: 0;
+    border-spacing: 0;
+    border: 0;
+}
+
+.table-row-reset {
+    padding: 0;
+}
+
+.table-cell-back-button {
+    padding: 0;
+    color: #c8c8c8;
+    text-align: center;
+    cursor: pointer;
+}
+
+.back-button-container {
+    padding: 0;
+    background-color: #036;
+    width: 10px;
+    height: 10px;
+    float: right;
+    border: 0;
+}
+
+.back-button-arrow {
+    padding: 0;
+    font-size: 25px;
+    background-color: #036;
+    width: 50px;
+    border-radius: 0 0 10px 0;
+    height: 36px;
+}
+
+.margin-left-5 {
+    margin-left: 5px;
+}
+
+.font-size-large {
+    font-size: large;
+}
+
+#p3info {
+    overflow-y: auto;
+    position: absolute;
+    top: 55px;
+    bottom: 0px;
+    width: 100%;
+    padding-top: 12px;
+    padding-bottom: 20px;
+}
+
+.account-image {
+    position: absolute;
+    right: 8px;
+    top: 7px;
+    border-radius: 8px;
+    box-shadow: 0px 0px 7px #000;
+}
+
+.account-section {
+    margin-left: 8px;
+    margin-right: 8px;
+}
+
+#p3info {
+    color: #1d1d1f;
+}
+
+.night #p3info {
+    color: #ddd;
+}
+
+#p3info a {
+    color: #007AFF;
+    text-decoration: none;
+    transition: color 0.15s ease;
+    font-weight: 500;
+}
+
+#p3info a:hover {
+    color: #0051D5;
+    text-decoration: underline;
+}
+
+.night #p3info a {
+    color: #5ac8fa;
+}
+
+.night #p3info a:hover {
+    color: #80c4ff;
+}
+
+#p3info strong {
+    font-weight: 600;
+    color: #1d1d1f;
+}
+
+.night #p3info strong {
+    color: #ddd;
+}
+
+.account-subsection {
+    margin-left: 9px;
+    margin-bottom: 8px;
+}
+
+.account-item {
+    margin-top: 5px;
+}
+
+#p3noMeshFound {
+    margin-left: 9px;
+}
+
+#p5myfiles {
+    position: absolute;
+    top: 55px;
+    bottom: 0px;
+    width: 100%;
+}
+
+.toolbar-cell {
+    width: 100%;
+    background: linear-gradient(to top, #e8e8e8 0%, #f5f5f5 100%);
+    text-align: left;
+    padding: 4px;
+    border-top: none;
+    border-bottom: none;
+    box-shadow: none;
+}
+
+.night .toolbar-cell {
+    background: linear-gradient(to top, #2a2a2a 0%, #404040 100%);
+}
+
+.toolbar-buttons-container {
+    width: 100%;
+    text-align: center;
+    display: flex;
+    justify-content: flex-start;
+    gap: 4px;
+    margin-bottom: 4px;
+    flex-wrap: nowrap;
+}
+
+.toolbar-button.desk-button-action {
+    width: calc(100% / 5 - 5px);
+    margin: 0;
+    flex: 0 0 calc(100% / 5 - 5px);
+    min-width: unset;
+    padding: 0 8px;
+}
+
+.toolbar-status-bar {
+    background: #e8e8e8;
+    height: 28px;
+    border-top: none;
+    border-bottom: none;
+    box-shadow: none;
+}
+
+.night .toolbar-status-bar {
+    background: #2a2a2a;
+}
+
+.file-table-container {
+    width: 100%;
+    height: calc(100% - 102px);
+    overflow: auto;
+    -webkit-user-select: none;
+    user-select: none;
+}
+
+.toolbar-bottom {
+    width: 100%;
+    height: 22px;
+    position: absolute;
+    bottom: 0px;
+    background: linear-gradient(to bottom, #e8e8e8 0%, #d0d0d0 100%);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    box-sizing: border-box;
+    border-top: none;
+    border-bottom: none;
+    box-shadow: none;
+}
+
+.night .toolbar-bottom {
+    background: linear-gradient(to bottom, #2a2a2a 0%, #1a1a1a 100%);
+    border-top-color: #555;
+}
+
+.toolbar-bottom-left {
+    text-align: left;
+    padding: 3px;
+    flex: 1;
+}
+
+.toolbar-bottom-right {
+    text-align: right;
+    padding: 3px;
+    flex-shrink: 0;
+}
+
+#p10 {
+    position: absolute;
+    bottom: 0;
+    top: 0;
+    width: 100%;
+    overflow: hidden;
+}
+
+#p10deskTopTable {
+    margin: 0;
+    padding: 0;
+    border-spacing: 0;
+    border: 0;
+    position: absolute;
+    top: 0;
+    z-index: 101;
+    pointer-events: auto;
+}
+
+@media (max-width: 767px) {
+    body:has(#top-bar:not([style*="display: none"]):not([style*="display:none"])) #p10deskTopTable {
+        top: calc(32px + env(safe-area-inset-top, 0px)) !important;
+    }
+    @supports not selector(:has(*)) {
+        #p10deskTopTable {
+            top: calc(32px + env(safe-area-inset-top, 0px)) !important;
+        }
+    }
+}
+
+#p10deskTopTable td[onclick],
+#p10deskTopTable td {
+    pointer-events: auto;
+}
+
+#p10deskTopTable td[onclick] {
+    cursor: pointer;
+}
+
+#p10deskTopTable a {
+    pointer-events: auto;
+    cursor: pointer;
+    z-index: 102;
+    position: relative;
+}
+
+#p10dialog {
+    z-index: 10000;
+    background-color: #EEE;
+    box-shadow: 0px 0px 15px #666;
+    font-family: Arial, Helvetica, sans-serif;
+    border-radius: 5px;
+    position: fixed;
+    top: 30px;
+    width: 300px;
+    left: 30px;
+}
+
+.dialog-header {
+    width: 100%;
+    background-color: #003366;
+    color: #FFF;
+    border-radius: 5px 5px 0 0;
+}
+
+.dialog-header-content {
+    padding: 5px;
+}
+
+.dialog-header-spacer {
+    width: 100%;
+    margin: 6px;
+}
+
+.dialog-body {
+    margin-right: 16px;
+    margin-left: 8px;
+}
+
+.dialog-footer {
+    width: 100%;
+    padding: 2px;
+    text-align: center;
+}
+
+.dialog-footer-ok {
+    padding: 10px;
+    margin-bottom: 20px;
+}
+
+.dialog-ok-button {
+    float: right;
+    width: 80px;
+}
+
+#p10general {
+    overflow-y: auto;
+    overflow-x: hidden;
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+    width: 100%;
+}
+
+#p10html {
+    margin-left: 8px;
+    margin-right: 8px;
+    padding-top: 55px;
+    padding-bottom: 20px;
+}
+
+/* Restore grid layout for p10html table */
+#p10html table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-bottom: 20px;
+    background-color: transparent;
+}
+
+#p10html table tr {
+    border-bottom: 1px solid #e5e5e7;
+    transition: background-color 0.15s ease;
+}
+
+#p10html table tr:hover {
+    background-color: rgba(0, 0, 0, 0.02);
+}
+
+.night #p10html table tr {
+    border-bottom-color: #444;
+}
+
+.night #p10html table tr:hover {
+    background-color: rgba(255, 255, 255, 0.05);
+}
+
+#p10html table td {
+    padding: 12px 8px;
+    vertical-align: top;
+    color: #1d1d1f;
+    font-size: 13px;
+    line-height: 1.5;
+}
+
+.night #p10html table td {
+    color: #ddd;
+}
+
+#p10html table td:first-child {
+    font-weight: 600;
+    width: 35%;
+    color: #86868b;
+    padding-right: 16px;
+    vertical-align: middle;
+}
+
+.night #p10html table td:first-child {
+    color: #aaa;
+}
+
+#p10html table td:last-child {
+    color: #1d1d1f;
+    vertical-align: middle;
+    display: flex;
+    align-items: center;
+    flex-wrap: wrap;
+    gap: 6px;
+}
+
+.night #p10html table td:last-child {
+    color: #ddd;
+}
+
+#p10html table td i {
+    color: #86868b;
+    font-style: italic;
+}
+
+.night #p10html table td i {
+    color: #888;
+}
+
+#p10html table td a {
+    color: #007AFF;
+    text-decoration: none;
+    transition: color 0.15s ease;
+    font-weight: 500;
+}
+
+#p10html table td a:hover {
+    color: #0051D5;
+    text-decoration: underline;
+}
+
+#p10html table td span[onclick] {
+    cursor: pointer;
+    color: #1d1d1f;
+    transition: color 0.15s ease;
+}
+
+#p10html table td span[onclick]:hover {
+    color: #007AFF;
+}
+
+.night #p10html table td span[onclick] {
+    color: #ddd;
+}
+
+.night #p10html table td span[onclick]:hover {
+    color: #5ac8fa;
+}
+
+
+#p10html input[type="button"] {
+    height: 28px;
+    padding: 0 12px;
+    border: none;
+    border-radius: 6px;
+    font-size: 13px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.15s ease;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
+    letter-spacing: 0.3px;
+    min-width: 70px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    line-height: 1;
+    background: linear-gradient(to bottom, #ffffff 0%, #f8f8f8 100%);
+    color: #1d1d1f;
+    border: 1px solid #d2d2d7;
+    margin-right: 8px;
+    margin-bottom: 8px;
+}
+
+#p10html input[type="button"]:hover {
+    background: linear-gradient(to bottom, #fafafa 0%, #f0f0f0 100%);
+    border-color: #a1a1a6;
+    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.12);
+    transform: translateY(-1px);
+}
+
+#p10html input[type="button"]:active {
+    background: linear-gradient(to bottom, #f0f0f0 0%, #e8e8e8 100%);
+    box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.1);
+    transform: translateY(0);
+}
+
+#p10html input[type="button"]:first-of-type,
+#p10html input[type="button"].active {
+    color: #1d1d1f;
+}
+
+.night #p10html input[type="button"] {
+    background: linear-gradient(to bottom, #555 0%, #444 100%);
+    color: #ddd;
+    border-color: #666;
+}
+
+.night #p10html input[type="button"]:hover {
+    background: linear-gradient(to bottom, #666 0%, #555 100%);
+}
+
+
+.desk-button-top-10 {
+    top: 10px;
+}
+
+.desk-button-top-60 {
+    top: 60px;
+}
+
+.desk-button-top-110 {
+    top: 110px;
+}
+
+.desk-button-top-160 {
+    top: 160px;
+}
+
+.desk-button-top-210 {
+    top: 210px;
+}
+
+.soft-keyboard-container {
+    position: absolute;
+    top: 0;
+    left: 0;
+    z-index: 200;
+    opacity: 0;
+    width: 1px;
+    height: 1px;
+}
+
+#softKeyboard {
+    z-index: 200;
+    opacity: 0;
+    width: 1px;
+    height: 1px;
+}
+
+#deskButtonMenu, #termButtonMenu {
+    position: absolute;
+    top: 10px;
+    left: 10px;
+    right: 55px;
+    bottom: 10px;
+    z-index: 1000;
+}
+
+#p10desktop {
+    overflow: hidden;
+    position: absolute;
+    top: 55px;
+    bottom: 0px;
+    width: 100%;
+}
+
+#deskarea1 {
+    position: absolute;
+    top: 0px;
+    width: 100%;
+    height: 36px;
+    z-index: 1;
+}
+
+.button-height-28 {
+    height: 28px;
+}
+
+.button-margin-right-3 {
+    margin-right: 3px;
+}
+
+.button-margin-left-3 {
+    margin-left: 3px;
+}
+
+#deskarea3 {
+    position: absolute;
+    top: 45px;
+    bottom: 45px;
+    width: 100%;
+    background-color: #000;
+    text-align: center;
+}
+
+#DeskParent {
+    height: 100%;
+}
+
+#Desk {
+    width: 100%;
+    -ms-touch-action: none;
+    touch-action: none;
+    pointer-events: none;
+    margin-left: 0px;
+}
+
+#p11DeskConsoleMsg {
+    cursor: pointer;
+    position: absolute;
+    left: 30px;
+    top: 17px;
+    color: yellow;
+    background-color: rgba(0, 0, 0, 0.6);
+    padding: 10px;
+    border-radius: 5px;
+    text-align: left;
+}
+
+#p11DeskSessionSelector {
+    position: absolute;
+    left: 30px;
+    top: 17px;
+    right: 30px;
+    bottom: 17px;
+    overflow-y: auto;
+}
+
+#deskarea4 {
+    position: absolute;
+    bottom: 9px;
+    width: 100%;
+    height: 36px;
+    z-index: 10;
+}
+
+.desk-toolbar-top {
+    position: absolute;
+    top: 0px;
+    width: 100%;
+    height: 44px;
+}
+
+.desk-toolbar {
+    padding: 4px 10px;
+    background: linear-gradient(to bottom, #f5f5f5 0%, #e8e8e8 100%);
+    height: 36px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    border-top: 1px solid #d0d0d0;
+    box-shadow: 0 -1px 3px rgba(0, 0, 0, 0.08);
+}
+
+.desk-toolbar-left {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex: 1;
+}
+
+.desk-toolbar-right {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex-shrink: 0;
+}
+
+.desk-button-primary,
+.desk-button-secondary,
+.desk-button-danger,
+.desk-button-action {
+    height: 28px;
+    padding: 0 12px;
+    border: none;
+    border-radius: 6px;
+    font-size: 13px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.15s ease;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
+    letter-spacing: 0.3px;
+    min-width: 70px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    line-height: 1;
+}
+
+.desk-button-primary {
+    background: linear-gradient(to bottom, #007AFF 0%, #0051D5 100%);
+    color: white;
+    text-shadow: 0 1px 1px rgba(0, 0, 0, 0.2);
+}
+
+.desk-button-primary:hover:not(:disabled) {
+    background: linear-gradient(to bottom, #0a84ff 0%, #0059e5 100%);
+    box-shadow: 0 3px 6px rgba(0, 122, 255, 0.3);
+    transform: translateY(-1px);
+}
+
+.desk-button-primary:active:not(:disabled) {
+    background: linear-gradient(to bottom, #0051D5 0%, #003aa0 100%);
+    box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.25);
+    transform: translateY(0);
+}
+
+.desk-button-secondary {
+    background: linear-gradient(to bottom, #8E8E93 0%, #636366 100%);
+    color: white;
+    text-shadow: 0 1px 1px rgba(0, 0, 0, 0.2);
+}
+
+.desk-button-secondary:hover:not(:disabled) {
+    background: linear-gradient(to bottom, #9e9ea3 0%, #737376 100%);
+    box-shadow: 0 3px 6px rgba(142, 142, 147, 0.3);
+    transform: translateY(-1px);
+}
+
+.desk-button-danger {
+    background: linear-gradient(to bottom, #FF3B30 0%, #D70015 100%);
+    color: white;
+    text-shadow: 0 1px 1px rgba(0, 0, 0, 0.2);
+}
+
+#connectbutton2s {
+    padding: 0 8px;
+    min-width: 60px;
+    font-size: 12px;
+}
+
+.desk-button-danger:hover {
+    background: linear-gradient(to bottom, #ff4b40 0%, #e70025 100%);
+    box-shadow: 0 3px 6px rgba(255, 59, 48, 0.3);
+    transform: translateY(-1px);
+}
+
+.desk-button-action {
+    background: linear-gradient(to bottom, #ffffff 0%, #f8f8f8 100%);
+    color: #1d1d1f;
+    border: 1px solid #d2d2d7;
+}
+
+.desk-button-action:hover {
+    background: linear-gradient(to bottom, #fafafa 0%, #f0f0f0 100%);
+    border-color: #a1a1a6;
+    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.12);
+    transform: translateY(-1px);
+}
+
+.desk-button-action:active {
+    background: linear-gradient(to bottom, #f0f0f0 0%, #e8e8e8 100%);
+    box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.1);
+    transform: translateY(0);
+}
+
+.desk-button-primary:disabled,
+.desk-button-secondary:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+    transform: none !important;
+}
+
+#p10html3 {
+    margin-left: 8px;
+    margin-right: 8px;
+    padding: 16px 0 20px 0;
+    border-top: 1px solid #e5e5e7;
+    margin-top: 12px;
+    padding-top: 20px;
+}
+
+.night #p10html3 {
+    border-top-color: #444;
+}
+
+#p10html3 .p10html3-buttons {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 8px;
+    align-items: center;
+    justify-content: flex-start;
+}
+
+#p10html3 .p10html3-buttons a {
+    height: 28px;
+    padding: 0 10px;
+    border: 1px solid #d2d2d7;
+    border-radius: 6px;
+    font-size: 13px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.15s ease;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
+    letter-spacing: 0.3px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    line-height: 1;
+    background: linear-gradient(to bottom, #ffffff 0%, #f8f8f8 100%);
+    color: #1d1d1f;
+    text-decoration: none;
+    flex: 0 0 auto;
+    white-space: nowrap;
+}
+
+#p10html3 .p10html3-buttons a:hover {
+    background: linear-gradient(to bottom, #fafafa 0%, #f0f0f0 100%);
+    border-color: #a1a1a6;
+    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.12);
+    transform: translateY(-1px);
+    text-decoration: none;
+}
+
+#p10html3 .p10html3-buttons a:active {
+    background: linear-gradient(to bottom, #f0f0f0 0%, #e8e8e8 100%);
+    box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.1);
+    transform: translateY(0);
+}
+
+.night #p10html3 .p10html3-buttons a {
+    background: linear-gradient(to bottom, #555 0%, #444 100%);
+    color: #ddd;
+    border-color: #666;
+}
+
+.night #p10html3 .p10html3-buttons a:hover {
+    background: linear-gradient(to bottom, #666 0%, #555 100%);
+}
+
+#p10html3 .p10html3-delete {
+    flex: 0 0 auto;
+    margin-left: auto;
+}
+
+#p10html2 table tr[style*="background-color:#AAAAAA"],
+#p10html2 table tr[style*="background-color: #AAAAAA"],
+#p10html2 table thead tr,
+#p10html2 table th {
+    background: linear-gradient(to bottom, #ffffff 0%, #f8f8f8 100%) !important;
+    background-color: transparent !important;
+}
+
+.night #p10html2 table tr[style*="background-color:#AAAAAA"],
+.night #p10html2 table tr[style*="background-color: #AAAAAA"],
+.night #p10html2 table thead tr,
+.night #p10html2 table th {
+    background: linear-gradient(to bottom, #555 0%, #444 100%) !important;
+    background-color: transparent !important;
+}
+
+.night #p10html2 table {
+    background-color: #2a2a2a !important;
+    border-color: #555 !important;
+}
+
+.night #p10html2 table td {
+    background-color: #2a2a2a !important;
+    color: #ddd !important;
+}
+
+.night #p10html2 table tr[style*="background-color:#DDD"],
+.night #p10html2 table tr[style*="background-color: #DDD"],
+.night #p10html2 table tr[style*="background-color:#EEE"],
+.night #p10html2 table tr[style*="background-color: #EEE"] {
+    background-color: #333 !important;
+}
+
+.night #p10html2 table tr:not([style*="background-color"]) {
+    background-color: #2a2a2a !important;
+}
+
+.desk-status-text {
+    color: #86868b;
+    font-size: 13px;
+    font-weight: 500;
+    padding: 4px 5px;
+    background: rgba(0, 0, 0, 0.04);
+    border-radius: 4px;
+    white-space: nowrap;
+    display: inline-flex;
+    align-items: center;
+    height: 28px;
+}
+
+.desk-toolbar-bottom-container {
+    position: absolute;
+    bottom: 9px;
+    width: 100%;
+    height: 44px;
+    z-index: 10;
+}
+
+.desk-toolbar-bottom {
+    padding: 4px 10px;
+    background: linear-gradient(to top, #f5f5f5 0%, #e8e8e8 100%);
+    height: 36px;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    border-top: 1px solid #d0d0d0;
+    box-shadow: 0 -1px 3px rgba(0, 0, 0, 0.08);
+}
+
+.desk-toolbar-bottom-left {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    flex: 1;
+}
+
+.desk-toolbar-bottom-right {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    flex-shrink: 0;
+}
+
+.desk-icon-button-wrapper {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    border-radius: 6px;
+    background: rgba(255, 255, 255, 0.9);
+    border: 1px solid #d2d2d7;
+    cursor: pointer;
+    transition: all 0.15s ease;
+    padding: 4px;
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+    flex-shrink: 0;
+}
+
+.desk-icon-button-wrapper:hover {
+    background: rgba(255, 255, 255, 1);
+    border-color: #a1a1a6;
+    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.15);
+    transform: translateY(-1px) scale(1.05);
+}
+
+.desk-icon-button-wrapper:active {
+    background: rgba(245, 245, 245, 1);
+    transform: translateY(0) scale(1);
+    box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.desk-icon-button {
+    cursor: pointer;
+    display: block;
+    opacity: 0.85;
+    transition: opacity 0.2s ease;
+}
+
+.desk-icon-button-wrapper:hover .desk-icon-button {
+    opacity: 1;
+}
+
+.night .desk-toolbar,
+.night .desk-toolbar-bottom {
+    background: linear-gradient(to top, #404040 0%, #2a2a2a 100%);
+    border-top-color: #555;
+}
+
+.night .desk-button-action {
+    background: linear-gradient(to bottom, #555 0%, #444 100%);
+    color: #ddd;
+    border-color: #666;
+}
+
+.night .desk-button-action:hover {
+    background: linear-gradient(to bottom, #666 0%, #555 100%);
+}
+
+.night .desk-status-text {
+    color: #aaa;
+}
+
+.night .desk-icon-button-wrapper {
+    background: rgba(60, 60, 60, 0.8);
+    border-color: #555;
+}
+
+.night .desk-icon-button-wrapper:hover {
+    background: rgba(80, 80, 80, 0.9);
+    border-color: #777;
+}
+
+#p10terminal {
+    overflow: hidden;
+    position: absolute;
+    top: 55px;
+    bottom: 0px;
+    width: 100%;
+    background-color: #333;
+}
+
+#termTable {
+    position: absolute;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    right: 0;
+}
+
+.area-head-line-height {
+    line-height: 24px;
+}
+
+#terminalCustomUpperRight {
+    float: left;
+    margin-right: 6px;
+}
+
+.terminal-button-span {
+    margin-left: 3px;
+}
+
+.terminal-button-span-right {
+    margin-right: 4px;
+}
+
+.terminal-status {
+    line-height: 22px;
+}
+
+#termarea3 {
+    position: absolute;
+    top: 45px;
+    bottom: 45px;
+    width: 100%;
+}
+
+#termarea3x {
+    width: 100%;
+    height: 100%;
+}
+
+.termarea3x-inner,
+#termarea3xdiv {
+    width: 100%;
+    height: 100%;
+    text-align: left;
+}
+
+#termarea4 {
+    position: absolute;
+    bottom: 9px;
+    width: 100%;
+    height: 36px;
+    z-index: 10;
+}
+
+.term-actions-container {
+    height: 28px;
+}
+
+#p12TermConsoleMsg {
+    cursor: pointer;
+    position: absolute;
+    left: 30px;
+    top: 45px;
+    color: yellow;
+    background-color: rgba(0, 0, 0, 0.6);
+    padding: 10px;
+    border-radius: 5px;
+}
+
+#p10files {
+    position: absolute;
+    top: 55px;
+    bottom: 0px;
+    width: 100%;
+}
+
+.files-toolbar-header {
+    background-color: #C0C0C0;
+    border-bottom: 2px solid black;
+    padding: 2px;
+    line-height: 24px;
+}
+
+.files-custom-upper-right {
+    float: left;
+    margin-right: 6px;
+}
+
+.files-toolbar-left {
+    margin-left: 2px;
+}
+
+.files-current-path {
+    overflow: hidden;
+    padding-left: 4px;
+    padding-top: 2px;
+    color: black;
+}
+
+.files-sort-dropdown {
+    text-align: right;
+    padding-right: 4px;
+}
+
+#p5myfiles {
+    position: absolute;
+    top: 55px;
+    bottom: 0px;
+    width: 100%;
+}
+
+#p5currentpath {
+    overflow: hidden;
+    padding-left: 4px;
+    padding-top: 2px;
+    color: black;
+}
+
+.night #p5currentpath {
+    color: #ddd;
+}
+
+#p5currentpath a {
+    color: black !important;
+}
+
+.night #p5currentpath a {
+    color: #ddd !important;
+}
+
+#p10deskTopTable {
+    margin: 0;
+    padding: 0;
+    border-spacing: 0;
+    border: 0;
+    position: absolute;
+    top: 0;
+    z-index: 101;
+    pointer-events: auto;
+}
+
+@media (max-width: 767px) {
+    body:has(#top-bar:not([style*="display: none"]):not([style*="display:none"])) #p10deskTopTable {
+        top: calc(2px + env(safe-area-inset-top, 0px)) !important;
+    }
+    @supports not selector(:has(*)) {
+        #p10deskTopTable {
+            top: calc(2px + env(safe-area-inset-top, 0px)) !important;
+        }
+    }
+}
+
+#p10deskTopTable td[onclick],
+#p10deskTopTable td {
+    pointer-events: auto;
+}
+
+#p10deskTopTable td[onclick] {
+    cursor: pointer;
+}
+
+#p10deskTopTable a {
+    pointer-events: auto;
+    cursor: pointer;
+    z-index: 102;
+    position: relative;
+}
+
+#p10dialog {
+    z-index: 10000;
+    background-color: #EEE;
+    box-shadow: 0px 0px 15px #666;
+    font-family: Arial, Helvetica, sans-serif;
+    border-radius: 5px;
+    position: fixed;
+    top: 30px;
+    width: 300px;
+    left: 30px;
+}
+
+#p10dialog2 {
+    margin: auto;
+    margin: 3px;
+}
+
+#p10details {
+    overflow-y: scroll;
+    position: absolute;
+    top: 55px;
+    bottom: 0px;
+    width: 100%;
+}
+
+#p10detailshtml {
+    margin-left: -3px;
+}
+
+#p10console {
+    overflow: hidden;
+    position: absolute;
+    top: 55px;
+    bottom: 0px;
+    width: 100%;
+}
+
+#p13FilesConsoleMsg {
+    cursor: pointer;
+    position: absolute;
+    left: 30px;
+    top: 165px;
+    color: yellow;
+    background-color: rgba(0, 0, 0, 0.6);
+    padding: 10px;
+    border-radius: 5px;
+}
+
+#p13filetable {
+    width: 100%;
+    height: calc(100% - 133px);
+    overflow: auto;
+    -webkit-user-select: none;
+    user-select: none;
+}
+
+#p13toolbarBottom {
+    width: 100%;
+    height: 22px;
+    position: absolute;
+    bottom: 0px;
+    background: linear-gradient(to bottom, #e8e8e8 0%, #d0d0d0 100%);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 3px;
+    box-sizing: border-box;
+    border-top: none;
+    border-bottom: none;
+    box-shadow: none;
+}
+
+.night #p13toolbarBottom {
+    background: linear-gradient(to bottom, #2a2a2a 0%, #1a1a1a 100%);
+}
+
+#p13currentpath {
+    overflow: hidden;
+    padding-left: 4px;
+    padding-top: 2px;
+    color: black;
+}
+
+.night #p13currentpath {
+    color: #ddd;
+}
+
+#p13currentpath a {
+    color: black !important;
+}
+
+.night #p13currentpath a {
+    color: #ddd !important;
+}
+
+.night #p13currentpath a[style*="color: #ffffff"],
+.night #p13currentpath a[style*="color:#ffffff"] {
+    color: #fff !important;
+}
+
+.sort-dropdown-wrapper {
+    position: relative;
+    display: inline-block;
+}
+
+#p13sortdropdown,
+#p5sortdropdown {
+    height: 20px;
+    padding: 0 24px 0 6px;
+    border: none;
+    border-radius: 4px;
+    background: rgba(255, 255, 255, 0.8);
+    color: #1d1d1f;
+    font-size: 12px;
+    font-weight: 500;
+    cursor: pointer;
+    transition: all 0.15s ease;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+    appearance: none;
+    -webkit-appearance: none;
+    -moz-appearance: none;
+}
+
+.sort-dropdown-icon {
+    position: absolute;
+    right: 8px;
+    top: 50%;
+    transform: translateY(-50%);
+    pointer-events: none;
+    font-size: 10px;
+    color: #1d1d1f;
+}
+
+#p13sortdropdown:hover,
+#p5sortdropdown:hover {
+    background: rgba(255, 255, 255, 0.95);
+    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.15);
+}
+
+#p13sortdropdown:focus,
+#p5sortdropdown:focus {
+    outline: none;
+    background: rgba(255, 255, 255, 1);
+    box-shadow: 0 0 0 2px rgba(0, 122, 255, 0.3);
+}
+
+.night #p13sortdropdown,
+.night #p5sortdropdown {
+    background: rgba(60, 60, 60, 0.8);
+    color: #ddd;
+}
+
+.night .sort-dropdown-icon {
+    color: #ddd;
+}
+
+.night #p13sortdropdown:hover,
+.night #p5sortdropdown:hover {
+    background: rgba(70, 70, 70, 0.95);
+}
+
+#p20 {
+    position: absolute;
+    bottom: 0;
+    top: 0;
+    width: 100%;
+}
+
+#p20info {
+    margin-left: 8px;
+    margin-right: 8px;
+    padding-top: 12px;
+    padding-bottom: 20px;
+}
+
+#p20info table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-bottom: 20px;
+    background-color: transparent;
+}
+
+#p20info table tr {
+    border-bottom: 1px solid #e5e5e7;
+    transition: background-color 0.15s ease;
+}
+
+#p20info table tr:hover {
+    background-color: rgba(0, 0, 0, 0.02);
+}
+
+.night #p20info table tr {
+    border-bottom-color: #444;
+}
+
+.night #p20info table tr:hover {
+    background-color: rgba(255, 255, 255, 0.05);
+}
+
+#p20info table td {
+    padding: 12px 8px;
+    vertical-align: middle;
+    color: #1d1d1f;
+    font-size: 13px;
+    line-height: 1.5;
+}
+
+.night #p20info table td {
+    color: #ddd;
+}
+
+#p20info table td:first-child {
+    font-weight: 600;
+    width: 120px;
+    color: #86868b;
+    padding-right: 16px;
+}
+
+.night #p20info table td:first-child {
+    color: #aaa;
+}
+
+#p20info table td:last-child {
+    color: #1d1d1f;
+}
+
+.night #p20info table td:last-child {
+    color: #ddd;
+}
+
+#p20info table td b {
+    font-weight: 600;
+    color: #1d1d1f;
+}
+
+.night #p20info table td b {
+    color: #ddd;
+}
+
+#p20info table td i {
+    color: #86868b;
+    font-style: italic;
+}
+
+.night #p20info table td i {
+    color: #888;
+}
+
+#p20info table td a {
+    color: #007AFF;
+    text-decoration: none;
+    transition: color 0.15s ease;
+    font-weight: 500;
+}
+
+#p20info table td a:hover {
+    color: #0051D5;
+    text-decoration: underline;
+}
+
+.night #p20info table td a {
+    color: #5ac8fa;
+}
+
+.night #p20info table td a:hover {
+    color: #80c4ff;
+}
+#p20info input[type="button"] {
+    height: 28px;
+    padding: 0 12px;
+    border: 1px solid #d2d2d7;
+    border-radius: 6px;
+    font-size: 13px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.15s ease;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
+    letter-spacing: 0.3px;
+    min-width: 70px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    line-height: 1;
+    background: linear-gradient(to bottom, #ffffff 0%, #f8f8f8 100%);
+    color: #1d1d1f;
+    margin-top: 12px;
+    margin-bottom: 8px;
+}
+
+#p20info input[type="button"]:hover {
+    background: linear-gradient(to bottom, #fafafa 0%, #f0f0f0 100%);
+    border-color: #a1a1a6;
+    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.12);
+    transform: translateY(-1px);
+}
+
+#p20info input[type="button"]:active {
+    background: linear-gradient(to bottom, #f0f0f0 0%, #e8e8e8 100%);
+    box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.1);
+    transform: translateY(0);
+}
+
+.night #p20info input[type="button"] {
+    background: linear-gradient(to bottom, #555 0%, #444 100%);
+    color: #ddd;
+    border-color: #666;
+}
+
+.night #p20info input[type="button"]:hover {
+    background: linear-gradient(to bottom, #666 0%, #555 100%);
+}
+#p20info .p20-add-user-button {
+    height: 28px;
+    padding: 0 12px;
+    border: 1px solid #d2d2d7;
+    border-radius: 6px;
+    font-size: 13px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.15s ease;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
+    letter-spacing: 0.3px;
+    min-width: 70px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    line-height: 1;
+    background: linear-gradient(to bottom, #ffffff 0%, #f8f8f8 100%);
+    color: #1d1d1f;
+    margin-top: 12px;
+    margin-bottom: 8px;
+    margin-right: 8px;
+}
+
+#p20info .p20-add-user-button:hover {
+    background: linear-gradient(to bottom, #fafafa 0%, #f0f0f0 100%);
+    border-color: #a1a1a6;
+    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.12);
+    transform: translateY(-1px);
+}
+
+#p20info .p20-add-user-button:active {
+    background: linear-gradient(to bottom, #f0f0f0 0%, #e8e8e8 100%);
+    box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.1);
+    transform: translateY(0);
+}
+
+.night #p20info .p20-add-user-button {
+    background: linear-gradient(to bottom, #555 0%, #444 100%);
+    color: #ddd;
+    border-color: #666;
+}
+
+.night #p20info .p20-add-user-button:hover {
+    background: linear-gradient(to bottom, #666 0%, #555 100%);
+}
+
+#p20info .p20-add-user-button i {
+    font-size: 12px;
+}
+#p20info > div > a[onclick*="p20installAndroidDialog"] {
+    display: inline-flex;
+    align-items: center;
+    gap: 6px;
+    padding: 6px 12px;
+    margin-bottom: 8px;
+    margin-right: 10px;
+    color: #007AFF;
+    text-decoration: none;
+    font-size: 13px;
+    font-weight: 500;
+    border-radius: 6px;
+    transition: all 0.15s ease;
+    background: rgba(0, 122, 255, 0.08);
+    border: 1px solid rgba(0, 122, 255, 0.2);
+}
+
+#p20info > div > a[onclick*="p20installAndroidDialog"]:hover {
+    background: rgba(0, 122, 255, 0.12);
+    border-color: rgba(0, 122, 255, 0.3);
+    color: #0051D5;
+    text-decoration: none;
+}
+
+.night #p20info > div > a[onclick*="p20installAndroidDialog"] {
+    color: #5ac8fa;
+    background: rgba(90, 200, 250, 0.1);
+    border-color: rgba(90, 200, 250, 0.2);
+}
+
+.night #p20info > div > a[onclick*="p20installAndroidDialog"]:hover {
+    background: rgba(90, 200, 250, 0.15);
+    border-color: rgba(90, 200, 250, 0.3);
+}
+
+#p20info table[style*="background-color:#EEE"],
+#p20info table[style*="background-color: #EEE"] {
+    background-color: transparent !important;
+    border: 1px solid #e5e5e7 !important;
+    border-radius: 6px;
+    overflow: hidden;
+}
+
+.night #p20info table[style*="background-color:#EEE"],
+.night #p20info table[style*="background-color: #EEE"] {
+    border-color: #555 !important;
+}
+
+#p20info table tr[style*="background-color:#AAAAAA"],
+#p20info table tr[style*="background-color: #AAAAAA"],
+#p20info table thead tr,
+#p20info table th {
+    background: linear-gradient(to bottom, #ffffff 0%, #f8f8f8 100%) !important;
+    background-color: transparent !important;
+}
+
+.night #p20info table tr[style*="background-color:#AAAAAA"],
+.night #p20info table tr[style*="background-color: #AAAAAA"],
+.night #p20info table thead tr,
+.night #p20info table th {
+    background: linear-gradient(to bottom, #555 0%, #444 100%) !important;
+    background-color: transparent !important;
+}
+
+#p20info table tr[style*="background-color:#AAAAAA"] th,
+#p20info table tr[style*="background-color: #AAAAAA"] th {
+    color: #1d1d1f !important;
+    font-weight: 600 !important;
+    font-size: 13px !important;
+    padding: 12px 8px !important;
+}
+
+.night #p20info table tr[style*="background-color:#AAAAAA"] th,
+.night #p20info table tr[style*="background-color: #AAAAAA"] th {
+    color: #ddd !important;
+}
+
+#p20info table tr[onclick] {
+    cursor: pointer;
+    transition: background-color 0.15s ease;
+}
+
+#p20info table tr[onclick]:hover {
+    background-color: rgba(0, 0, 0, 0.03) !important;
+}
+
+.night #p20info table tr[onclick]:hover {
+    background-color: rgba(255, 255, 255, 0.08) !important;
+}
+
+#p20info table tr[style*="background-color:#DDD"],
+#p20info table tr[style*="background-color: #DDD"] {
+    background-color: #f5f5f5 !important;
+}
+
+.night #p20info table tr[style*="background-color:#DDD"],
+.night #p20info table tr[style*="background-color: #DDD"] {
+    background-color: #333 !important;
+}
+
+#p20info table tr[onclick] td {
+    padding: 10px 8px !important;
+    vertical-align: middle !important;
+}
+
+#p20info table tr[onclick] a[onclick*="p20deleteUser"] {
+    opacity: 0.6;
+    transition: opacity 0.15s ease;
+}
+
+#p20info table tr[onclick] a[onclick*="p20deleteUser"]:hover {
+    opacity: 1;
+}
+
+#p20info table tr[onclick] a[onclick*="p20deleteUser"] img {
+    filter: brightness(0.8);
+}
+
+.night #p20info table tr[onclick] a[onclick*="p20deleteUser"] img {
+    filter: brightness(1.5);
+}
+#p20info .p20-delete-group-button {
+    height: 28px;
+    padding: 0 12px;
+    border: 1px solid #d2d2d7;
+    border-radius: 6px;
+    font-size: 13px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.15s ease;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
+    letter-spacing: 0.3px;
+    min-width: 70px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    line-height: 1;
+    background: linear-gradient(to bottom, #ffffff 0%, #f8f8f8 100%);
+    color: #1d1d1f;
+    margin-top: 0;
+    margin-bottom: 0;
+}
+
+#p20info .p20-delete-group-button:hover {
+    background: linear-gradient(to bottom, #fafafa 0%, #f0f0f0 100%);
+    border-color: #a1a1a6;
+    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.12);
+    transform: translateY(-1px);
+}
+
+#p20info .p20-delete-group-button:active {
+    background: linear-gradient(to bottom, #f0f0f0 0%, #e8e8e8 100%);
+    box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.1);
+    transform: translateY(0);
+}
+
+.night #p20info .p20-delete-group-button {
+    background: linear-gradient(to bottom, #555 0%, #444 100%);
+    color: #ddd;
+    border-color: #666;
+}
+
+.night #p20info .p20-delete-group-button:hover {
+    background: linear-gradient(to bottom, #666 0%, #555 100%);
+}
+
+#p15consoleText {
+    width: 100%;
+    padding: 6px 10px;
+    height: 28px;
+    background-color: #fff;
+    border: 1px solid #d2d2d7;
+    border-radius: 6px;
+    font-size: 13px;
+    color: #1d1d1f;
+    transition: all 0.15s ease;
+    box-sizing: border-box;
+}
+
+#p15consoleText:focus {
+    outline: none;
+    border-color: #007AFF;
+    background-color: #fff;
+    box-shadow: 0 0 0 3px rgba(0, 122, 255, 0.1);
+}
+
+.night #p15consoleText {
+    background-color: #2a2a2a;
+    border-color: #555;
+    color: #fff;
+}
+
+.night #p15consoleText:focus {
+    background-color: #2a2a2a;
+    border-color: #007AFF;
+    box-shadow: 0 0 0 3px rgba(0, 122, 255, 0.2);
+}
+
+#p15uploadCore {
+    height: 28px;
+    padding: 0 12px;
+    border: none;
+    border-radius: 6px;
+    font-size: 13px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.15s ease;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
+    letter-spacing: 0.3px;
+    min-width: 70px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    line-height: 1;
+    background: linear-gradient(to bottom, #007AFF 0%, #0051D5 100%);
+    color: white;
+    text-shadow: 0 1px 1px rgba(0, 0, 0, 0.2);
+}
+
+#p15uploadCore:hover:not(:disabled) {
+    background: linear-gradient(to bottom, #0a84ff 0%, #0059e5 100%);
+    box-shadow: 0 3px 6px rgba(0, 122, 255, 0.3);
+    transform: translateY(-1px);
+}
+
+#p15uploadCore:active:not(:disabled) {
+    background: linear-gradient(to bottom, #0051D5 0%, #003aa0 100%);
+    box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.25);
+    transform: translateY(0);
+}
+
+#p15uploadCore:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+    transform: none !important;
+}
+
+#p15outputselect {
+    height: 28px;
+    padding: 0 12px;
+    border: 1px solid #d2d2d7;
+    border-radius: 6px;
+    font-size: 13px;
+    cursor: pointer;
+    transition: all 0.15s ease;
+    background: linear-gradient(to bottom, #ffffff 0%, #f8f8f8 100%);
+    color: #1d1d1f;
+    min-width: 70px;
+}
+
+#p15outputselect:focus {
+    outline: none;
+    border-color: #007AFF;
+    box-shadow: 0 0 0 3px rgba(0, 122, 255, 0.1);
+}
+
+.night #p15outputselect {
+    background: linear-gradient(to bottom, #555 0%, #444 100%);
+    color: #ddd;
+    border-color: #666;
+}
+
+.night #p15outputselect:focus {
+    border-color: #007AFF;
+    box-shadow: 0 0 0 3px rgba(0, 122, 255, 0.2);
+}
+
+#id_p15consoleClear {
+    height: 28px;
+    padding: 0 12px;
+    border: 1px solid #d2d2d7;
+    border-radius: 6px;
+    font-size: 13px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.15s ease;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
+    letter-spacing: 0.3px;
+    min-width: 70px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    line-height: 1;
+    background: linear-gradient(to bottom, #ffffff 0%, #f8f8f8 100%);
+    color: #1d1d1f;
+}
+
+#id_p15consoleClear:hover {
+    background: linear-gradient(to bottom, #fafafa 0%, #f0f0f0 100%);
+    border-color: #a1a1a6;
+    box-shadow: 0 2px 5px rgba(0, 0, 0, 0.12);
+    transform: translateY(-1px);
+}
+
+#id_p15consoleClear:active {
+    background: linear-gradient(to bottom, #f0f0f0 0%, #e8e8e8 100%);
+    box-shadow: inset 0 2px 4px rgba(0, 0, 0, 0.1);
+    transform: translateY(0);
+}
+
+.night #id_p15consoleClear {
+    background: linear-gradient(to bottom, #555 0%, #444 100%);
+    color: #ddd;
+    border-color: #666;
+}
+
+.night #id_p15consoleClear:hover {
+    background: linear-gradient(to bottom, #666 0%, #555 100%);
+}
+
+#MainComputerImage {
+    cursor: pointer;
+}

--- a/views/default3-mobile.handlebars
+++ b/views/default3-mobile.handlebars
@@ -1,0 +1,6448 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr" xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta content="text/html; charset=utf-8" http-equiv="Content-Type" />
+    <meta name="viewport" content="user-scalable=1.0,initial-scale=1.0,minimum-scale=1.0,maximum-scale=1.0,viewport-fit=cover" />
+    <meta name="format-detection" content="telephone=no" />
+    <meta name="robots" content="noindex,nofollow">
+    <link rel="manifest" href="{{{domainurl}}}manifest.json">
+    <link rel="shortcut icon" href="{{{domainurl}}}favicon.ico" />
+    <link rel="icon" type="image/png" sizes="16x16" href="{{{domainurl}}}favicon-16x16.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="{{{domainurl}}}favicon-32x32.png">
+    <link rel="apple-touch-icon" href="/favicon-303x303.png" />
+    <link type="text/css" href="styles/xterm.css" media="screen" rel="stylesheet" title="CSS" />
+    <link type="text/css" href="styles/style-mobile-bootstrap.css" media="screen" rel="stylesheet" title="CSS" />
+    {{{customCSSTags}}}
+    <meta name="apple-mobile-web-app-capable" content="yes">
+    <meta name="apple-mobile-web-app-status-bar-style" content="#ffffff">
+    <meta name="apple-mobile-web-app-title" content="{{{title}}}">
+    <script type="text/javascript" src="scripts/common-0.0.1{{{min}}}.js"></script>
+    <script type="text/javascript" src="scripts/meshcentral{{{min}}}.js"></script>
+    <script type="text/javascript" src="scripts/fontawesome/all{{{min}}}.js"></script>
+    <script type="text/javascript" src="scripts/agent-redir-ws-0.1.1{{{min}}}.js"></script>
+    <script type="text/javascript" src="scripts/agent-desktop-0.0.2{{{min}}}.js"></script>
+    <script type="text/javascript" src="scripts/amt-0.2.0{{{min}}}.js"></script>
+    <script type="text/javascript" src="scripts/amt-redir-ws-0.1.0{{{min}}}.js"></script>
+    <script type="text/javascript" src="scripts/amt-desktop-0.0.2{{{min}}}.js"></script>
+    <script type="text/javascript" src="scripts/xterm{{{min}}}.js"></script>
+    <script type="text/javascript" src="scripts/xterm-addon-fit{{{min}}}.js"></script>
+    <script type="text/javascript" src="scripts/zlib{{{min}}}.js"></script>
+    <script type="text/javascript" src="scripts/zlib-inflate{{{min}}}.js"></script>
+    <script type="text/javascript" src="scripts/zlib-adler32{{{min}}}.js"></script>
+    <script type="text/javascript" src="scripts/zlib-crc32{{{min}}}.js"></script>
+    <script keeplink=1 type="text/javascript" src="scripts/filesaver.min.js"></script>
+    {{{customJSTags}}}
+    <meta name="msapplication-TileColor" content="#00aba9">
+    <meta name="theme-color" content="#ffffff">
+    <title>{{{title}}}</title>
+</head>
+<body id="body" onload="if (typeof(startup) !== 'undefined') startup();">
+    <div id=container>
+        <div id="notifiyBox" class="notifiyBox" style="display:none"></div>
+        <div id="mastheadx"></div>
+        <div id="masthead" class="noselect masthead-container">
+            <div class="masthead-left">
+                <div class="masthead-title" onclick="go(1,event)">{{{titlehtml}}}</div>
+                <div class="masthead-titles-container">
+                    <div class="title" onclick="go(1,event)">{{{title1}}}</div>
+                    <div class="title2" onclick="go(1,event)">{{{title2}}}</div>
+                </div>
+            </div>
+
+            <div class="masthead-right">
+                <div id="notificationCount"
+                    class="notification-icon position-relative"
+                    style="display:none"
+                    title="Click to view current notifications"
+                    onclick="clickNotificationIcon()">
+                    <i class="fa-solid fa-bell fa-xl text-white"></i>
+                    <span id="notificationBadge"
+                        class="position-absolute top-1 start-100 translate-middle badge rounded-pill bg-danger">0</span>
+                </div>
+
+                <div class="user-menu-container">
+                    <div id="userDropdown">
+                        <div id="userDropdownButton">
+                            <img id="userDropdownImage" src="images/user-256.png" alt="User" />
+                            <i class="fa fa-chevron-down LogoffLinkColor" style="font-size: 12px;"></i>
+                        </div>
+                        <div id="userDropdownMenu">
+                            <div id="userDropdownMenuContainer">
+                                <div class="userDropdownMenuItem" data-action="devices" onclick="handleUserMenuItem('devices')">
+                                    <i class="fa fa-desktop userDropdownMenuIcon"></i>
+                                    <span>My Devices</span>
+                                </div>
+
+                                <div id="toggleNightMenuItem" class="userDropdownMenuItem" data-action="toggle-night" onclick="toggleNightMode(); QV('userDropdownMenu', false);">
+                                    <i id="nightModeIcon" class="fa userDropdownMenuIcon night-mode-icon"></i>
+                                    <span id="nightModeText">Toggle night mode</span>
+                                </div>
+
+                                <div class="userDropdownMenuItem" data-action="notes" onclick="handleUserMenuItem('notes')">
+                                    <i class="fa fa-sticky-note userDropdownMenuIcon"></i>
+                                    <span>Personal Notes</span>
+                                </div>
+
+                                <div class="userDropdownMenuItem" data-action="account" onclick="handleUserMenuItem('account')">
+                                    <i class="fa fa-user userDropdownMenuIcon"></i>
+                                    <span>My Account</span>
+                                </div>
+
+                                <div id="userDropdownMenuDivider"></div>
+
+                                <div class="userDropdownMenuItem" data-action="logout" onclick="handleUserMenuItem('logout')">
+                                    <i class="fa fa-sign-out userDropdownMenuIcon"></i>
+                                    <span>Logout</span>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <span id="idleTimeoutNotify" class="idle-timeout-notify"></span>
+                </div>
+            </div>
+        </div>
+        <div id=page_content>
+            <div id=column_l>
+                <div id=p0 class="d-none w-100 h-100">
+                    <div class="d-flex align-items-center w-100 h-100">
+                        <div id=p0message class="text-center w-100"><span id="p0span">Server disconnected</span>, <href onclick=reload() style="cursor:pointer"><u>click to reconnect</u></href>.</div>
+                    </div>
+                </div>
+                <div id=p1 class="d-none w-100 h-100">
+                    <div class="d-flex align-items-center w-100 h-100">
+                        <div id=p1message class="text-center w-100"></div>
+                    </div>
+                </div>
+                <div id=p2 class="d-none position-absolute">
+                    <div id="devListToolbarSpan" class="noselect">
+                        <div class="d-flex align-items-center flex-wrap gap-2">
+                            <div style="position: relative; flex: 1; min-width: 120px;">
+                                <input id=SearchInput autocomplete=off type=search placeholder="Filter" onchange=onDeviceSearchChanged(event) onclick=onDeviceSearchChanged(event) onkeyup=onDeviceSearchChanged(event) onfocus=onSearchFocus(1) onblur=onSearchFocus(0) />
+                                <span id=SearchInputClearButton role="button" onclick="clearSearchInput()" class="d-flex">
+                                    <i class="fa fa-xmark"></i>
+                                </span>
+                            </div>
+                            <div class="form-check">
+                                <div class="form-check-wrapper">
+                                    <input class="form-check-input" type=checkbox id=RealNameCheckBox onclick=onRealNameCheckBox() />
+                                    <i class="fa fa-check form-check-icon"></i>
+                                </div>
+                                <label class="form-check-label" for="RealNameCheckBox">OS Name</label>
+                            </div>
+                            <div class="form-check">
+                                <div class="form-check-wrapper">
+                                    <input class="form-check-input" type=checkbox id=OnlineCheckBox onclick=onOnlineCheckBox(event) />
+                                    <i class="fa fa-check form-check-icon"></i>
+                                </div>
+                                <label class="form-check-label" for="OnlineCheckBox">Online</label>
+                            </div>
+                        </div>
+                    </div>
+                    <div id=xdevices onscroll="onDevicesScroll()" ontouchstart="onDeviceTouch(true)" ontouchend="onDeviceTouch(false)"></div>
+                </div>
+                <div id=p3 class="d-none position-absolute">
+                    <table cellspacing=0 class="table-reset">
+                        <tr class="table-row-reset">
+                            <td class="table-cell-back-button" width=60px valign=top onclick=goBack()>
+                                <div class="back-button-container">
+                                    <div class="menucurve"></div>
+                                </div>
+                                <div class="back-button-arrow"><i class="fa fa-angle-left"></i></div>
+                            </td>
+                            <td>
+                                <div class="margin-left-5">
+                                    <strong class="font-size-large"><span id=p3userName></span></strong><br />
+                                </div>
+                            </td>
+                        </tr>
+                    </table>
+                    <div id=p3info>
+                        <img id="p2AccountImage" alt="" loading="lazy" width="128" height="128" onclick="account_manageImage(0)" src="images/user-256.png" class="account-image" />
+                        <div class="account-section">
+                            <div id="p3AccountActions">
+                                <div id="p2AccountSecurity" class="d-none">
+                                    <p><strong>Account Security</strong></p>
+                                    <div class="account-subsection">
+                                        <div id="managePhoneNumber1" class="account-item d-none"><a onclick="account_managePhone()" style="cursor:pointer">Manage phone number</a> <span id="authPhoneNumberCheck"><strong>&#x2713;</strong></span></div>
+                                        <div id="manageEmail2FA" class="account-item d-none"><a onclick="account_manageAuthEmail()" style="cursor:pointer">Manage email authentication</a> <span id="authEmailSetupCheck"><strong>&#x2713;</strong></span></div>
+                                        <div class="account-item"><a href=# onclick="account_showLocalizationSettings()">Localization Settings</a></div>
+                                        <div id="manageAuthApp" class="account-item d-none"><a onclick="account_manageAuthApp()" style="cursor:pointer">Manage authenticator app</a> <span id="authAppSetupCheck"><strong>&#x2713;</strong></span></div>
+                                        <div id="manageOtp" class="account-item d-none"><a onclick="account_manageOtp(0)" style="cursor:pointer">Manage backup codes</a> <span id="authCodesSetupCheck"><strong>&#x2713;</strong></span></div>
+                                    </div>
+                                </div>
+                                <div id="p2AccountActions" class="d-none">
+                                    <p><strong>Account Actions</strong></p>
+                                    <div class="account-subsection">
+                                        <div class="account-item"><span id="viewPreviousLogins"><a onclick="return account_viewPreviousLogins()" style="cursor:pointer">View previous logins</a></span></div>
+                                        <div class="account-item"><span id="managePhoneNumber2" class="d-none"><a onclick="account_managePhone()" style="cursor:pointer">Manage phone number</a></span></div>
+                                        <div class="account-item"><span id="verifyEmailId" class="d-none"><a onclick="account_showVerifyEmail()" style="cursor:pointer">Verify email</a></span></div>
+                                        <span id="p2AccountPassActions">
+                                            <div class="account-item"><span id="changeEmailId" class="d-none"><a onclick="account_showChangeEmail()" style="cursor:pointer">Change email address</a></span></div>
+                                            <div class="account-item"><a onclick="account_showChangePassword()" style="cursor:pointer">Change password</a><span id="p2nextPasswordUpdateTime"></span></div>
+                                            <div class="account-item"><a onclick="account_showDeleteAccount()" style="cursor:pointer">Delete account</a></div>
+                                        </span>
+                                        <div class="account-item" id="setDarkModeLink"><a onclick="toggleNightMode()" style="cursor:pointer">Set dark mode</a></div>
+                                        <div class="account-item"><a onclick="showNotes(false)" style="cursor:pointer">Personal notes</a></div>
+                                    </div>
+                                <br class="clearfix" />
+                                </div>
+                            </div>
+                            <strong>Device Groups</strong>
+                            <span id="p3createMeshLink1">( <a onclick=account_createMesh() style="cursor:pointer"><img src="images/icon-addnew.png" width=12 height=12 border=0 /> New</a> )</span>
+                            <br /><br />
+                            <div id=p3meshes></div>
+                            <div id=p3noMeshFound class="d-none">No device groups.<span id="p3createMeshLink2"> <a onclick=account_createMesh() style="cursor:pointer"><strong>Get started here!</strong></a></span></div>
+                            <br class="clearfix" />
+                        </div>
+                    </div>
+                </div>
+                <div id=p5 class="d-none">
+                    <table cellspacing=0 style="margin:0;padding:0;border-spacing:0;border:0;">
+                        <tr style=padding:0>
+                            <td style="padding:0;color:#c8c8c8;text-align:center;cursor:pointer" width=60px valign=top onclick=goBack()>
+                                <div style="padding:0;background-color:#036;width:10px;height:10px;float:right;border:0">
+                                    <div class="menucurve"></div>
+                                </div>
+                                <div style="padding:0;font-size:25px;background-color:#036;width:50px;border-radius:0 0 10px 0;height:36px;display:flex;align-items:center;justify-content:center"><i class="fa fa-angle-left"></i></div>
+                            </td>
+                            <td>
+                                <img src="/images/user-50.png" width=50 height=50 />
+                            </td>
+                            <td>
+                                <div style=margin-left:5px>
+                                    <strong style="font-size:large">My Files</strong><br />
+                                </div>
+                            </td>
+                        </tr>
+                    </table>
+                    <div id=p5myfiles>
+                        <div id="p5toolbar" class="toolbar-cell">
+                            <div class="toolbar-buttons-container">
+                                <input type=button class="toolbar-button desk-button-action" id=p5FolderUp disabled="disabled" onclick="p5folderup()" value="Up" onkeypress="return false" onkeydown="return false" />
+                                <input type=button class="toolbar-button desk-button-action" id=p5SelectAllButton disabled="disabled" onclick="p5selectallfile()" value="SelectAll" onkeypress="return false" onkeydown="return false" />
+                                <input type=button class="toolbar-button desk-button-action" id=p5RenameFileButton disabled="disabled" value="Rename" onclick="p5renamefile()" onkeypress="return false" onkeydown="return false" />
+                                <input type=button class="toolbar-button desk-button-action" id=p5DeleteFileButton disabled="disabled" value="Delete" onclick="p5deletefile()" onkeypress="return false" onkeydown="return false" />
+                                <input type=button class="toolbar-button desk-button-action" id=p5NewFolderButton disabled="disabled" value="Folder" onclick="p5createfolder()" onkeypress="return false" onkeydown="return false" />
+                            </div>
+                            <div class="toolbar-buttons-container">
+                                <input type=button class="toolbar-button desk-button-action" id=p5UploadButton disabled="disabled" value="Upload" onclick="p5uploadFile()" onkeypress="return false" onkeydown="return false" />
+                                <input type=button class="toolbar-button desk-button-action" id=p5CutButton disabled="disabled" value="Cut" onclick="p5copyFile(1)" onkeypress="return false" onkeydown="return false" />
+                                <input type=button class="toolbar-button desk-button-action" id=p5CopyButton disabled="disabled" value="Copy" onclick="p5copyFile(0)" onkeypress="return false" onkeydown="return false" />
+                                <input type=button class="toolbar-button desk-button-action" id=p5PasteButton disabled="disabled" value="Paste" onclick="p5pasteFile()" onkeypress="return false" onkeydown="return false" />
+                                <input type=button class="toolbar-button desk-button-action" id=p5RefreshButton value="Refresh" onclick="p5refreshFiles()" onkeypress="return false" onkeydown="return false" />
+                            </div>
+                        </div>
+                        <div class="toolbar-status-bar">
+                            <table style="width:100%">
+                                <tr>
+                                    <td id=p5currentpath></td>
+                                    <td style="text-align:right;padding-right:4px">
+                                        <div class="sort-dropdown-wrapper">
+                                            <select id=p5sortdropdown onchange=updateFiles()>
+                                                <option value=1 selected="selected">Sort by name</option>
+                                                <option value=2>Sort by size</option>
+                                                <option value=3>Sort by date</option>
+                                                <option value=4>Descend by name</option>
+                                                <option value=5>Descend by size</option>
+                                                <option value=6>Descend by date</option>
+                                            </select>
+                                            <i class="fa fa-chevron-down sort-dropdown-icon"></i>
+                                        </div>
+                                    </td>
+                                </tr>
+                            </table>
+                        </div>
+                        <div id="p5filetable" class="file-table-container">
+                            <span id="p5files"></span>
+                        </div>
+                        <div id="p5toolbarBottom" class="toolbar-bottom">
+                            <div class="toolbar-bottom-left">
+                                <span id="p5bottomstatus"></span>
+                            </div>
+                            <div class="toolbar-bottom-right" id="p5rightOfButtons">
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div id=p10 class="d-none position-absolute">
+                    <table id=p10deskTopTable cellspacing=0 class="table-reset">
+                        <tr style=padding:0>
+                            <td style="padding:0;color:#c8c8c8;text-align:center;cursor:pointer" width=60px valign=top onclick=goBack()>
+                                <div style="padding:0;background-color:#036;width:10px;height:10px;float:right;border:0">
+                                    <div class="menucurve"></div>
+                                </div>
+                                <div style="padding:0;font-size:25px;background-color:#036;width:50px;border-radius:0 0 10px 0;height:36px;display:flex;align-items:center;justify-content:center"><i class="fa fa-angle-left"></i></div>
+                            </td>
+                            <td>
+                                <a id=MainComputerImage class="cursor-pointer" onclick=p10showiconselector()></a>
+                            </td>
+                            <td>
+                                <div style=margin-left:5px>
+                                    <strong><span id=p10deviceName></span></strong><br />
+                                    <span id=MainComputerState></span>
+                                </div>
+                            </td>
+                        </tr>
+                    </table>
+                    <div id=p10dialog class="position-fixed" style="display:none">
+                        <div class="dialog-header">
+                            <div class="dialog-header-content">Keyboard Shortcuts Customization</div>
+                            <div class="dialog-header-spacer"></div>
+                        </div>
+                        <div class="dialog-body"><div id=p10dialog2></div></div>
+                        <div class="dialog-footer"><input type=button value="Restore Default Keyboard Shortcuts" onclick=restoreDeskCustomizeKey() /></div>
+                        <div class="dialog-footer-ok"><input type="button" value="OK" class="dialog-ok-button" onclick="deskCustomizeKeysEx()"></div>
+                    </div>
+                    <div id=p10general style="display:none;position:absolute;top:0;bottom:0;left:0;right:0;overflow-y:auto;overflow-x:hidden">
+                        <div class="deviceNotifyLargeDot">
+                            <img id="p10deviceStar" class=deviceNotifyLargeDotSub src=images/icon-star-notify-40.png width=35 height=35>
+                            <div id="p10deviceMsg" onclick=showDeviceMessages(null,null,event) class=deviceNotifyLargeDotSub></div>
+                            <img id="p10deviceNotify" onclick=showDeviceSessions() class=deviceNotifyLargeDotSub src=images/icon-relay-notify-40.png width=35 height=35>
+                            <img id="p10deviceHelp" onclick=showDeviceHelpRequests(null,null,event) class=deviceNotifyLargeDotSub src=images/icon-help-notify-40.png width=35 height=35>
+                        </div>
+                        <div id="p10deviceBattery" class="deviceBatteryLarge deviceBatteryLarge1"></div>
+                        <div id=p10html></div>
+                        <div id=p10html2></div>
+                        <div id=p10html3></div>
+                    </div>
+                    <img id="deskkeybutton1" src="images/mobile-desk-exit.png" class="deskButton" style="top:10px;display:none" onclick="exitButton()" />
+                    <img id="deskkeybutton3a" src="images/mobile-desk-menu-open.png" class="deskButton" style="top:60px;display:none" onclick="toggleMenu(false)" />
+                    <img id="deskkeybutton3b" src="images/mobile-desk-menu-close.png" class="deskButton" style="top:60px;display:none" onclick="toggleMenu(true)" />
+                    <img id="deskkeybutton4a" src="images/mobile-desk-mouse-left.png" class="deskButton" style="top:110px;display:none" onclick="deskChangeMouseButton(0)" />
+                    <img id="deskkeybutton4b" src="images/mobile-desk-mouse-right.png" class="deskButton" style="top:110px;display:none" onclick="deskChangeMouseButton(1)" />
+                    <img id="deskkeybutton5a" src="images/mobile-desk-scale-out.png" class="deskButton" style="top:160px;display:none" onclick="deskChangeFullscreenZoom()" />
+                    <img id="deskkeybutton5b" src="images/mobile-desk-scale-in.png" class="deskButton" style="top:160px;display:none" onclick="deskChangeFullscreenZoom()" />
+                    <img id="deskkeybutton2a" src="images/mobile-desk-keyboard-open.png" class="deskButton" style="top:210px;display:none" onclick="toggleKeyboard()" />
+                    <img id="deskkeybutton2b" src="images/mobile-desk-keyboard-close.png" class="deskButton" style="top:210px;display:none" onclick="toggleKeyboard()" />
+                    <div style="position:absolute;top:0;left:0;z-index:200;opacity:0;width:1px;height:1px">
+                        <input id="softKeyboard" autocapitalize="off" autocomplete="off" type="text" inputmode="text" spellcheck="false" style="z-index:200;opacity:0;width:1px;height:1px" onfocus="keyboardFocusChange()" onblur="keyboardFocusChange()" />
+                    </div>
+                    <div id="deskButtonMenu" style="display:none"></div>
+                    <div id=p10desktop style="display:none">
+                        <div id=deskarea1 class="desk-toolbar-top">
+                            <div class="desk-toolbar">
+                                <div class="desk-toolbar-left">
+                                    <input type=button id=connectbutton1 value="Connect" class="desk-button-primary" onclick=connectDesktop(event,3) onkeypress="return false" onkeydown="return false" disabled="disabled">
+                                    <input type=button id=connectbutton1h value="HW Connect" class="desk-button-secondary" onclick=connectDesktop(event,2) onkeypress="return false" onkeydown="return false" disabled="disabled">
+                                    <input type=button id=disconnectbutton1 value="Disconnect" class="desk-button-danger" onclick=connectDesktop(event,0) onkeypress="return false" onkeydown="return false">
+                                    <span id="deskstatus" class="desk-status-text">Disconnected</span>
+                                </div>
+                                <div class="desk-toolbar-right">
+                                    <span id="p14power"></span>&nbsp;
+                                    <input type=button id=deskFullScreen value="Full Screen" class="desk-button-primary" onclick=deskToggleFull(event) onkeypress="return false" onkeydown="return false" disabled="disabled">
+                                </div>
+                            </div>
+                        </div>
+                        <div id=deskarea3 style="position:absolute;top:53px;bottom:53px;width:100%;background-color:#000;text-align:center">
+                            <div id=DeskParent style="height:100%">
+                                <canvas id=Desk width=640 height=200 style="width:100%;-ms-touch-action:none;margin-left:0px" oncontextmenu="return false" onmousedown=dmousedown(event) onmouseup=dmouseup(event) onmousemove=dmousemove(event) onmousewheel=dmousewheel(event)></canvas>
+                            </div>
+                            <div id=p11DeskConsoleMsg style="display:none" onclick=p11clearConsoleMsg()></div>
+                            <div id=p11DeskSessionSelector style="display:none"></div>
+                        </div>
+                        <div id=deskarea4 class="desk-toolbar-bottom-container">
+                            <div class="desk-toolbar-bottom">
+                                <div class="desk-toolbar-bottom-left">
+                                    <input id="deskActionsBtn" type=button class="desk-button-action" onkeypress="return false" onkeydown="return false" value=Actions onclick=deviceActionFunction() />
+                                    <input type="button" value="Settings" class="desk-button-action" onkeypress="return false" onkeydown="return false" onclick="showDesktopSettings()">
+                                    <input type="button" value="Power Actions..." class="desk-button-action" onkeypress="return false" onkeydown="return false" onclick="showPowerActionDlg()" style="display:none">
+                                    <input type="button" id="DeskScreens" value="Screens" class="desk-button-action" onkeypress="return false" onkeydown="return false" onclick="deskSelectScreens()" style="display:none">
+                                    <label><span id="DeskControlSpan" style="display:none"><input id="DeskControl" type="checkbox" onkeypress="return false" onkeydown="return false">Input</span></label>
+                                </div>
+                                <div class="desk-toolbar-bottom-right">
+                                    <span id=DeskLockButton class="desk-icon-button-wrapper" onclick=deviceLockFunction()><i class="fa fa-lock desk-icon-button"></i></span>
+                                    <span id=DeskChatButton class="desk-icon-button-wrapper" onclick=deviceChat(event)><i class="fa fa-comment desk-icon-button"></i></span>
+                                    <span id=DeskToastButton class="desk-icon-button-wrapper" onclick=deviceToastFunction()><i class="fa fa-bell desk-icon-button"></i></span>
+                                    <span id=DeskOpenWebButton class="desk-icon-button-wrapper" onclick=deviceUrlFunction()><i class="fa fa-globe desk-icon-button"></i></span>
+                                    <span id=DeskRunButton class="desk-icon-button-wrapper" onclick=runDeviceCmd()><i class="fa fa-play desk-icon-button"></i></span>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div id="termButtonMenu" style="display:none;position:absolute;top:10px;left:10px;right:55px;bottom:10px;z-index:1000"></div>
+                    <div id=p10terminal style="display:none">
+                        <div id=termTable style="position:absolute;top:0;bottom:0;left:0;right:0">
+                            <div id="termarea1" class="desk-toolbar-top">
+                                <div class="desk-toolbar">
+                                    <div class="desk-toolbar-left">
+                                        <span id="connectbutton2span"><input type="button" id="connectbutton2" value="Connect" class="desk-button-primary" onclick=connectTerminal(event,1) onkeypress="return false" onkeydown="return false" disabled="disabled" /></span>
+                                        <span id="connectbutton2sspan"><input type="button" id="connectbutton2s" value="SSH Connect" class="desk-button-secondary" onclick=connectTerminal(event,3) onkeypress="return false" onkeydown="return false" disabled="disabled" /></span>
+                                        <span id="disconnectbutton2span"><input type="button" id="disconnectbutton2" value="Disconnect" class="desk-button-danger" onclick=connectTerminal(event,0) onkeypress="return false" onkeydown="return false" /></span>
+                                        <span id="termstatus" class="desk-status-text">Disconnected</span><span id="termtitle"></span>
+                                    </div>
+                                    <div class="desk-toolbar-right">
+                                        <div id="terminalCustomUpperRight"></div>
+                                        <input type=button id=termFullScreen value="Full Screen" class="desk-button-primary" onclick=deskToggleFull(event) onkeypress="return false" onkeydown="return false" disabled="disabled">
+                                    </div>
+                                </div>
+                            </div>
+                            <div id="termarea3" style="position:absolute;top:45px;bottom:45px;width:100%;" cellpadding=0 cellspacing=0>
+                                <div id="termarea3x" style="width:100%;height:100%">
+                                    <div style="width:100%;height:100%;text-align:left" id="termarea3xdiv"></div>
+                                </div>
+                            </div>
+                            <div id="termarea4" class="desk-toolbar-bottom-container">
+                                <div class="desk-toolbar-bottom">
+                                    <div class="desk-toolbar-bottom-left">
+                                        <input id="termActionsBtn" type=button class="desk-button-action" title="Perform power actions on the device" onkeypress="return false" onkeydown="return false" value=Actions onclick=deviceActionFunction() />
+                                        <input id="ctrlcbutton" type=button class="desk-button-action" onkeypress="return false" onkeydown="return false" value="Ctl-C" onclick="termSendKey(3,'ctrlcbutton')" />
+                                        <input id="ctrlxbutton" type=button class="desk-button-action" onkeypress="return false" onkeydown="return false" value="Ctl-X" onclick="termSendKey(24,'ctrlxbutton')" />
+                                        <input id="escbutton" type=button class="desk-button-action" onkeypress="return false" onkeydown="return false" value="ESC" onclick="termSendKey(27,'escbutton')" />
+                                    </div>
+                                    <div class="desk-toolbar-bottom-right">
+                                    </div>
+                                </div>
+                            </div>
+                            <div id=p12TermConsoleMsg style="display:none" onclick=p12clearConsoleMsg()></div>
+                        </div>
+                    </div>
+                    <div id=p10files style="display:none">
+                        <div id="filesToolbarTop" class="desk-toolbar-top">
+                            <div class="desk-toolbar">
+                                <div class="desk-toolbar-left">
+                                    <input id=p13AutoConnect value="AutoConnect" class="desk-button-action" onclick=autoConnectFiles(event) onkeypress="return false" onkeydown="return false" type="button" style="display:none">
+                                    <input id=p13Connect value="Connect" class="desk-button-primary" onclick=connectFiles(event,1) onkeypress="return false" onkeydown="return false" type="button" />
+                                    <input id=p13Connects value="SFTP Connect" class="desk-button-secondary" onclick=connectFiles(event,2) onkeypress="return false" onkeydown="return false" type="button" />
+                                    <input id=p13Disconnect value="Disconnect" class="desk-button-danger" onclick=connectFiles(event) onkeypress="return false" onkeydown="return false" type="button" />
+                                    <span id=p13Status class="desk-status-text">Disconnected</span>
+                                </div>
+                                <div class="desk-toolbar-right">
+                                    <div id="filesCustomUpperRight"></div>
+                                    <input id="filesActionsBtn" type=button class="desk-button-action" onkeypress="return false" onkeydown="return false" value=Actions onclick=deviceActionFunction() />
+                                </div>
+                            </div>
+                        </div>
+                        <div id="p13toolbar" class="toolbar-cell" style="margin-top:44px">
+                            <div class="toolbar-buttons-container">
+                                <input type=button class="toolbar-button desk-button-action" id=p13FolderUp disabled="disabled" onclick="p13folderup()" value="Up" />
+                                <input type=button class="toolbar-button desk-button-action" id=p13SelectAllButton disabled="disabled" onclick="p13selectallfile()" value="SelectAll" onkeypress="return false" onkeydown="return false" />
+                                <input type=button class="toolbar-button desk-button-action" id=p13RenameFileButton disabled="disabled" value="Rename" onclick="p13renamefile()" onkeypress="return false" onkeydown="return false" />
+                                <input type=button class="toolbar-button desk-button-action" id=p13DeleteFileButton disabled="disabled" value="Delete" onclick="p13deletefile()" onkeypress="return false" onkeydown="return false" />
+                                <input type=button class="toolbar-button desk-button-action" id=p13NewFolderButton disabled="disabled" value="Folder" onclick="p13createfolder()" onkeypress="return false" onkeydown="return false" />
+                            </div>
+                            <div class="toolbar-buttons-container">
+                                <input type=button class="toolbar-button desk-button-action" id=p13UploadButton disabled="disabled" value="Upload" onclick="p13uploadFile()" onkeypress="return false" onkeydown="return false" />
+                                <input type=button class="toolbar-button desk-button-action" id=p13CutButton disabled="disabled" value="Cut" onclick="p13copyFile(1)" onkeypress="return false" onkeydown="return false" />
+                                <input type=button class="toolbar-button desk-button-action" id=p13CopyButton disabled="disabled" value="Copy" onclick="p13copyFile(0)" onkeypress="return false" onkeydown="return false" />
+                                <input type=button class="toolbar-button desk-button-action" id=p13PasteButton disabled="disabled" value="Paste" onclick="p13pasteFile()" onkeypress="return false" onkeydown="return false" />
+                                <input type=button class="toolbar-button desk-button-action" id=p13RefreshButton disabled="disabled" value="Refresh" onclick="p13folderup(9999)" onkeypress="return false" onkeydown="return false" />
+                            </div>
+                        </div>
+                        <div class="toolbar-status-bar">
+                            <table style="width:100%">
+                                <tr>
+                                    <td id=p13currentpath></td>
+                                    <td style="text-align:right;padding-right:4px">
+                                        <div class="sort-dropdown-wrapper">
+                                            <select id=p13sortdropdown onchange=p13updateFiles()>
+                                                <option value=1 selected="selected">Sort by name</option>
+                                                <option value=2>Sort by size</option>
+                                                <option value=3>Sort by date</option>
+                                                <option value=4>Descend by name</option>
+                                                <option value=5>Descend by size</option>
+                                                <option value=6>Descend by date</option>
+                                            </select>
+                                            <i class="fa fa-chevron-down sort-dropdown-icon"></i>
+                                        </div>
+                                    </td>
+                                </tr>
+                            </table>
+                        </div>
+                        <div id=p13FilesConsoleMsg style="display:none" onclick=p13clearConsoleMsg()></div>
+                        <div id="p13filetable">
+                            <span id="p13files"></span>
+                        </div>
+                        <div id="p13toolbarBottom" class="toolbar-bottom">
+                            <div class="toolbar-bottom-left">
+                                <span id="p13bottomstatus"></span>
+                            </div>
+                            <div class="toolbar-bottom-right">
+                            </div>
+                        </div>
+                    </div>
+                    <div id=p10details style="display:none">
+                        <div id=p10detailshtml></div>
+                    </div>
+                    <div id=p10console style="display:none">
+                        <div id="consoleTable" style="display:flex;flex-direction:column;height:100%;position:relative">
+                            <div style="position:absolute;top:0;width:100%;height:44px;z-index:10">
+                                <div class="desk-toolbar">
+                                    <div class="desk-toolbar-left">
+                                        <div id="p15statetext" class="desk-status-text"></div>
+                                    </div>
+                                    <div class="desk-toolbar-right">
+                                        <div id=p15coreName style="margin-right:8px;font-size:13px;color:#86868b"></div>
+                                        <input type=button id=p15uploadCore class="desk-button-primary" value="Agent Action" onclick=p15uploadCore(event) />
+                                    </div>
+                                </div>
+                            </div>
+                            <div id=p15agentConsole style="position:absolute;top:0px;bottom:44px;left:0;right:0;overflow:auto">
+                                <pre id=p15agentConsoleText style="margin:0;padding:8px;font-family:monospace"></pre>
+                            </div>
+                            <div style="position:absolute;bottom:0;width:100%;height:44px;z-index:10">
+                                <div class="desk-toolbar-bottom">
+                                    <div class="desk-toolbar-bottom-left" style="flex:1;margin-right:12px">
+                                        <input id=p15consoleText onkeyup=p15consoleSend(event) style="width:100%;padding:6px 10px;height:28px;background-color:#fff;border:1px solid #d2d2d7;border-radius:6px;font-size:13px;color:#1d1d1f;box-sizing:border-box" />
+                                    </div>
+                                    <div class="desk-toolbar-bottom-right" style="gap:8px">
+                                        <div id="p15outputselecttd">
+                                            <select id=p15outputselect onchange="setupConsole()" class="desk-button-action" style="height:28px;padding:0 12px;font-size:13px;cursor:pointer">
+                                                <option id="p15outputselect1" value=1>Agent</option>
+                                                <option id="p15outputselect3" value=3>Push</option>
+                                                <option id="p15outputselect2" value=2>MQTT</option>
+                                            </select>
+                                        </div>
+                                        <input id="id_p15consoleClear" type="button" class="desk-button-action" value="Clear" onclick="p15consoleClear()" />
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                <div id=p20 class="d-none position-absolute">
+                    <table cellspacing=0 style="margin:0;padding:0;border-spacing:0;border:0;position:absolute;top:0">
+                        <tr style=padding:0>
+                            <td style="padding:0;color:#c8c8c8;text-align:center;cursor:pointer" width=60px valign=top onclick=goBack()>
+                                <div style="padding:0;background-color:#036;width:10px;height:10px;float:right;border:0">
+                                    <div class="menucurve"></div>
+                                </div>
+                                <div style="padding:0;font-size:25px;background-color:#036;width:50px;border-radius:0 0 10px 0;height:36px;display:flex;align-items:center;justify-content:center"><i class="fa fa-angle-left"></i></div>
+                            </td>
+                            <td onclick="p20editmesh(1)">
+                                <img src="/images/meshicon50.png" width=50 height=50 />
+                            </td>
+                            <td onclick="p20editmesh(1)">
+                                <div style=margin-left:5px>
+                                    <strong style="font-size:large"><span id=p20meshName></span></strong><br />
+                                </div>
+                            </td>
+                        </tr>
+                    </table>
+                    <div style="overflow-y:auto;position:absolute;top:55px;bottom:0px;left:0px;right:0px">
+                        <div id=p20info></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div id=top-bar style="display:none;height:32px;width:100%;text-align:center;background-color:#036;position:absolute">
+            <table id=topBarMenu cellpadding=0 cellspacing=0 style="height:32px;width:100%;color:white;cursor:pointer;table-layout:fixed"></table>
+        </div>
+    </div>
+    <div id=dialog style="display:none">
+        <div style="width:100%;background-color:#003366;color:#FFF;border-radius:5px 5px 0 0">
+            <div id=id_dialogclose style=float:right;padding:5px;cursor:pointer onclick=setDialogMode()><b>X</b></div>
+            <div id=id_dialogtitle style=padding:5px></div>
+            <div style=width:100%;margin:6px></div>
+        </div>
+        <div style="margin-right:16px;margin-left:8px">
+            <div id=dialog1 style="margin:auto;text-align:center;margin:3px">
+                <div id=id_dialogMessage style="padding:10px"></div>
+            </div>
+            <div id=dialog2 style="margin:auto;margin:3px">
+                <div id=id_dialogOptions></div>
+            </div>
+            <div id=dialog3 style="margin:auto;margin:3px">
+                <select id="deskkeys" style="width:100%">
+                    <option value=10>Ctrl+Alt+Del</option>
+                    <option value=11>Tab</option>
+                    <option value=5>Win</option>
+                    <option value=0>Win+Down</option>
+                    <option value=1>Win+Up</option>
+                    <option value=2>Win+L</option>
+                    <option value=3>Win+M</option>
+                    <option value=4>Shift+Win+M</option>
+                    <option value=6>Win+R</option>
+                    <option value=7>Alt-F4</option>
+                    <option value=8>Ctrl-W</option>
+                    <option value=9>Alt-Tab</option>
+                    <option value=12>Shift-F10</option>
+                </select>
+            </div>
+            <div id=dialog4 style="margin:auto;margin:3px">
+                <div id=d3upload>
+                    <div>File Selection</div>
+                    <select id=d3uploadMode onchange=d3modechange()>
+                        <option value=1>Local file upload</option>
+                        <option value=2>Server file selection</option>
+                    </select>
+                </div>
+                <div id=d3localmode style="display:none">
+                    <div>Upload File</div>
+                    <form id=d3localmodeform method=post enctype=multipart/form-data action=uploadfile.ashx target=fileUploadFrame>
+                        <input type=text id=d3auth name=auth style="display:none" />
+                        <input type=text id=d3filter name=filter style="display:none" />
+                        <input type=text id=d3attrib name=attrib style="display:none" />
+                        <input type=file id=d3localFile name=files onchange=d3setActions() />
+                        <input type=submit id=d3submit style="display:none" />
+                    </form>
+                </div>
+                <div id=d3servermode>
+                    <div id=d3serveraction valign=bottom>
+                        <input type=button id=p3FolderUp disabled="disabled" onclick=d3folderup() value="Up" />&nbsp;<span id=p3CurrentFolder></span>
+                    </div>
+                    <div id=d3serverfiles></div>
+                </div>
+            </div>
+            <div id=dialog7 style="margin:auto;margin:3px">
+                <div id="d7meshkvm">
+                    <h4 style="width:100%;border-bottom:1px solid gray">Agent Remote Desktop</h4>
+                    <table style="width:100%">
+                        <tr>
+                            <td>
+                                Quality
+                            </td>
+                            <td style="width:100px">
+                                <select id="d7bitmapquality" style="float:right;width:200px" dir="rtl"></select>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td>
+                                Scaling
+                            </td>
+                            <td style="width:100px">
+                                <select id="d7bitmapscaling" style="float:right;width:200px" dir="rtl">
+                                    <option selected=selected value=1024>100%</option>
+                                    <option value=896>87.5%</option>
+                                    <option value=768>75%</option>
+                                    <option value=640>62.5%</option>
+                                    <option value=512>50%</option>
+                                    <option value=384>37.5%</option>
+                                    <option value=256>25%</option>
+                                    <option value=128>12.5%</option>
+                                </select>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td>
+                                Rate
+                            </td>
+                            <td style="width:100px">
+                                <select id="d7framelimiter" style="float:right;width:200px" dir="rtl">
+                                    <option selected=selected value=50>Fast</option>
+                                    <option value=100>Medium</option>
+                                    <option value=400>Slow</option>
+                                    <option value=1000>Very slow</option>
+                                </select>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td>
+                                Encoding
+                            </td>
+                            <td style="width:100px">
+                                <select id="d7encoding" style="float:right;width:200px" dir="rtl">
+                                    <option value=1>JPEG</option>
+                                    <option value=2>PNG</option>
+                                    <option value=3>TIFF</option>
+                                    <option selected=selected value=4>WEBP</option>
+                                </select>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td></td>
+                            <td>
+                                <label style="display:block" id="d7deskAutoLockLabel"><input type="checkbox" id="d7deskAutoLock" />Lock on Disconnect</label>
+                            </td>
+                        </tr>
+                    </table>
+                </div>
+                <div id="d7amtkvm">
+                    <h4 style="width:100%;border-bottom:1px solid gray">Intel&reg; AMT Hardware KVM</h4>
+                    <table style="width:100%">
+                        <tr>
+                            <td>Encoding</td>
+                            <td style="width:100px">
+                                <select id="d7desktopmode" style="float:right;width:200px">
+                                    <option value="1">RLE8, Fastest</option>
+                                    <option value="2">RLE16, Recommended</option>
+                                    <option value="3">RAW8, Slow</option>
+                                    <option value="4">RAW16, Very Slow</option>
+                                </select>
+                            </td>
+                        </tr>
+                    </table>
+                </div>
+            </div>
+        </div>
+        <div id="idx_dlgButtonBar" style="padding:10px;margin-bottom:20px">
+            <input id="idx_dlgCancelButton" type="button" value="Cancel" style="float:right;width:80px;margin-left:5px" onclick="dialogclose(0)">
+            <input id="idx_dlgOkButton" type="button" value="OK" style="float:right;width:80px" onclick="dialogclose(1)">
+            <div><input id="idx_dlgDeleteButton" type="button" value="Delete" style="display:none" onclick="dialogclose(2)" /></div>
+        </div>
+    </div>
+    <div id=topMenu style="z-index:1000;background-color:#EEE;box-shadow:0px 0px 15px #666;font-family:Arial,Helvetica,sans-serif;border-radius:0px 0px 5px 5px;position:fixed;top:50px;right:5px;width:170px;display:none">
+        <div style="padding:12px;border-top:1px solid gray;color:black;cursor:pointer" onclick=topMenu(2)>My Files</div>
+        <div style="padding:12px;border-top:1px solid gray;color:black;cursor:pointer" onclick=topMenu(1)>My Account</div>
+        <div id="logoutMenuOption"><a id="logoutMenuOptionRef" href=/logout><div style="padding:12px;border-top:1px solid gray;color:black;cursor:pointer">Logout</div></a></div>
+    </div>
+    <audio id="chimes"><source src="sounds/chimes.mp3" type="audio/mp3" /></audio>
+    <iframe name="fileUploadFrame" style=display:none></iframe>
+    <script>
+        'use strict';
+        var random = '{{{randomlength}}}'
+
+        var webState = '{{{webstate}}}';
+        if (webState != '') { webState = JSON.parse(decodeURIComponent(webState)); }
+        for (var i in webState) { localStorage.setItem(i, webState[i]); }
+        if (webState && !webState.loctag) { delete localStorage.removeItem('loctag'); }
+
+        var urlargs = parseUriArgs();
+        if (urlargs.key != null) { urlargs.key = "" + urlargs.key; }
+        if (urlargs.key && (isAlphaNumeric(urlargs.key) == false)) { delete urlargs.key; }
+        if (urlargs.locale && (isAlphaNumeric(urlargs.locale) == false)) { delete urlargs.locale; }
+        delete urlargs.user;
+        delete urlargs.pass;
+        delete urlargs.viewmode;
+        delete urlargs.gotonode;
+        delete urlargs.gotodevicename;
+        delete urlargs.gotodevicername;
+        delete urlargs.gotodeviceip;
+        delete urlargs.gotomesh;
+        delete urlargs.panel;
+
+        var args = parseUriArgs();
+        if (args.key && (isAlphaNumeric(args.key) == false)) { delete args.key; }
+        if (args.locale && (isAlphaNumeric(args.locale) == false)) { delete args.locale; }
+
+        var debugLevel = parseInt('{{{debuglevel}}}');
+        var features = parseInt('{{{features}}}');
+        var features2 = parseInt('{{{features2}}}');
+        var sessionTime = parseInt('{{{sessiontime}}}');
+        var sessionRefreshTimer = null;
+        var domain = '{{{domain}}}';
+        var domainUrl = '{{{domainurl}}}';
+        var authCookie = '{{{authCookie}}}';
+        var authRelayCookie = '{{{authRelayCookie}}}';
+        var logoutControls = JSON.parse(decodeURIComponent('{{{logoutControls}}}'));
+        var authCookieRenewTimer = null;
+        var webRelayPort = parseInt('{{{webRelayPort}}}');
+        var hidePowerTimeline = '{{{hidePowerTimeline}}}';
+        var webRelayDns = '{{{webRelayDns}}}';
+        var meshserver = null;
+        var xdr = null;
+        var usergroups = null;
+        var stars = {};
+        var serverinfo = null;
+        var nodes = [];
+        var meshes = {};
+        var filetree = {};
+        var userinfo = null;
+        var serverinfo = null;
+        var users = null;
+        var nodeShortIdent = 0;
+        var serverPublicNamePort = '{{{serverDnsName}}}:{{{serverPublicPort}}}';
+        var debugmode = false;
+        var attemptWebRTC = ((features & 128) != 0);
+        var webrtcconfiguration = '{{{webrtcconfig}}}';
+        if (webrtcconfiguration == '') { webrtcconfiguration = null; } else { try { webrtcconfiguration = JSON.parse(decodeURIComponent(webrtcconfiguration)); } catch (ex) { console.log('Invalid WebRTC config: "' + webrtcconfiguration + '".'); webrtcconfiguration = null; } }
+        var StatusStrs = ["Disconnected", "Connecting...", "Setup...", "Connected", "Intel&reg; AMT Connected"];
+        var agentsStr = ["Unknown", "Windows 32bit console", "Windows 64bit console", "Windows 32bit service", "Windows 64bit service", "Linux 32bit", "Linux 64bit", "MIPS", "XENx86", "Android", "Linux ARM", "macOS x86-32bit", "Android x86", "PogoPlug ARM", "Android", "Linux Poky x86-32bit", "macOS x86-64bit", "ChromeOS", "Linux Poky x86-64bit", "Linux NoKVM x86-32bit", "Linux NoKVM x86-64bit", "Windows MinCore console", "Windows MinCore service", "NodeJS", "ARM-Linaro", "ARMv6l / ARMv7l", "ARMv8 64bit", "ARMv6l / ARMv7l / NoKVM", "MIPS24KC (OpenWRT)", "Apple Silicon", "FreeBSD x86-64", "Unknown", "Linux ARM 64 bit (glibc/2.24 NOKVM)", "Alpine Linux x86 64 Bit (MUSL)", "Assistant (Windows)", "Armada370 - ARM32/HF (libc/2.26)", "OpenWRT x86-64", "OpenBSD x86-64", "Unknown", "Unknown", "MIPSEL24KC (OpenWRT)", "ARMADA/CORTEX-A53/MUSL (OpenWRT)", "Windows ARM 64bit console", "Windows ARM 64bit service", "ARMVIRT32 (OpenWRT)", "RISC-V x86-64"];
+        var files;
+        var terminal;
+        var passRequirements = '{{{passRequirements}}}';
+        if (passRequirements != '') { passRequirements = JSON.parse(decodeURIComponent(passRequirements)); }
+        var sessionActivity = Date.now();
+        var deskPinchZoom;
+        var deskKeyboardShortcuts = [];
+        var nightMode = setNightMode();
+        var xterm = null;
+        var xtermfit = null;
+        var xtermResizeTimer = null;
+        var devicePagingState = null;
+
+        var p11DeskConsoleMsgTimer = null;
+        var p12TermConsoleMsgTimer = null;
+        var p13FilesConsoleMsgTimer = null;
+
+        var webpSupport = false;
+        check_webp_feature('lossy', function (f, x) {
+            webpSupport = x;
+            if (!x) {
+                d7encoding.options[1].disabled = true;
+                d7encoding.value = 1;
+            }
+        });
+
+        function startup() {
+            if ((features & 32) == 0) {
+                var loc = null;
+                try { loc = top.location.toString().toLowerCase(); } catch (e) { }
+                if (top != self && (loc == null || top.active == false)) { top.location = self.location; return; }
+            }
+
+            if (!args.locale) { var x = getstore('loctag', 0); if ((x != null) && (x != '*')) { args.locale = x; } }
+
+            window.onresize = center;
+            center();
+            QV('changeEmailId', (features & 0x200000) == 0);
+            QH('p1message', "Connecting...");
+            go(1);
+
+            document.onkeypress = ondeskkeypress;
+            document.onkeydown = ondeskkeydown;
+            document.onkeyup = ondeskkeyup;
+            document.onclick = function (e) { if ((xxdialogMode == 999) && (e.target.id != 'topMenuIcon')) { QV('topMenu', false); xxdialogMode = 0; } }
+
+            meshserver = MeshServerCreateControl(domainUrl);
+            meshserver.onStateChanged = onStateChanged;
+            meshserver.onMessage = onMessage;
+            meshserver.trace = args.trace;
+            meshserver.Start();
+
+            try { stars = JSON.parse(getstore('stars', '{}')); } catch (ex) { }
+
+            if (logoutControls && logoutControls.logoutUrl) { Q('logoutMenuOptionRef').href = logoutControls.logoutUrl; }
+
+            var t = localStorage.getItem('desktopsettings');
+            if (t != null) { desktopsettings = JSON.parse(t); }
+            applyDesktopSettings();
+
+            if (args.webrtc != null) { attemptWebRTC = (args.webrtc == 1); }
+
+            if (sessionTime >= 10) { sessionRefreshTimer = setTimeout(refreshCookieSession, Math.round((sessionTime * 60000) * 0.8)); }
+
+            QV('setDarkModeLink', (features2 & 0x00300000) == 0);
+
+            deskKeyboardShortcuts = [];
+            var deskKeyboardShortcutsStr = getstore('deskKeyShortcuts', '0x0A002E,0x100000,0x100028,0x100026,0x10004C,0x10004D,0x11004D,0x100052,0x020073,0x080057,0x020009,0x100025,0x100027').split(',');
+            for (var i in deskKeyboardShortcutsStr) { deskKeyboardShortcuts.push(parseInt(deskKeyboardShortcutsStr[i])); }
+            updateDeskShortcutKeys();
+            updateTermShortcutKeys();
+        }
+
+        function refreshCookieSession() {
+            var xdr = null;
+            try { xdr = new XDomainRequest(); } catch (e) { }
+            if (!xdr) xdr = new XMLHttpRequest();
+            xdr.open('GET', window.location.origin + domainUrl + 'refresh.ashx');
+            xdr.timeout = 15000;
+            xdr.onload = function () { sessionRefreshTimer = setTimeout(refreshCookieSession, Math.round((sessionTime * 60000) * 0.8)); };
+            xdr.onerror = xdr.ontimeout = function () { sessionRefreshTimer = null; };
+            xdr.send();
+        }
+
+        function onStateChanged(server, state, prevState, errorCode) {
+            if (state == 0) {
+                setDialogMode(0);
+                go(0);
+                deleteAllNotifications();
+                if (errorCode == 'noauth') { QH('p0span', "Unable to perform authentication"); return; }
+                if (prevState == 2) { setTimeout(serverPoll, 5000); } else { QH('p0span', "Unable to connect web socket"); }
+                if (authCookieRenewTimer != null) { clearInterval(authCookieRenewTimer); authCookieRenewTimer = null; }
+                devicePagingState = null;
+                updateDevicePageState();
+            } else if (state == 2) {
+                meshserver.send({ action: 'usergroups' });
+                meshserver.send({ action: 'meshes' });
+                meshserver.send({ action: 'nodes', skip: (devicePagingState == null) ? 0 : devicePagingState.skip });
+                meshserver.send({ action: 'files' });
+                authCookieRenewTimer = setInterval(function () { meshserver.send({ action: 'authcookie' }); }, 1800000);
+            }
+            QV('topMenuIcon', state == 2);
+        }
+
+        var userDropdownOpen = false;
+
+        function initializeUserDropdown() {
+            var dropdownButton = Q('userDropdownButton');
+            var dropdownMenu = Q('userDropdownMenu');
+
+            if (!dropdownButton || !dropdownMenu) return;
+
+            dropdownMenu.style.display = 'none';
+
+            dropdownButton.onclick = function(e) {
+                e.preventDefault();
+                e.stopPropagation();
+                userDropdownOpen = !userDropdownOpen;
+                dropdownMenu.style.display = userDropdownOpen ? 'block' : 'none';
+            };
+
+            document.addEventListener('click', function(e) {
+                if (!dropdownMenu.contains(e.target) && !dropdownButton.contains(e.target)) {
+                    dropdownMenu.style.display = 'none';
+                    userDropdownOpen = false;
+                }
+            });
+        }
+
+        function handleUserMenuItem(action) {
+            Q('userDropdownMenu').style.display = 'none';
+            userDropdownOpen = false;
+
+            switch(action) {
+                case 'devices': goForward('devices'); break;
+                case 'toggle-night': toggleNightMode(); break;
+                case 'notes': showNotes(false); break;
+                case 'account': go(3); break;
+                case 'logout': 
+                    if (logoutControls && logoutControls.logoutUrl) {
+                        window.location.href = logoutControls.logoutUrl;
+                    }
+                    break;
+            }
+        }
+
+        function updateUserDropdownVisibility() {
+            var userDropdown = Q('userDropdown');
+            var dropdownImage = Q('userDropdownImage');
+
+            if (logoutControls && logoutControls.name) {
+                QS('userDropdown').display = 'block';
+
+                var userImageSrc = 'images/user-256.png';
+                if (userinfo && userinfo.flags && (userinfo.flags & 1)) {
+                    if (userinfo.accountImageRnd == null) { userinfo.accountImageRnd = Math.floor(Math.random() * 9999999999); }
+                    userImageSrc = 'userimage.ashx?rnd=' + userinfo.accountImageRnd;
+                }
+                if (dropdownImage) {
+                    dropdownImage.src = userImageSrc;
+                }
+            } else {
+                QS('userDropdown').display = 'none';
+            }
+        }
+
+        function updateNightModeIcon() {
+            var nightModeItem = document.querySelector('.userDropdownMenuItem[data-action="toggle-night"]');
+            if (nightModeItem) {
+                var icon = nightModeItem.querySelector('#nightModeIcon');
+                var textSpan = nightModeItem.querySelector('#nightModeText');
+                if (icon && textSpan) {
+                    var isNightMode = document.body.classList.contains('night');
+                    var iconClass = isNightMode ? 'fa-sun' : 'fa-moon';
+                    var text = isNightMode ? "Toggle Light Mode" : "Toggle Dark Mode";
+                    var newIcon = document.createElement('i');
+                    newIcon.id = 'nightModeIcon';
+                    newIcon.className = 'fa ' + iconClass + ' userDropdownMenuIcon night-mode-icon';
+                    icon.parentNode.replaceChild(newIcon, icon);
+                    textSpan.textContent = text;
+                }
+            }
+        }
+
+        document.addEventListener('DOMContentLoaded', function() {
+            try {
+                initializeUserDropdown();
+                updateUserDropdownVisibility();
+                updateNightModeIcon();
+            } catch (ex) { }
+        });
+
+        function serverPoll() {
+            xdr = null;
+            try { xdr = new XDomainRequest(); } catch (e) { }
+            if (!xdr) xdr = new XMLHttpRequest();
+            xdr.open('HEAD', window.location.href);
+            xdr.timeout = 15000;
+            xdr.onload = function () { if (xdr.status < 500) reload(); else setTimeout(serverPoll, 10000); };
+            xdr.onerror = xdr.ontimeout = function () { setTimeout(serverPoll, 10000); };
+            xdr.send();
+        }
+
+        function updateSelf() {
+            var accountSettingsLocked = ((features2 & 0x100) != 0);
+            if (userinfo) { accountSettingsLocked = ((userinfo.siteadmin != 0xFFFFFFFF) && ((userinfo.siteadmin & 1024) != 0)) || ((features2 & 0x100) != 0); }
+            QV('p3AccountActions', ((features & 4) == 0) && (serverinfo.domainauth == false) && (accountSettingsLocked == false));
+            QV('logoutMenuOption', ((features & 4) == 0) && (serverinfo.domainauth == false));
+            QV('p2AccountSecurity', ((features & 4) == 0) && (serverinfo.domainauth == false) && ((features & 4096) != 0) && (accountSettingsLocked == false));
+            QV('p2AccountImage', !accountSettingsLocked);
+            QV('verifyEmailId', (userinfo.emailVerified !== true) && (userinfo.email != null) && (serverinfo.emailcheck == true));
+            QV('manageAuthApp', (serverinfo.lock2factor != true) && (features & 4096) && ((userinfo.otpsecret == 1) || ((features2 & 0x00020000) == 0)));
+            QV('manageOtp', (serverinfo.lock2factor != true) && ((features2 & 0x40000) == 0) && (features & 4096) && ((userinfo.otpsecret == 1) || (userinfo.otphkeys > 0)));
+            QV('authPhoneNumberCheck', (userinfo.phone != null));
+            QV('authEmailSetupCheck', (userinfo.otpekey == 1) && (userinfo.email != null) && (userinfo.emailVerified == true));
+            QV('authAppSetupCheck', userinfo.otpsecret == 1);
+            QV('authCodesSetupCheck', userinfo.otpkeys > 0);
+            QV('p2AccountActions', ((features & 4) == 0) && (serverinfo.domainauth == false) && (userinfo != null));
+            QV('p2AccountPassActions', ((features & 4) == 0) && (serverinfo.domainauth == false) && (userinfo != null) && (userinfo._id.split('/')[2].startsWith('~') == false));
+
+            QV('p3createMeshLink1', false);
+            QV('p3createMeshLink2', false);
+
+            if ((userinfo.flags != null) && (userinfo.flags & 1)) {
+                if (userinfo.accountImageRnd == null) { userinfo.accountImageRnd = Math.floor(Math.random() * 9999999999); }
+                Q('p2AccountImage').src = 'userimage.ashx?rnd=' + userinfo.accountImageRnd;
+            } else {
+                Q('p2AccountImage').src = 'images/user-256.png';
+            }
+            
+            updateUserDropdownVisibility();
+
+            if (typeof userinfo.passchange == 'number') {
+                if (userinfo.passchange == -1) { QH('p2nextPasswordUpdateTime', " - Reset on next login."); }
+                else if ((passRequirements != null) && (typeof passRequirements.reset == 'number')) {
+                    var seconds = (userinfo.passchange) + (passRequirements.reset * 86400) - Math.floor(Date.now() / 1000);
+                    if (seconds < 0) { QH('p2nextPasswordUpdateTime', " - Reset on next login."); }
+                    else if (seconds < 3600) { var secs = Math.floor(seconds / 60); QH('p2nextPasswordUpdateTime',format((secs == 1)?" - Reset in 1 minute.":" - Reset in {0} minutes.", secs)); }
+                    else if (seconds < 86400) { var hours = Math.floor(seconds / 3600); QH('p2nextPasswordUpdateTime', format((hours == 1) ? " - Reset in 1 hour." : " - Reset in {0} hours.", hours)); }
+                    else { var days = Math.floor(seconds / 86400); QH('p2nextPasswordUpdateTime', format((hours == 1) ? " - Reset in 1 day." : " - Reset in {0} days.", days)); }
+                }
+            }
+        }
+
+        function setSessionActivity() { sessionActivity = Date.now(); }
+        function checkIdleSessionTimeout() {
+            var delta = (Date.now() - sessionActivity);
+            if (delta > serverinfo.timeout) {
+                if (desktop != null) {
+                    desktop.Stop();
+                    desktopNode = desktop = null;
+                }
+                if (terminal != null) {
+                    terminal.Stop();
+                    terminal = null;
+                }
+                if (files != null) {
+                    files.Stop();
+                    files = null;
+                }
+                if (serverinfo.logoutonidlesessiontimeout) {
+                    if (urlargs.key) { window.location.href = 'logout?key=' + urlargs.key; }
+					else { window.location.href = 'logout'; }
+                }
+            }
+        }
+
+        function onMessage(server, message) {
+            switch (message.action) {
+                case 'serverinfo': {
+                    serverinfo = message.serverinfo;
+                    if (serverinfo.timeout) { setInterval(checkIdleSessionTimeout, 10000); checkIdleSessionTimeout(); }
+                    if (userinfo != null) updateSelf();
+                    if (serverinfo.certExpire != null) {
+                        var days = Math.floor((serverinfo.certExpire - Date.now()) / 86400000);
+                        if ((days >= 0) && (days < 20)) {
+                            addNotification({ text: format("Certificate expires in {0} day(s)", days) });
+                        }
+                    }
+
+                    QV('manageEmail2FA', (features & 0x00800000) && (serverinfo.lock2factor != true));
+                    QV('managePhoneNumber1', (features & 0x02000000) && (features & 0x04000000) && (serverinfo.lock2factor != true));
+                    QV('managePhoneNumber2', (features & 0x02000000) && !(features & 0x04000000) && (serverinfo.lock2factor != true));
+
+                    break;
+                }
+                case 'authcookie': {
+                    authCookie = message.cookie;
+                    authRelayCookie = message.rcookie;
+                    break;
+                }
+                case 'userinfo': {
+                    userinfo = message.userinfo;
+                    QH('p3userName', userinfo.name);
+                    if (serverinfo != null) updateSelf();
+                    updateUserDropdownVisibility();
+                    break;
+                }
+                case 'users': {
+                    users = {};
+                    for (var m in message.users) { users[message.users[m]._id] = message.users[m]; }
+                    if (currentUser != null) { currentUser = users[currentUser._id]; }
+                    updateUsers();
+                    break;
+                }
+                case 'wssessioncount': {
+                    wssessions = message.wssessions;
+                    updateUsers();
+                    break;
+                }
+                case 'meshes': {
+                    meshes = {};
+                    for (var m in message.meshes) { meshes[message.meshes[m]._id] = message.meshes[m]; }
+                    if (currentMesh != null) { currentMesh = meshes[currentMesh._id]; }
+                    updateMeshes();
+                    mainUpdate(4);
+                    break;
+                }
+                case 'usergroups': {
+                    var groupCount = 0;
+                    if (Array.isArray(message.ugroups)) {
+                        usergroups = {};
+                        for (var i in message.ugroups) { groupCount++; usergroups[message.ugroups[i]._id] = message.ugroups[i]; }
+                        if (groupCount == 0) { usergroups = null; }
+                    } else {
+                        usergroups = message.ugroups;
+                        for (var i in message.ugroups) { groupCount++; }
+                        if (groupCount == 0) { usergroups = null; }
+                    }
+                    break;
+                }
+                case 'files': {
+                    filetree = setupBackPointers(message.filetree);
+                    updateFiles();
+                    break;
+                }
+                case 'nodes': {
+                    nodes = [];
+                    for (var m in message.nodes) {
+                        for (var n in message.nodes[m]) {
+                            message.nodes[m][n].namel = message.nodes[m][n].name.toLowerCase();
+                            if (message.nodes[m][n].rname) { message.nodes[m][n].rnamel = message.nodes[m][n].rname.toLowerCase(); } else { message.nodes[m][n].rnamel = message.nodes[m][n].namel; }
+                            message.nodes[m][n].meshnamel = meshes[m]?meshes[m].name.toLowerCase():'*';
+                            message.nodes[m][n].meshid = m;
+                            message.nodes[m][n].state = (message.nodes[m][n].state) ? (message.nodes[m][n].state) : 0;
+                            message.nodes[m][n].desc = message.nodes[m][n].desc;
+                            if (!message.nodes[m][n].icon) message.nodes[m][n].icon = 1;
+                            message.nodes[m][n].ident = ++nodeShortIdent;
+                            nodes.push(message.nodes[m][n]);
+                        }
+                    }
+
+                    if ((currentNode != null) && (IsNodeViewable(currentNode) == false)) { currentNode = null; go(2); }
+
+                    if (currentNode != null) { currentNode = getNodeFromId(currentNode._id); if (currentNode != null) { gotoDevice(currentNode._id, xxcurrentView, true); } else { go(2); } }
+
+                    devicePagingState = (message.totalcount == null) ? null : { total: message.totalcount, skip: message.skip, limit: message.limit };
+                    updateDevicePageState();
+
+                    mainUpdate(4);
+                    if (xxcurrentView == 0) { if ('{{viewmode}}' != '') { go(parseInt('{{viewmode}}')); } else { setDialogMode(0); go(2); } }
+                    if ('{{currentNode}}' != '') { gotoDevice('{{currentNode}}', parseInt('{{viewmode}}')); }
+                    break;
+                }
+                case 'powertimeline': {
+                    if (message.nodeid != powerTimelineReq) break;
+                    powerTimelineNode = message.nodeid;
+                    powerTimeline = message.timeline;
+                    powerTimelineUpdate = Date.now() + 300000;
+                    for (var i in powerTimeline) { if (i % 2 == 1) { powerTimeline[i] = powerTimeline[i] * 1000; } }
+                    if (currentNode._id == message.nodeid) { drawDeviceTimeline(); }
+                    break;
+                }
+                case 'getsysinfo': {
+                    if (message.nodeid != powerTimelineReq) break;
+                    if (message.noinfo === true) {
+                        updateDeviceDetails(getNodeFromId(message.nodeid));
+                    } else {
+                        updateDeviceDetails(getNodeFromId(message.nodeid), message.hardware);
+                    }
+                    break;
+                }
+                case 'lastconnect': {
+                    var node = getNodeFromId(message.nodeid);
+                    if (node != null) {
+                        node.lastconnect = message.time;
+                        node.lastaddr = message.addr;
+                    }
+                    break;
+                }
+                case 'msg': {
+                    if (message.nodeid != null) {
+                        var index = -1;
+                        if (nodes != null) { for (var i in nodes) { if (nodes[i]._id == message.nodeid) { index = i; break; } } }
+                        if (index != -1) {
+                            if (message.type == 'console') { p15consoleReceive(nodes[index], message.value, message.source); }
+                            else if (message.type == 'notify') {
+                                var n = getstore('notifications', 0);
+                                if (((n & 8) == 0) && (message.amtMessage != null)) { break; }
+                                var n = { text: message.value, title: message.title, icon: message.icon, titleid: message.titleid, msgid: message.msgid, args: message.args };
+                                if (message.id != null) { n.id = message.id; }
+                                if (message.nodeid != null) { n.nodeid = message.nodeid; }
+                                if (message.tag != null) { n.tag = message.tag; }
+                                if (message.url != null) { n.url = message.url; }
+                                if (message.username != null) { n.username = message.username; }
+                                if (typeof message.maxtime == 'number') { n.maxtime = message.maxtime; }
+                                addNotification(n);
+                            } else if ((message.type == 'userSessions') && (currentNode != null) && (currentNode._id == message.nodeid) && (desktop == null)) {
+                                var userSessions = [];
+                                if (message.data != null) { for (var i in message.data) { if ((message.data[i].State == 'Active') || (message.data[i].StationName == 'Console') || (debugmode == 3)) { userSessions.push(message.data[i]); } } }
+                                if (userSessions.length == 0) { connectDesktop(null, 1, null, message.tag); }
+                                else if (userSessions.length == 1) { connectDesktop(null, 1, userSessions[0].SessionId, message.tag); }
+                                else {
+                                    var x = '';
+                                    var sortBy = "{{{userSessionsSort}}}";
+                                    if (sortBy != '') {
+                                        userSessions.sort(function(a, b) {
+                                            if (!a[sortBy]) return -1;
+                                            if (!b[sortBy]) return 1;
+                                            if (a[sortBy] < b[sortBy]) return -1;
+                                            if (a[sortBy] > b[sortBy]) return 1;
+                                            return 0;
+                                        });
+                                    }
+                                    for (var i in userSessions) {
+                                        x += '<div style="text-align:left;cursor:pointer;background-color:gray;margin:5px;padding:5px;border-radius:5px" onclick=connectDesktop(event,1,' + userSessions[i].SessionId + ',' + message.tag + ')>' + userSessions[i].State + ', ' + userSessions[i].StationName;
+                                        if (userSessions[i].Username) { if (userSessions[i].Domain) { x += ' - ' + userSessions[i].Domain + '/' + userSessions[i].Username; } else { x += ' - ' + userSessions[i].Username; } }
+                                        x += '</div>';
+                                    }
+                                    QH('p11DeskSessionSelector', x);
+                                    QV('p11DeskSessionSelector', true);
+                                }
+                            }
+                        }
+                    } else {
+                        if (message.type == 'notify') {
+                            var n = { text: message.value, title: message.title, icon: message.icon, titleid: message.titleid, msgid: message.msgid, args: message.args };
+                            if (message.id != null) { n.id = message.id; }
+                            if (message.tag != null) { n.tag = message.tag; }
+                            if (message.url != null) { n.url = message.url; }
+                            if (message.username != null) { n.username = message.username; }
+                            if (typeof message.maxtime == 'number') { n.maxtime = message.maxtime; }
+                            addNotification(n);
+                        }
+                    }
+                    break;
+                }
+                case 'getnetworkinfo': {
+                    if (currentNode._id != message.nodeid) return;
+                    updateDeviceDetails(getNodeFromId(message.nodeid), null, message);
+                    break;
+                }
+                case 'getNotes': {
+                    var n = Q('d2devNotes');
+                    if (n && (message.id == decodeURIComponent(n.attributes['noteid'].value))) {
+                        if (message.notes) { QH('d2devNotes', decodeURIComponent(message.notes)); } else { QH('d2devNotes', ''); }
+                        var ro = (n.attributes['ro'].value == 'true');
+                        if (ro == false) {
+                            n.removeAttribute('readonly');
+                            QE('idx_dlgOkButton', true);
+                            QV('idx_dlgOkButton', true);
+                            focusTextBox('d2devNotes');
+                        }
+                    }
+                    break;
+                }
+                case 'otpauth-request': {
+                    if ((xxdialogMode == 2) && (xxdialogTag == 'otpauth-request')) {
+                        if (message.err != null) {
+                            var otpauthErrors = ['', "2FA is locked", "Backup codes are locked", "Login token in use", "OTP 2FA not allowed", "Account is locked", "Unable to load OTPLIB"];
+                            if ((message.err > 0) && (message.err < otpauthErrors.length)) { QH('d2optinfo', otpauthErrors[message.err]); } else { QH('d2optinfo', format("Error #{0}", message.err)); }
+                        } else {
+                            var secret = message.secret;
+                            if (secret.length == 52) { secret = secret.split(/(.............)/).filter(Boolean).join(' '); }
+                            else if (secret.length == 32) { secret = secret.split(/(....)/).filter(Boolean).join(' '); secret = secret.substring(0, 20) + '<br/>' + secret.substring(20) }
+                            QH('d2optinfo', format("Install" + ' <a href="https://play.google.com/store/apps/details?id=com.google.android.apps.authenticator2" rel="noreferrer noopener" target=_blank>' + "Google Authenticator" + '</a> ' + "or a compatible application, use <a href=\"{0}\" rel=\"noreferrer noopener\" target=_blank> this link</a> or enter the secret below. Then, enter the current 6 digit token to activate 2-Step login.", message.url) + '<br /><br /><div style=width:100%;text-align:center><tt id=d2optsecret secret="' + message.secret + '" style=font-size:15px>' + secret + '</tt><br /><br />Token: <input type=text autocomplete="one-time-code" inputmode="numeric" pattern="[0-9]*" onkeypress=\"return (event.keyCode == 8) || (event.charCode >= 48 && event.charCode <= 57)\" onkeyup=account_addOtpCheck(event) onkeydown=account_addOtpCheck() maxlength=6 id=d2otpauthinput type=text></div>');
+                            QV('idx_dlgOkButton', true);
+                            QE('idx_dlgOkButton', false);
+                            Q('d2otpauthinput').focus();
+                        }
+                    }
+                    break;
+                }
+                case 'otpauth-setup': {
+                    if (xxdialogMode) return;
+                    setDialogMode(2, "Authenticator App", 1, null, message.success ? ('<b style=color:green>' + "Authenticator app activation successful." + '</b> ' + "You will now need a valid token to login again.") : ('<b style=color:red>' + "2-step login activation failed." + '</b> ' + "Clear the secret from the application and try again. You only have a few minutes to enter the proper code."));
+                    break;
+                }
+                case 'otpauth-clear': {
+                    if (xxdialogMode) return;
+                    setDialogMode(2, "Authenticator App", 1, null, message.success ? ('<b>' + "Authenticator application removed." + '</b> ' + "You can reactivate this feature at any time.") : ('<b style=color:red>' + "2-step login activation removal failed." + '</b> ' + "Try again."));
+                    break;
+                }
+                case 'otpauth-getpasswords': {
+                    if (xxdialogMode) return;
+                    var x = "One time tokens can be used as secondary authentication. Generate a set, print them and keep them in a safe place.";
+                    x += '<div style=\'border-radius:6px;border: 2px dashed #888;width:100%;margin-top:8px\'><div style=\'padding:8px;font-family:Arial, Helvetica, sans-serif;font-size:20px;font-weight:bold\'><table style=width:100%;text-align:center>';
+                    if (message.passwords) {
+                        var j = 0;
+                        for (var i in message.passwords) {
+                            if (++j % 2) { x += '<tr>'; }
+                            var p = '' + message.passwords[i].p;
+                            while (p.length < 8) { p = '0' + p; }
+                            if (message.passwords[i].u === true) { x += '<td>' + p.substring(0, 4) + '&nbsp;' + p.substring(4); } else { x += '<td><strike style=color:#BBB>' + p.substring(0, 4) + '&nbsp;' + p.substring(4); + '</strike>'; }
+                        }
+                    } else {
+                        x += '<tr><td>' + "No Active Tokens";
+                    }
+                    x += '</table></div></div><br />';
+                    x += '<div><input type=button value=\'' + "Close" + '\' onclick=setDialogMode(0) style=float:right></input>';
+                    x += '<input type=button value=\'' + "New Tokens" + '\' onclick=\'account_manageOtp(1);\'></input>';
+                    if (message.passwords != null) { x += '<input type=button value=\'' + "Clear" + '\' onclick=\'account_manageOtp(2);\'></input>'; }
+                    x += '</div><br />';
+                    setDialogMode(2, "Manage Backup Codes", 8, null, x, 'otpauth-manage');
+                    break;
+                }
+                case 'verifyPhone': {
+                    if (xxdialogMode && (xxdialogTag != 'verifyPhone')) return;
+                    var x = '<table><tr><td><img src="images/phone80.png" style=padding:8px>';
+                    x += '<td>Check your phone and enter the verification code.';
+                    x += '<br /><br /><div style=width:100%;text-align:center>' + "Verification code:" + ' <input type=tel pattern="[0-9]" inputmode="number" maxlength=6 id=d2phoneCodeInput onKeyUp=account_managePhoneCodeValidate() onkeypress="if (event.key==\'Enter\') account_managePhoneCodeValidate(1)"></div></table>';
+                    setDialogMode(2, "Phone Notifications", 3, account_managePhoneConfirm, x, message.cookie);
+                    Q('d2phoneCodeInput').focus();
+                    account_managePhoneCodeValidate();
+                    break;
+                }
+                case 'previousLogins': {
+                    if ((xxdialogMode == 2) && (xxdialogTag == 'previousLogins')) {
+                        var x = '', c = 'BBB', xx = '';
+                        if (message.events.length == 0) {
+                            x += 'No previous login.';
+                        } else {
+                            x += '<div style=max-height:260px;overflow-y:scroll;overflow-x:hidden>';
+                            for (var i in message.events) {
+                                var m = message.events[i].m;
+                                if (m == 107) { m = "Valid login"; c = 'BBD1BB'; xx = ''; }
+                                else if (m == 108) { m = "Invalid 2FA"; c = 'DD9DC3'; xx = 'x'; }
+                                else if (m == 109) { m = "Locked account"; c = 'E1BBBB'; xx = 'x'; }
+                                else if (m == 110) { m = "Invalid password"; c = 'E1BBBB'; xx = 'x'; }
+                                x += '<div style=width:260px;background-color:#' + c + ';border-radius:6px;margin-bottom:4px;padding:4px><div><b>' + EscapeHtml(m) + '</b><br />' + printDateTime(new Date(message.events[i].t)) + '</div><div style=font-size:x-small>' + EscapeHtml(message.events[i].a.join(', ')) + '</div></div></tr>';
+                            }
+                            x += '</div>';
+                        }
+                        setDialogMode(2, "Previous Logins", 1, null, x);
+                    }
+                    break;
+                }
+                case 'event': {
+                    if (message.event.noact) break;
+                    switch (message.event.action) {
+                        case 'serverinfochange': {
+                            if (message.event.lock2factor != null) { serverinfo.lock2factor = message.event.lock2factor; updateSelf(); }
+                            break;
+                        }
+                        case 'userWebState': {
+                            if (localStorage != null) {
+                                var webstate = JSON.parse(message.event.state);
+                                for (var i in webstate) { localStorage.setItem(i, webstate[i]); }
+
+                                if (webstate.stars != null) { stars = JSON.parse(webstate.stars); }
+
+                                if ((webstate.loctag != null) && (webstate.loctag != oldLoctag)) {
+                                    if (webstate.loctag != null) { args.locale = webstate.loctag; } else { delete args.locale; }
+                                    mainUpdate(4 + 128);
+                                } else if (webstate.stars != null) {
+                                    mainUpdate(4);
+                                    if (Q('SearchInput').value == '*') { onSearchInputChanged(); }
+                                }
+                                if (currentNode) { refreshDevice(currentNode._id); }
+
+                                if (webstate.deskKeyShortcuts != null) {
+                                    deskKeyboardShortcuts = [];
+                                    var deskKeyboardShortcutsStr = webstate.deskKeyShortcuts.split(',');
+                                    for (var i in deskKeyboardShortcutsStr) { deskKeyboardShortcuts.push(parseInt(deskKeyboardShortcutsStr[i])); }
+                                    updateDeskShortcutKeys();
+                                }
+                            }
+                            break;
+                        }
+                        case 'accountchange': {
+                            if ((typeof message.event.account != 'object') || (message.event.account == null)) { console.log(message.event); return; };
+                            if (userinfo.name == message.event.account.name) {
+                                var newsiteadmin = message.event.account.siteadmin ? message.event.account.siteadmin : 0;
+                                var oldsiteadmin = userinfo.siteadmin ? userinfo.siteadmin : 0;
+                                if ((message.event.account.quota != userinfo.quota) || (((userinfo.siteadmin & 8) == 0) && ((message.event.account.siteadmin & 8) != 0))) { meshserver.send({ action: 'files' }); }
+                                userinfo = message.event.account;
+                                updateSelf();
+
+                                if (message.event.nodeListChange == userinfo._id) { meshserver.send({ action: 'nodes', skip: (devicePagingState == null) ? 0 : devicePagingState.skip }); }
+                            }
+                            break;
+                        }
+                        case 'createusergroup':
+                        case 'usergroupchange': {
+                            if (usergroups == null) { usergroups = {}; }
+                            var ugroup = usergroups[message.event.ugrpid];
+                            if (ugroup == null) {
+                                usergroups[message.event.ugrpid] = { _id: message.event.ugrpid, name: message.event.name, desc: message.event.desc, domain: message.event.domain, links: message.event.links };
+                            } else {
+                                ugroup.name = message.event.name;
+                                ugroup.desc = message.event.desc;
+                                ugroup.links = message.event.links;
+                                ugroup.flags = message.event.flags;
+                            }
+
+                            meshserver.send({ action: 'meshes' });
+                            meshserver.send({ action: 'nodes', skip: (devicePagingState == null) ? 0 : devicePagingState.skip });
+                            break;
+                        }
+                        case 'deleteusergroup': {
+                            if ((usergroups != null) && (usergroups[message.event.ugrpid] != null)) {
+                                delete usergroups[message.event.ugrpid];
+                                var c = 0;
+                                for (var i in usergroups) { c++; }
+                                if (c == 0) { usergroups = null; }
+                            }
+                            break;
+                        }
+                        case 'createmesh': {
+                            if ((meshes[message.event.meshid] == null) && ((userinfo.manageAllDeviceGroups) || (message.event.mesh.links[userinfo._id] != null))) {
+                                meshes[message.event.meshid] = message.event.mesh;
+                                mainUpdate(4 + 128);
+                                meshserver.send({ action: 'files' });
+                            }
+                            break;
+                        }
+                        case 'meshchange': {
+                            if (meshes[message.event.meshid] == null) {
+                                var add = false;
+                                if (message.event.links[userinfo._id] != null) { add = true; }
+                                if (userinfo.links[message.event.meshid] != null) { add = true; }
+                                for (var i in userinfo.links) { if ((i.startsWith('ugrp/')) && (message.event.links[i] != null)) { add = true; } }
+
+                                if (add) {
+                                    meshes[message.event.meshid] = { _id: message.event.meshid, name: message.event.name, mtype: message.event.mtype, desc: message.event.desc, links: message.event.links, relayid: message.event.relayid };
+                                    meshserver.send({ action: 'nodes', skip: (devicePagingState == null) ? 0 : devicePagingState.skip });
+                                }
+                            } else {
+                                if (meshes[message.event.meshid].name != message.event.name) {
+                                    meshes[message.event.meshid].name = message.event.name;
+                                    for (var i in nodes) { if (nodes[i].meshid == message.event.meshid) { nodes[i].meshnamel = message.event.name.toLowerCase(); } }
+                                }
+                                meshes[message.event.meshid].desc = message.event.desc;
+                                meshes[message.event.meshid].links = message.event.links;
+                                if (message.event.relayid != null) { meshes[message.event.meshid].relayid = message.event.relayid; }
+
+                                if (IsMeshViewable(message.event.meshid) == false) {
+                                    if ((xxcurrentView == 20) && (currentMesh == meshes[message.event.meshid])) go(2);
+                                    delete meshes[message.event.meshid];
+
+                                    var newnodes = [];
+                                    for (var i in nodes) { if ((nodes[i].meshid != message.event.meshid) || ((userinfo.links != null) && (userinfo.links[nodes[i]._id] != null))) { newnodes.push(nodes[i]); } }
+                                    nodes = newnodes;
+
+                                    if (xxcurrentView >= 10 && xxcurrentView < 20 && currentNode && !IsNodeViewable(currentNode)) { setDialogMode(0); go(2); currentNode = null; }
+                                }
+                            }
+                            mainUpdate(4 + 128);
+                            meshserver.send({ action: 'files' });
+
+                            if (xxcurrentView == 20 && currentMesh._id == message.event.meshid) { p20updateMesh(); }
+                            break;
+                        }
+                        case 'deletemesh': {
+                            if (meshes[message.event.meshid]) {
+                                delete meshes[message.event.meshid];
+                                updateMeshes();
+                                meshserver.send({ action: 'files' });
+                            }
+
+                            var newnodes = [];
+                            for (var i in nodes) { if (nodes[i].meshid != message.event.meshid) { newnodes.push(nodes[i]); } }
+                            nodes = newnodes;
+                            mainUpdate(4);
+
+                            if (xxcurrentView >= 20 && xxcurrentView < 30 && currentMesh._id == message.event.meshid) { setDialogMode(0); go(2); }
+                            if (xxcurrentView >= 10 && xxcurrentView < 20 && currentNode && !IsNodeViewable(currentNode)) { setDialogMode(0); go(2); }
+
+                            break;
+                        }
+                        case 'addnode': {
+                            var node = message.event.node;
+                            if (!meshes[node.meshid]) break;
+                            if (getNodeFromId(node._id) != null) break;
+                            node.namel = node.name.toLowerCase();
+                            if (node.rname) { node.rnamel = node.rname.toLowerCase(); } else { node.rnamel = node.namel; }
+                            node.meshnamel = meshes[node.meshid]?meshes[node.meshid].name.toLowerCase():'*';
+                            node.state = 0;
+                            if (!node.icon) node.icon = 1;
+                            node.ident = ++nodeShortIdent;
+                            nodes.push(node);
+                            mainUpdate(4);
+                            break;
+                        }
+                        case 'removenode': {
+                            var index = -1;
+                            for (var i in nodes) { if (nodes[i]._id == message.event.nodeid) { index = i; break; } }
+                            if (index != -1) {
+                                var node = nodes[index];
+                                if (currentNode == node) {
+                                    if (xxcurrentView >= 10 && xxcurrentView < 20) { setDialogMode(0); go(2); }
+                                    currentNode = null;
+                                }
+                                nodes.splice(index, 1);
+                                mainUpdate(4);
+                            }
+                            break;
+                        }
+                        case 'changenode': {
+                            var index = -1;
+                            for (var i in nodes) { if (nodes[i]._id == message.event.nodeid) { index = i; break; } }
+                            if (index != -1) {
+                                var node = nodes[index];
+
+                                node.name = message.event.node.name;
+                                node.rname = message.event.node.rname;
+                                node.lusers = message.event.node.lusers;
+                                node.users = message.event.node.users;
+                                node.host = message.event.node.host;
+                                node.desc = message.event.node.desc;
+                                node.publicip = message.event.node.publicip;
+                                node.iploc = message.event.node.iploc;
+                                node.wifiloc = message.event.node.wifiloc;
+                                node.gpsloc = message.event.node.gpsloc;
+                                node.tags = message.event.node.tags;
+                                node.ssh = message.event.node.ssh;
+                                node.rdp = message.event.node.rdp;
+                                node.userloc = message.event.node.userloc;
+                                node.rdpport = message.event.node.rdpport;
+                                node.rfbport = message.event.node.rfbport;
+                                node.sshport = message.event.node.sshport;
+                                node.httpport = message.event.node.httpport;
+                                node.httpsport = message.event.node.httpsport;
+                                node.consent = message.event.node.consent;
+                                node.pmt = message.event.node.pmt;
+                                if (message.event.node.agent != null) {
+                                    if (node.agent == null) node.agent = {};
+                                    if (message.event.node.agent.ver != null) { node.agent.ver = message.event.node.agent.ver; }
+                                    if (message.event.node.agent.id != null) { node.agent.id = message.event.node.agent.id; }
+                                    if (message.event.node.agent.caps != null) { node.agent.caps = message.event.node.agent.caps; }
+                                    if (message.event.node.agent.root != null) { node.agent.root = message.event.node.agent.root; }
+                                    if (message.event.node.agent.core != null) { node.agent.core = message.event.node.agent.core; } else { if (node.agent.core) { delete node.agent.core; } }
+                                    node.agent.tag = message.event.node.agent.tag;
+                                }
+                                if (message.event.node.intelamt != null) {
+                                    if (node.intelamt == null) node.intelamt = {};
+                                    if (message.event.node.intelamt.state != null) { node.intelamt.state = message.event.node.intelamt.state; }
+                                    if (message.event.node.intelamt.host != null) { node.intelamt.user = message.event.node.intelamt.host; }
+                                    if (message.event.node.intelamt.user != null) { node.intelamt.user = message.event.node.intelamt.user; }
+                                    if (message.event.node.intelamt.tls != null) { node.intelamt.tls = message.event.node.intelamt.tls; }
+                                    if (message.event.node.intelamt.ver != null) { node.intelamt.ver = message.event.node.intelamt.ver; }
+                                    if (message.event.node.intelamt.tag != null) { node.intelamt.tag = message.event.node.intelamt.tag; }
+                                    if (message.event.node.intelamt.uuid != null) { node.intelamt.uuid = message.event.node.intelamt.uuid; }
+                                    if (message.event.node.intelamt.realm != null) { node.intelamt.realm = message.event.node.intelamt.realm; }
+                                    if (message.event.node.intelamt.flags != null) { node.intelamt.flags = message.event.node.intelamt.flags; }
+                                    if (message.event.node.intelamt.warn != null) { node.intelamt.warn = message.event.node.intelamt.warn; } else { delete node.intelamt.warn; }
+                                }
+                                if (message.event.node.av != null) { node.av = message.event.node.av; }
+                                if (message.event.node.wsc != null) { node.wsc = message.event.node.wsc; }
+                                node.namel = node.name.toLowerCase();
+                                if (node.rname) { node.rnamel = node.rname.toLowerCase(); } else { node.rnamel = node.namel; }
+                                if (message.event.node.icon) { node.icon = message.event.node.icon; }
+                                if (message.event.node.lastbootuptime != null) { node.lastbootuptime = message.event.node.lastbootuptime; }
+
+                                refreshDevice(node._id);
+                                updateDeviceViewDevice(node);
+                                if (currentNode == node) { updateDeviceDetails(); }
+                            }
+                            break;
+                        }
+                        case 'nodemeshchange': {
+                            var index = -1;
+                            for (var i in nodes) { if (nodes[i]._id == message.event.nodeid) { index = i; break; } }
+                            if (index != -1) {
+                                var node = nodes[index];
+                                if ((meshes[message.event.newMeshId] == null) && ((userinfo.links == null) || (userinfo.links[node._id] == null))) {
+                                    if (xxcurrentView >= 10 && xxcurrentView < 20 && currentNode && !IsNodeViewable(currentNode)) { setDialogMode(0); go(2); currentNode = null; }
+                                    nodes.splice(index, 1);
+                                } else {
+                                    node.meshid = message.event.newMeshId;
+                                    node.meshnamel = meshes[message.event.newMeshId]?meshes[message.event.newMeshId].name.toLowerCase():'*';
+                                }
+                                mainUpdate(4);
+                                refreshDevice(message.event.nodeid);
+                            } else {
+                                var node = message.event.node;
+                                if (!meshes[node.meshid]) break;
+                                node.namel = node.name.toLowerCase();
+                                if (node.rname) { node.rnamel = node.rname.toLowerCase(); } else { node.rnamel = node.namel; }
+                                node.meshnamel = meshes[node.meshid]?meshes[node.meshid].name.toLowerCase():'*';
+                                node.state = 0;
+                                if (!node.icon) node.icon = 1;
+                                node.ident = ++nodeShortIdent;
+                                if (nodes == null) { }
+                                nodes.push(node);
+
+                                mainUpdate(4);
+                            }
+                            break;
+                        }
+                        case 'nodeconnect': {
+                            var index = -1;
+                            for (var i in nodes) { if (nodes[i]._id == message.event.nodeid) { index = i; break; } }
+                            if (index != -1) {
+                                var node = nodes[index];
+
+                                node.conn = message.event.conn;
+                                node.pwr = message.event.pwr;
+
+                                if ((node.conn & 1) == 0) { delete node.sessions; }
+
+                                refreshDevice(node._id);
+                                updateDeviceViewDevice(node);
+                            }
+                            break;
+                        }
+                        case 'login': {
+                            if (users != null && users['user/' + domain + '/' + message.event.username.toLowerCase()]) { users['user/' + domain + '/' + message.event.username.toLowerCase()].login = message.event.time; }
+                            break;
+                        }
+                        case 'notify': {
+                            var n = { text: message.event.value, title: message.event.title, icon: message.event.icon, titleid: message.titleid, msgid: message.msgid, args: message.args };
+                            if (message.id != null) { n.id = message.id; }
+                            if (message.event.tag != null) { n.tag = message.event.tag; }
+                            if (typeof message.maxtime == 'number') { n.maxtime = message.maxtime; }
+                            addNotification(n);
+                            break;
+                        }
+                        case 'sysinfohash': {
+                            if ((currentNode != null) && (message.event.nodeid == powerTimelineReq)) { meshserver.send({ action: 'getsysinfo', nodeid: message.event.nodeid }); }
+                            break;
+                        }
+                        case 'ifchange': {
+                            if ((currentNode != null) && (currentNode._id == message.event.nodeid)) { meshserver.send({ action: 'getnetworkinfo', nodeid: currentNode._id }); }
+                            break;
+                        }
+                        case 'devicesessions': {
+                            var node = getNodeFromId(message.event.nodeid);
+                            if (node == null) break;
+                            node.sessions = message.event.sessions;
+                            if (node.sessions != null) {
+                                for (var i in node.sessions) { if (Object.keys(node.sessions[i]).length == 0) { delete node.sessions[i]; } }
+                                if (Object.keys(node.sessions).length == 0) { delete node.sessions; }
+                            }
+
+                            refreshDevice(message.event.nodeid);
+                            updateDeviceViewDevice(node);
+
+                            if (xxdialogTag == ('SESSIONS-' + message.event.nodeid)) { showDeviceSessions(message.event.nodeid, true); }
+                            if (xxdialogTag == ('HELPREQ-' + message.event.nodeid)) { showDeviceHelpRequests(message.event.nodeid, true); }
+
+                            break;
+                        }
+                        case 'stopped': {
+                            break;
+                        }
+                        default:
+                            break;
+                    }
+                    break;
+                }
+                case 'getcookie': {
+                    if (message.tag == 'novnc') {
+                        var vncurl = window.location.origin + domainUrl + 'novnc/vnc.html?ws=wss%3A%2F%2F' + window.location.host + encodeURIComponentEx(domainUrl) + (message.localRelay?'local':'mesh') + 'relay.ashx%3Fauth%3D' + message.cookie + '&show_dot=1' + (urlargs.key?('&key=' + urlargs.key):'') + '&l={{{lang}}}';
+                        var node = getNodeFromId(message.nodeid);
+                        if (node != null) { vncurl += '&name=' + encodeURIComponentEx(node.name); }
+                        safeNewWindow(vncurl, 'mcnovnc/' + message.nodeid);
+                    } else if (message.tag == 'mstsc') {
+                        var rdpurl = window.location.origin + domainUrl + 'mstsc.html?ws=' + message.cookie + (urlargs.key?('&key=' + urlargs.key):'');
+                        var node = getNodeFromId(message.nodeid);
+                        if (node != null) { rdpurl += '&name=' + encodeURIComponentEx(node.name); }
+                        if (message.localRelay) { rdpurl += '&local=1'; }
+                        safeNewWindow(rdpurl, 'mcmstsc/' + message.nodeid);
+                    } else if (message.tag == 'ssh') {
+                        var sshurl = window.location.origin + domainUrl + 'ssh.html?ws=' + message.cookie + (urlargs.key?('&key=' + urlargs.key):'');
+                        var node = getNodeFromId(message.nodeid);
+                        if (node != null) { sshurl += '&name=' + encodeURIComponentEx(node.name); }
+                        if (message.localRelay) { sshurl += '&local=1'; }
+                        safeNewWindow(sshurl, 'mcssh/' + message.nodeid);
+                    }
+                    break;
+                }
+                default:
+                    break;
+            }
+        }
+
+        var updateNaggleTimer = null;
+        var updateNaggleFlags = 0;
+        function mainUpdate(flags) {
+            updateNaggleFlags |= flags;
+            if (updateNaggleTimer == null) {
+                updateNaggleTimer = setTimeout(function () {
+                    if (updateNaggleFlags & 1) { onSearchInputChanged(); }
+                    if (updateNaggleFlags & 4) { updateDevices(); updateDeviceDetails(); }
+                    if (updateNaggleFlags & 128) { updateMeshes(); }
+                    updateNaggleTimer = null;
+                    updateNaggleFlags = 0;
+                    gotoStartViewPage();
+                }, 150);
+            }
+        }
+
+        function gotoStartViewPage() {
+            var xviewmode = parseInt('{{viewmode}}');
+            if (xxcurrentView > 1) return;
+            if ('{{currentNode}}'.toLowerCase() != '') {
+                if (getNodeFromId('{{currentNode}}') == null) return;
+                gotoDevice('{{currentNode}}', xviewmode);
+            } else if (args.gotonode != null) {
+                if (args.gotonode.length == 96) { args.gotonode = btoa(hex2rstr(args.gotonode)).split('+').join('@').split('/').join('$'); }
+                if (getNodeFromId('node/' + domain + '/' + args.gotonode) == null) return;
+                if (args.panel) { currentDevicePanel = parseInt(args.panel); }
+                gotoDevice('node/' + domain + '/' + args.gotonode, xviewmode);
+            } else if (args.gotodevicename != null) {
+                var foundNode = null;
+                if (nodes != null) { for (var i in nodes) { if (nodes[i].name == args.gotodevicename) { foundNode = nodes[i]._id; } } }
+                if (foundNode) { gotoDevice(foundNode, xviewmode); go(xviewmode); }
+            } else if (args.gotodevicername != null) {
+                var foundNode = null;
+                if (nodes != null) { for (var i in nodes) { if (nodes[i].rname == args.gotodevicername) { foundNode =  nodes[i]._id; } } }
+                if (foundNode) { gotoDevice(foundNode, xviewmode); goBackStack.push(1); } 
+            } else if (args.gotodeviceip != null) {
+                var foundNode = null;
+                if (nodes != null) { for (var i in nodes) { if (nodes[i].ip == args.gotodeviceip) { foundNode = nodes[i]._id; } } }
+                if (foundNode) { gotoDevice(foundNode, xviewmode); go(xviewmode); }
+            } else if (args.gotomesh != null) {
+                if (meshes['mesh/' + domain + '/' + args.gotomesh] == null) return;
+                gotoMesh('mesh/' + domain + '/' + args.gotomesh);
+                go(xviewmode);
+            } else if (!isNaN(xviewmode)) {
+                go(xviewmode);
+            } else {
+                setDialogMode(0);
+                go(1);
+            }
+            delete args.gotonode;
+            delete args.gotomesh;
+            delete args.panel;
+            if (xxcurrentView < 2) { go(2); }
+        }
+
+        function topMenu(select) {
+            if ((xxdialogMode != null) && (xxdialogMode != 0) && (xxdialogMode != 999)) return;
+            if (select === undefined) {
+                var x = (QS('topMenu').display == 'none');
+                if (x == true) { if ((xxdialogMode == 0) || (xxdialogMode == null)) { QV('topMenu', true); xxdialogMode = 999; } } else { QV('topMenu', false); xxdialogMode = 0; }
+            } else {
+                QV('topMenu', false);
+                xxdialogMode = 0;
+                if ((select == 1) && (xxcurrentView != 3)) { goForward('account'); }
+                if ((select == 2) && (xxcurrentView != 5)) { goForward('files'); }
+            }
+        }
+
+        var backStack = [];
+        function goBack() { if (xxdialogMode) return; if (backStack.length > 0) { backStack.pop(); } goStack(); }
+        function goForward(id) { if (xxdialogMode) return; backStack.push(id); goStack(); }
+        function goStack() {
+            if (backStack.length == 0) { go(2); return; }
+            var id = backStack[backStack.length - 1], idtype = id.split('/')[0];
+            if (idtype == 'node') { setupDeviceMenu(0); gotoDevice(id); }
+            if (idtype == 'mesh') { gotoMesh(id); }
+            if (idtype == 'account') { go(3); }
+            if (idtype == 'devices') { go(2); }
+            if (idtype == 'files') {
+                if ((features & 0x00040000) && !((userinfo.otpsecret == 1) || (userinfo.otphkeys > 0) || (userinfo.otpkeys > 0) || (userinfo.otpduo > 0) || (userinfo.otpdev > 0) || ((features & 0x00800000) && (userinfo.otpekey == 1)))) { setDialogMode(2, "Account Security", 1, null, "Unable to access this feature until two-factor authentication is enabled. This is required for extra security. Go to the \"My Account\" and look at the \"Account Security\" section."); return; }  
+                go(5);
+            }
+        }
+
+        function updateFooterMenu(options, targetView) {
+            var viewToCheck = (targetView != null) ? targetView : xxcurrentView;
+            var shouldShow = (viewToCheck == 10);
+            
+            if (options == null) { options = []; }
+            
+            while (options.length < 6) { options.push({ n: '', f: '' }); }
+            if (options.length > 6) { options = options.slice(0, 6); }
+            
+            var x = '', prev = '';
+            for (var i = 0; i < 6; i++) {
+                var item = options[i] || { n: '', f: '' };
+                var hasContent = (item.n && item.n != '');
+                var cursorStyle = hasContent ? 'cursor:pointer' : 'cursor:default';
+                var onclickAttr = (hasContent && item.f) ? 'onclick="' + item.f + '"' : '';
+                var borderStyle = (i > 0 && hasContent && prev != '') ? ';border-left:solid 1px white' : '';
+                x += '<td style="' + cursorStyle + borderStyle + '" ' + onclickAttr + '>' + (item.n || '&nbsp;') + '</td>'; 
+                if (hasContent) prev = item.n;
+            }
+            QH('topBarMenu', '<tr>' + x + '</tr>');
+            QV('top-bar', shouldShow);
+            
+            var baseTop = shouldShow ? 82 : 50;
+            var pageContentTop = 'calc(' + baseTop + 'px + env(safe-area-inset-top))';
+            QS('page_content').top = pageContentTop;
+        }
+
+        function account_viewPreviousLogins() {
+            if (xxdialogMode) return;
+            setDialogMode(2, "Previous Logins", 1, null, "Loading...", 'previousLogins');
+            meshserver.send({ action: 'previousLogins' });
+        }
+
+        function account_manageImage(mode) {
+            if (xxdialogMode) return;
+            var user = (mode == 0) ? userinfo : currentUser;
+            var x = '<input id=p2file type=file style=width:100% accept="image/*" onchange=account_manageImageEx()><div style=width:100%><canvas id=p2canvas width=256 height=256 style="width:256px;height:256px;margin-left:12px;margin-top:8px;border-radius:16px;box-shadow: 0px 0px 15px #000" onclick=account_canvasClick() /></div>';
+            setDialogMode(2, "Manage Account Image", 7, account_manageImageEx2, x, user._id);
+            var ctx = Q('p2canvas').getContext('2d');
+            if (user.accountImageRnd == null) { user.accountImageRnd = Math.floor(Math.random() * 9999999999); }
+            var arg = '';
+            if (mode == 1) { arg = '&id=' + user._id.split('/')[2]; }
+            var myImg = new Image();
+            myImg.onload = function () { ctx.clearRect(0, 0, 256, 256); ctx.drawImage(myImg, 0, 0); };
+            myImg.src = ((user.flags != null) && (user.flags & 1)) ? ('userimage.ashx?rnd=' + user.accountImageRnd + arg) : 'images/user-256.png';
+            QE('idx_dlgDeleteButton', (user.flags != null) && (user.flags & 1));
+            QE('idx_dlgOkButton', false);
+        }
+
+        function account_canvasClick() { Q('p2file').click(); }
+
+        function account_manageImageEx() {
+            var file = Q('p2file').files[0];
+            var img = new Image;
+            img.onload = function () {
+                var cx = 0, cy = 0, min = Math.min(img.width, img.height);
+                if (img.width > min) { cx = (img.width - min) / 2; }
+                if (img.height > min) { cy = (img.height - min) / 2; }
+                var ctx = Q('p2canvas').getContext('2d');
+                ctx.imageSmoothingEnabled = true;
+                ctx.webkitImageSmoothingEnabled = true;
+                ctx.mozImageSmoothingEnabled = true;
+                ctx.clearRect(0, 0, 256, 256);
+                ctx.drawImage(img, cx, cy, min, min, 0, 0, 256, 256);
+                QE('idx_dlgOkButton', true);
+            }
+            img.src = URL.createObjectURL(file);
+        }
+
+        function account_manageImageEx2(b, userid) {
+            meshserver.send({ action: 'updateUserImage', userid: userid, image: (b == 2) ? 0 : Q('p2canvas').toDataURL('image/jpeg', 0.8) });
+        }
+
+        function toggleNightMode() {
+            if (xxdialogMode) return;
+            var cNightMode = getstore('nightMode', '0');
+            var x = '<input type=radio id=night0 name=nightmoderadio value=0 ' + ((cNightMode == 0) ? 'checked' : '') + '><label for=night0>' + "Browser default" + '</label><br>';
+            x += '<input type=radio id=night2 name=nightmoderadio value=2 ' + ((cNightMode == 2) ? 'checked' : '') + '><label for=night2>' + "Light mode" + '</label><br>';
+            x += '<input type=radio id=night1 name=nightmoderadio value=1 ' + ((cNightMode == 1) ? 'checked' : '') + '><label for=night1>' + "Dark mode" + '</label><br>';
+            setDialogMode(2, "Night Mode", 3, toggleNightModeEx, x);
+            QV('uiMenu', false);
+        }
+
+        function toggleNightModeEx() {
+            var nNightMode = '0';
+            if (Q('night1').checked) { nNightMode = '1'; }
+            if (Q('night2').checked) { nNightMode = '2'; }
+            putstore('nightMode', nNightMode);
+            setNightMode();
+        }
+
+        function setNightMode() {
+            var nNightMode = getstore('nightMode', '0')
+            nightMode = false;
+            if ((features2 & 0x00100000) != 0) { nNightMode = '1'; }
+            if ((features2 & 0x00200000) != 0) { nNightMode = '2'; }
+            if (nNightMode == '1') { nightMode = true; }
+            else if ((nNightMode == '0') && (window.matchMedia)) { nightMode = window.matchMedia('(prefers-color-scheme: dark)').matches }
+            if (nightMode) { QC('body').add('night'); QS('body')['background-color'] = '#000'; QS('body')['color'] = 'lightgray'; } else { QC('body').remove('night'); QS('body')['background-color'] = '#FFF'; QS('body')['color'] = 'black'; }
+            return nightMode;
+        }
+
+        function account_managePhone() {
+            if (xxdialogMode || ((features & 0x02000000) == 0)) return;
+            var x;
+            if (userinfo.phone != null) {
+                x = '<table style=width:100%><tr><td style=width:56px><img src="images/phone80.png" style=padding:8px>';
+                x += '<td style=text-align:center><div style=padding:6px>' + "Verified phone number" + '</div><div style=font-size:20px>' + userinfo.phone + '</div>';
+                x += '<div style=margin:10px><label><input id=d2delPhone type=checkbox onclick=account_managePhoneRemoveValidate() />' + "Remove phone number" + '</label></div>';
+                setDialogMode(2, "Phone Notifications", 3, account_managePhoneRemove, x);
+                account_managePhoneRemoveValidate();
+            } else {
+                x = '<table style=width:100%><tr><td style=width:56px><img src="images/phone80.png" style=padding:8px>';
+                x += '<td>Enter your SMS capable phone number. Once verified, the number may be used for login verification and other notifications.';
+                x += '<br /><br /><div style=width:100%;text-align:center>' + "Phone number:" + ' <input type=tel pattern="[0-9]" autocomplete="tel" inputmode="tel" maxlength=18 id=d2phoneinput onKeyUp=account_managePhoneValidate() onkeypress="if (event.key==\'Enter\') account_managePhoneValidate(1)"></div></table>';
+                setDialogMode(2, "Phone Notifications", 3, account_managePhoneAdd, x, 'verifyPhone');
+                Q('d2phoneinput').focus();
+                account_managePhoneValidate();
+            }
+        }
+
+        function isPhoneNumber(x) { return x.match(/^\(?([0-9]{3,4})\)?[-. ]?([0-9]{3})[-. ]?([0-9]{4})$/) }
+        function account_managePhoneValidate(x) { var ok = isPhoneNumber(Q('d2phoneinput').value); QE('idx_dlgOkButton', ok); if ((x == 1) && ok) { dialogclose(1); } }
+        function account_managePhoneCodeValidate(x) { var ok = (Q('d2phoneCodeInput').value.length == 6) && Q('d2phoneCodeInput').value.match(/[0-9]/); QE('idx_dlgOkButton', ok); if ((x == 1) && ok) { dialogclose(1); } }
+        function account_managePhoneConfirm(b, tag) { meshserver.send({ action: 'confirmPhone', code: Q('d2phoneCodeInput').value, cookie: tag }); }
+        function account_managePhoneAdd() { if (isPhoneNumber(Q('d2phoneinput').value) == false) return; QE('d2phoneinput', false); meshserver.send({ action: 'verifyPhone', phone: Q('d2phoneinput').value }); }
+        function account_managePhoneRemove() { if (Q('d2delPhone').checked) { meshserver.send({ action: 'removePhone' }); } }
+        function account_managePhoneRemoveValidate() { QE('idx_dlgOkButton', Q('d2delPhone').checked); }
+
+        function account_manageAuthEmail() {
+            if (xxdialogMode || ((features & 0x00800000) == 0)) return;
+            var emailU2Fenabled = ((userinfo.otpekey == 1) && (userinfo.email != null) && (userinfo.emailVerified == true));
+            setDialogMode(2, "Email Authentication", 1, function () {
+                if (emailU2Fenabled != Q('email2facheck').checked) { meshserver.send({ action: 'otpemail', enabled: Q('email2facheck').checked }); }
+            }, "When enabled, on each login, you will be given the option to receive a login token to you email account for added security." + '<br /><br /><label><input id=email2facheck type=checkbox ' + (emailU2Fenabled ? 'checked' : '') + '/>' + "Enable email two-factor authentication." + '</label>');
+        }
+
+        var loclist = { 'af': "Afrikaans", 'sq': "Albanian", 'ar': "Arabic (Standard)", 'ar-dz': "Arabic (Algeria)", 'ar-bh': "Arabic (Bahrain)", 'ar-eg': "Arabic (Egypt)", 'ar-iq': "Arabic (Iraq)", 'ar-jo': "Arabic (Jordan)", 'ar-kw': "Arabic (Kuwait)", 'ar-lb': "Arabic (Lebanon)", 'ar-ly': "Arabic (Libya)", 'ar-ma': "Arabic (Morocco)", 'ar-om': "Arabic (Oman)", 'ar-qa': "Arabic (Qatar)", 'ar-sa': "Arabic (Saudi Arabia)", 'ar-sy': "Arabic (Syria)", 'ar-tn': "Arabic (Tunisia)", 'ar-ae': "Arabic (U.A.E.)", 'ar-ye': "Arabic (Yemen)", 'an': "Aragonese", 'hy': "Armenian", 'as': "Assamese", 'ast': "Asturian", 'az': "Azerbaijani", 'eu': "Basque", 'bg': "Bulgarian", 'be': "Belarusian", 'bn': "Bengali", 'bs': "Bosnian", 'br': "Breton", 'my': "Burmese", 'ca': "Catalan", 'ch': "Chamorro", 'ce': "Chechen", 'zh': "Chinese", 'zh-hk': "Chinese (Hong Kong)", 'zh-cn': "Chinese (PRC)", 'zh-sg': "Chinese (Singapore)", 'zh-tw': "Chinese (Taiwan)", 'cv': "Chuvash", 'co': "Corsican", 'cr': "Cree", 'hr': "Croatian", 'cs': "Czech", 'da': "Danish", 'nl': "Dutch (Standard)", 'nl-be': "Dutch (Belgian)", 'en': "English", 'en-au': "English (Australia)", 'en-bz': "English (Belize)", 'en-ca': "English (Canada)", 'en-ie': "English (Ireland)", 'en-jm': "English (Jamaica)", 'en-nz': "English (New Zealand)", 'en-ph': "English (Philippines)", 'en-za': "English (South Africa)", 'en-tt': "English (Trinidad & Tobago)", 'en-gb': "English (United Kingdom)", 'en-us': "English (United States)", 'en-zw': "English (Zimbabwe)", 'eo': "Esperanto", 'et': "Estonian", 'fo': "Faeroese", 'fa': "Farsi (Persian)", 'fj': "Fijian", 'fi': "Finnish", 'fr': "French (Standard)", 'fr-be': "French (Belgium)", 'fr-ca': "French (Canada)", 'fr-fr': "French (France)", 'fr-lu': "French (Luxembourg)", 'fr-mc': "French (Monaco)", 'fr-ch': "French (Switzerland)", 'fy': "Frisian", 'fur': "Friulian", 'gd': "Gaelic (Scots)", 'gd-ie': "Gaelic (Irish)", 'gl': "Galacian", 'ka': "Georgian", 'de': "German (Standard)", 'de-at': "German (Austria)", 'de-de': "German (Germany)", 'de-li': "German (Liechtenstein)", 'de-lu': "German (Luxembourg)", 'de-ch': "German (Switzerland)", 'el': "Greek", 'gu': "Gujurati", 'ht': "Haitian", 'he': "Hebrew", 'hi': "Hindi", 'hu': "Hungarian", 'is': "Icelandic", 'id': "Indonesian", 'iu': "Inuktitut", 'ga': "Irish", 'it': "Italian (Standard)", 'it-ch': "Italian (Switzerland)", 'ja': "Japanese", 'kn': "Kannada", 'ks': "Kashmiri", 'kk': "Kazakh", 'km': "Khmer", 'ky': "Kirghiz", 'tlh': "Klingon", 'ko': "Korean", 'ko-kp': "Korean (North Korea)", 'ko-kr': "Korean (South Korea)", 'la': "Latin", 'lv': "Latvian", 'lt': "Lithuanian", 'lb': "Luxembourgish", 'mk': "FYRO Macedonian", 'ms': "Malay", 'ml': "Malayalam", 'mt': "Maltese", 'mi': "Maori", 'mr': "Marathi", 'mo': "Moldavian", 'nv': "Navajo", 'ng': "Ndonga", 'ne': "Nepali", 'no': "Norwegian", 'nb': "Norwegian (Bokmal)", 'nn': "Norwegian (Nynorsk)", 'oc': "Occitan", 'or': "Oriya", 'om': "Oromo", 'fa-ir': "Persian/Iran", 'pl': "Polish", 'pt': "Portuguese", 'pt-br': "Portuguese (Brazil)", 'pa': "Punjabi", 'pa-in': "Punjabi (India)", 'pa-pk': "Punjabi (Pakistan)", 'qu': "Quechua", 'rm': "Rhaeto-Romanic", 'ro': "Romanian", 'ro-mo': "Romanian (Moldavia)", 'ru': "Russian", 'ru-mo': "Russian (Moldavia)", 'sz': "Sami (Lappish)", 'sg': "Sango", 'sa': "Sanskrit", 'sc': "Sardinian", 'sd': "Sindhi", 'si': "Singhalese", 'sr': "Serbian", 'sk': "Slovak", 'sl': "Slovenian", 'so': "Somani", 'sb': "Sorbian", 'es': "Spanish", 'es-ar': "Spanish (Argentina)", 'es-bo': "Spanish (Bolivia)", 'es-cl': "Spanish (Chile)", 'es-co': "Spanish (Colombia)", 'es-cr': "Spanish (Costa Rica)", 'es-do': "Spanish (Dominican Republic)", 'es-ec': "Spanish (Ecuador)", 'es-sv': "Spanish (El Salvador)", 'es-gt': "Spanish (Guatemala)", 'es-hn': "Spanish (Honduras)", 'es-mx': "Spanish (Mexico)", 'es-ni': "Spanish (Nicaragua)", 'es-pa': "Spanish (Panama)", 'es-py': "Spanish (Paraguay)", 'es-pe': "Spanish (Peru)", 'es-pr': "Spanish (Puerto Rico)", 'es-es': "Spanish (Spain)", 'es-uy': "Spanish (Uruguay)", 'es-ve': "Spanish (Venezuela)", 'sx': "Sutu", 'sw': "Swahili", 'sv': "Swedish", 'sv-fi': "Swedish (Finland)", 'sv-sv': "Swedish (Sweden)", 'ta': "Tamil", 'tt': "Tatar", 'te': "Teluga", 'th': "Thai", 'tig': "Tigre", 'ts': "Tsonga", 'tn': "Tswana", 'tr': "Turkish", 'tk': "Turkmen", 'uk': "Ukrainian", 'hsb': "Upper Sorbian", 'ur': "Urdu", 've': "Venda", 'vi': "Vietnamese", 'vo': "Volapuk", 'wa': "Walloon", 'cy': "Welsh", 'xh': "Xhosa", 'ji': "Yiddish", 'zu': "Zulu" };
+        var loclistex = { 'zh-chs': "Chinese (Simplified)", 'zh-cht': "Chinese (Traditional)" };
+        function account_showLocalizationSettings() {
+            if (xxdialogMode) return false;
+            var n = getstore('loctag', 0), y = '';
+            var x = '<select id=d2locselect style=width:180px><option value="*">' + "User browser value" + '</option>';
+            for (var i in loclist) { x += '<option value="' + i + '"' + ((n == i)?' selected':'') + '>' + i + ' - ' + loclist[i] + '</option>'; }
+            x += '</select>';
+            if (serverinfo.languages && serverinfo.languages.length > 0) {
+                y += "Changing the language will require a refresh of the page." + '<br /><br />';
+                var z = '<select id=d2langselect style=width:180px><option value="*">' + "User browser value" + '</option>';
+                for (var i in serverinfo.languages) {
+                    var lang = serverinfo.languages[i];
+                    z += '<option value="' + lang + '"' + ((userinfo.lang == lang)?' selected':'') + '>' + lang + ' - ' + (loclist[lang]?loclist[lang]:loclistex[lang]) + '</option>';
+                }
+                z += '</select>';
+                y += addHtmlValue("Language", z);
+            }
+            y += addHtmlValue("Dates & Time", x);
+
+            if ((userinfo.siteadmin == 0xFFFFFFFF) && (domain == '')) {
+                y += '<br /><a rel="noreferrer noopener" target="_blank" href="translator.htm">' + "Help translate MeshCentral" + '</a>';
+            }
+
+            setDialogMode(2, "Localization Settings", 3, account_showLocalizationSettingsEx, y);
+            return false;
+        }
+
+        function account_showLocalizationSettingsEx() {
+            var lang = Q('d2langselect').value;
+            if ((lang == '*') && (userinfo.lang == null)) { lang = userinfo.lang; }
+            if (lang != userinfo.lang) { meshserver.send({ action: 'changelang', lang: lang }); }
+
+            var n = getstore('loctag', 0);
+            var m = Q('d2locselect').value;
+            if (n != m) {
+                if (m != '*') { args.locale = m; } else { delete args.locale; }
+                putstore('loctag', args.locale);
+                mainUpdate(0xFFFFFFFF);
+            }
+        }
+
+
+        function account_manageAuthApp() {
+            if (xxdialogMode || ((features & 4096) == 0)) return;
+            if (userinfo.otpsecret == 1) { account_removeOtp(); } else { account_addOtp(); }
+        }
+
+        function account_addOtp() {
+            if (xxdialogMode || (userinfo.otpsecret == 1) || ((features & 4096) == 0)) return;
+            setDialogMode(2, "Authenticator App", 2, function () { meshserver.send({ action: 'otpauth-setup', secret: Q('d2optsecret').attributes.secret.value, token: Q('d2otpauthinput').value }); }, '<div id=d2optinfo>' + "Loading..." + '</div>', 'otpauth-request');
+            meshserver.send({ action: 'otpauth-request' });
+        }
+
+        function account_addOtpCheck(e) {
+            var tokenIsValid = (Q('d2otpauthinput').value.length == 6);
+            QE('idx_dlgOkButton', tokenIsValid);
+            if (e && (e.keyCode == 13) && tokenIsValid) { dialogclose(1); }
+        }
+
+        function account_removeOtp() {
+            if (xxdialogMode || (userinfo.otpsecret != 1) || ((features & 4096) == 0)) return;
+            setDialogMode(2, "Authenticator App", 3, function () { meshserver.send({ action: 'otpauth-clear' }); }, "Confirm removal of authenticator application 2-step login?");
+        }
+
+        function account_manageOtp(action) {
+            if ((xxdialogMode == 2) && (xxdialogTag == 'otpauth-manage')) { dialogclose(0); }
+            if (xxdialogMode || ((features & 4096) == 0) || ((userinfo.otpsecret != 1) && (userinfo.otphkeys < 1))) return;
+            meshserver.send({ action: 'otpauth-getpasswords', subaction: action });
+        }
+
+        function account_showVerifyEmail() {
+            if (xxdialogMode || (userinfo.emailVerified == true) || (serverinfo.emailcheck != true)) return;
+            var x = "Click ok to send a verification mail to:" + '<br /><div style=padding:8px><b>' + EscapeHtml(userinfo.email) + '</b></div>' + "Please wait a few minute to receive the verification.";
+            setDialogMode(2, "Email Verification", 3, account_showVerifyEmailEx, x);
+        }
+
+        function account_showVerifyEmailEx() {
+            meshserver.send({ action: 'verifyemail', email: userinfo.email });
+        }
+
+        function account_showChangeEmail() {
+            if (xxdialogMode) return;
+            var x = addHtmlValue("Email", '<input id=dp3email style=width:170px maxlength=256 onchange=account_validateEmail() onkeyup=account_validateEmail(event) />');
+            setDialogMode(2, "Email Address Change", 3, account_changeEmail, x);
+            if (userinfo.email != null) { Q('dp3email').value = userinfo.email; }
+            account_validateEmail();
+            Q('dp3email').focus();
+        }
+
+        function account_validateEmail(e, email) {
+            QE('idx_dlgOkButton', validateEmail(Q('dp3email').value) && (Q('dp3email').value != userinfo.email));
+            if ((e != null) && (e.keyCode == 13)) { dialogclose(1); }
+        }
+
+        function account_changeEmail() {
+            meshserver.send({ action: 'changeemail', email: Q('dp3email').value });
+        }
+
+        function account_showDeleteAccount() {
+            if (xxdialogMode) return;
+            var x = '<form method=post><table style=margin-left:10px><input type=hidden name=action value=deleteaccount /><input type=hidden name=authcookie value=' + authCookie + ' /><tr>';
+            x += '<td align=right>' + "Password:" + '</td><td><input id=apassword1 type=password name=apassword1 autocomplete=off onchange=account_validateDeleteAccount() onkeyup=account_validateDeleteAccount() /></td>';
+            x += '</tr><tr><td align=right>' + "Password:" + '</td><td><input id=apassword2 type=password name=apassword2 autocomplete=off onchange=account_validateDeleteAccount() onkeyup=account_validateDeleteAccount() /></td>';
+            x += '</tr></table><div style=padding:10px;margin-bottom:4px>';
+            x += '<input id=account_dlgCancelButton type=button value="' + "Cancel" + '" style=float:right;width:80px;margin-left:5px onclick=dialogclose(0)>';
+            x += '<input id=account_dlgOkButton type=submit value="' + "OK" + '" style="float:right;width:80px" onclick=dialogclose(1)>';
+            x += '</div><br /></form>';
+            setDialogMode(2, "Delete Account", 0, null, x);
+            account_validateDeleteAccount();
+            Q('apassword1').focus();
+        }
+
+        function account_showChangePassword() {
+            if (xxdialogMode) return false;
+            var x = '<table style=margin-left:10px>';
+            x += '<tr><td align=right>' + nobreak("Old password:") + '</td><td><input id=apassword0 type=password name=apassword0 autocomplete=off onchange=account_validateNewPassword() onkeyup=account_validateNewPassword() onkeydown=account_validateNewPassword() /> <b></b></td></tr>';
+            x += '<tr><td align=right>' + nobreak("New password:") + '</td><td><input id=apassword1 type=password name=apassword1 autocomplete=off onchange=account_validateNewPassword() onkeyup=account_validateNewPassword() onkeydown=account_validateNewPassword() /> <b><span id=dxPassWarn></span></b></td></tr>';
+            x += '<tr><td align=right>' + nobreak("New password:") + '</td><td><input id=apassword2 type=password name=apassword2 autocomplete=off onchange=account_validateNewPassword() onkeyup=account_validateNewPassword() onkeydown=account_validateNewPassword() /></td></tr>';
+            if (features & 0x00010000) { x += '<tr><td align=right>' + "Password hint:" + '</td><td><input id=apasswordhint name=apasswordhint maxlength=250 type=text autocomplete=off onchange=account_validateNewPassword() onkeyup=account_validateNewPassword() onkeydown=account_validateNewPassword() /></td></tr>'; }
+            x += '</table>'
+            if (passRequirements) {
+                var r = [], rc = 0;
+                for (var i in passRequirements) { if ((i != 'reset') && (i != 'hint')) { r.push(i + ':' + passRequirements[i]); rc++; } }
+                if (rc > 0) { x += '<br /><span style=font-size:x-small>' + format("Requirements: {0}.", r.join(', ')) + '</span>'; }
+            }
+            x += '<br />';
+            setDialogMode(2, "Change Password", 3, account_showChangePasswordEx, x);
+            Q('apassword0').focus();
+            account_validateNewPassword();
+            return false;
+        }
+
+        function account_showChangePasswordEx() {
+            if (Q('apassword1').value == Q('apassword2').value) {
+                var r = { action: 'changepassword', oldpass: Q('apassword0').value, newpass: Q('apassword1').value };
+                if (features & 0x00010000) { r.hint = Q('apasswordhint').value; }
+                meshserver.send(r);
+            }
+        }
+
+        function account_createMesh() {
+            if (xxdialogMode) return;
+
+            if ((userinfo.siteadmin != 0xFFFFFFFF) && ((userinfo.siteadmin & 64) != 0)) { setDialogMode(2, "New Device Group", 1, null, "This account does not have the rights to create a new device group."); return; }
+
+            if ((userinfo.emailVerified !== true) && (serverinfo.emailcheck == true) && (userinfo.siteadmin != 0xFFFFFFFF)) { setDialogMode(2, "Account Security", 1, null, "Unable to access a device until a email address is verified. This is required for password recovery. Go to the \"My Account\" to change and verify an email address."); return; }
+
+            if ((features & 0x00040000) && !((userinfo.otpsecret == 1) || (userinfo.otphkeys > 0) || (userinfo.otpkeys > 0) || (userinfo.otpduo > 0) || (userinfo.otpdev > 0) || ((features & 0x00800000) && (userinfo.otpekey == 1)))) { setDialogMode(2, "Account Security", 1, null, "Unable to access a device until two-factor authentication is enabled. This is required for extra security. Go to the \"My Account\" and look at the \"Account Security\" section."); return; }
+
+            var x = addHtmlValue("Name", '<input id=dp3meshname style=width:170px maxlength=64 onchange=account_validateMeshCreate() onkeyup=account_validateMeshCreate() />');
+            x += addHtmlValue("Type", '<div style=width:170px;margin:0;padding:0><select id=dp3meshtype style=width:100% onchange=account_validateMeshCreate() ><option value=2>' + "Software Agent Group" + '</option><option value=1>' + "Intel&reg; AMT only" + '</option></select></div>');
+            x += addHtmlValue("Description", '<div style=width:170px;margin:0;padding:0><textarea id=dp3meshdesc maxlength=1024 style=width:100%;resize:none></textarea></div>');
+            setDialogMode(2, "Create Device Group", 3, account_createMeshEx, x);
+            account_validateMeshCreate();
+            Q('dp3meshname').focus();
+        }
+
+        function account_validateMeshCreate() {
+            QE('idx_dlgOkButton', Q('dp3meshname').value.length > 0);
+        }
+
+        function account_createMeshEx(button, tag) {
+            meshserver.send({ action: 'createmesh', meshname: Q('dp3meshname').value, meshtype: parseInt(Q('dp3meshtype').value), desc: Q('dp3meshdesc').value });
+        }
+
+        function account_validateDeleteAccount() {
+            QE('account_dlgOkButton', (Q('apassword1').value.length > 0) && (Q('apassword1').value == Q('apassword2').value));
+        }
+
+        function account_validateNewPassword() {
+            var r = '', ok = (Q('apassword0').value.length > 0) && (Q('apassword1').value.length > 0) && (Q('apassword1').value == Q('apassword2').value) && (Q('apassword0').value != Q('apassword1').value);
+            if ((features & 0x00010000) && (Q('apasswordhint').value == Q('apassword1').value)) { ok = false; }
+            if (Q('apassword1').value != '') {
+                if (passRequirements == null || passRequirements == '') {
+                    var passStrength = checkPasswordStrength(Q('apassword1').value);
+                    if (passStrength >= 80) { r = '<span style=color:green>Strong<span>'; } else if (passStrength >= 60) { r = '<span style=color:blue>&#9679;<span>'; } else { r = '<span style=color:red>&#9679;<span>'; }
+                } else {
+                    var passReq = checkPasswordRequirements(Q('apassword1').value, passRequirements);
+                    if (passReq == false) { ok = false; r = '<span style=color:red>' + "Policy" + '<span>' }
+                }
+            }
+            QH('dxPassWarn', r);
+            QE('idx_dlgOkButton', ok);
+        }
+
+        function checkPasswordStrength(password) {
+            var r = 0, letters = {}, varCount = 0, variations = { digits: /\d/.test(password), lower: /[a-z]/.test(password), upper: /[A-Z]/.test(password), nonWords: /\W/.test(password) }
+            if (!password) return 0;
+            for (var i = 0; i < password.length; i++) { letters[password[i]] = (letters[password[i]] || 0) + 1; r += 5.0 / letters[password[i]]; }
+            for (var c in variations) { varCount += (variations[c] == true) ? 1 : 0; }
+            return parseInt(r + (varCount - 1) * 10);
+        }
+
+        function checkPasswordRequirements(password, requirements) {
+            if ((requirements == null) || (requirements == '') || (typeof requirements != 'object')) return true;
+            if (requirements.min) { if (password.length < requirements.min) return false; }
+            if (requirements.max) { if (password.length > requirements.max) return false; }
+            var numeric = 0, lower = 0, upper = 0, nonalpha = 0;
+            for (var i = 0; i < password.length; i++) {
+                if (/\d/.test(password[i])) { numeric++; }
+                if (/[a-z]/.test(password[i])) { lower++; }
+                if (/[A-Z]/.test(password[i])) { upper++; }
+                if (/\W/.test(password[i])) { nonalpha++; }
+            }
+            if (requirements.numeric && (numeric < requirements.numeric)) return false;
+            if (requirements.lower && (lower < requirements.lower)) return false;
+            if (requirements.upper && (upper < requirements.upper)) return false;
+            if (requirements.nonalpha && (nonalpha < requirements.nonalpha)) return false;
+            return true;
+        }
+
+        function updateMeshes() {
+            var r = '', count = 0;
+            for (i in meshes) {
+                count++;
+
+                var meshrights = GetMeshRights(meshes[i]);
+                var rights = "Partial Rights";
+                if (meshrights == 0xFFFFFFFF) rights = "Full Administrator"; else if (meshrights == 0) rights = "No Rights";
+
+                r += '<div style=cursor:pointer onclick=goForward(\'' + i + '\')>';
+                r += '<div style="float:left;margin-left:4px"><img src="/images/meshicon50.png" width=50 height=50 /></div>';
+                r += '<div class=meshList>';
+                r += '<div><div style=color:black;padding-left:12px;padding-top:2px><b>' + EscapeHtml(meshes[i].name) + '</b></div><div style=padding-left:12px;padding-top:3px;color:black>' + rights + '</div></div>';
+                r += '</div></div>';
+            }
+
+            QH('p3meshes', r);
+            QV('p3noMeshFound', count == 0);
+        }
+
+        function gotoMesh(meshid) {
+            if ((features & 0x00040000) && !((userinfo.otpsecret == 1) || (userinfo.otphkeys > 0) || (userinfo.otpkeys > 0) || (userinfo.otpduo > 0) || (userinfo.otpdev > 0) || ((features & 0x00800000) && (userinfo.otpekey == 1)))) { setDialogMode(2, "Account Security", 1, null, "Unable to access this feature until two-factor authentication is enabled. This is required for extra security. Go to the \"My Account\" and look at the \"Account Security\" section."); return; }  
+            currentMesh = meshes[meshid];
+            if (currentMesh == null) { goBack(); }
+            p20updateMesh();
+            go(20);
+        }
+
+        function d3init() {
+            d3fileoptions = { dialog: 1, filter: 'd3filter', files: 'd3serverfiles', folderup: 'p3FolderUp', currentFolder: 'p3CurrentFolder', func: d3setActions };
+            Q('d3localFile').value = '';
+            Q('d3localFile').accept  = Q('d3filter').value;
+            d3modechange();
+        }
+
+        function d3modechange() {
+            var mode = Q('d3uploadMode').value;
+            QV('d3localmode', mode == 1);
+            QV('d3servermode', mode == 2);
+            if (mode == 1) { d3setActions(); } else { d3updatefiles(); }
+        }
+
+        var d3filetreelinkpath;
+        var d3filetreelocation = [];
+        var d3fileoptions = null;
+        function d3updatefiles() {
+            if (d3fileoptions == null) return;
+            if ((d3fileoptions.filter == 'd3filter') && (Q('d3uploadMode').value == 1)) return;
+            var html1 = '', html2 = '', filetreex = filetree, folderdepth = 1, publicPath = null, lastFolderName = '';
+
+            var d3filetreelocation2 = [], oldlinkpath = d3filetreelinkpath, checkedBoxes = [], checkboxes = document.getElementsByName('fc');
+            for (var i = 0; i < checkboxes.length; i++) { if (checkboxes[i].checked) { checkedBoxes.push(checkboxes[i].value) }; }
+
+            d3filetreelinkpath = '';
+            for (var i in d3filetreelocation) {
+                if ((filetreex.f != null) && (filetreex.f[d3filetreelocation[i]] != null)) {
+                    d3filetreelocation2.push(d3filetreelocation[i]);
+                    if ((folderdepth == 1)) {
+                        var sp = d3filetreelocation[i].split('/');
+                        publicPath = window.location.origin + domainUrl + sp[0] + 'files/' + sp[2];
+                        if (d3filetreelocation[i] === userinfo._id) { d3filetreelinkpath += 'self'; } else { d3filetreelinkpath += (sp[0] + '/' + sp[2]); }
+                    } else {
+                        if (d3filetreelinkpath != '') { d3filetreelinkpath += '/' + d3filetreelocation[i]; if (folderdepth > 2) { publicPath += '/' + d3filetreelocation[i]; } }
+                    }
+                    filetreex = filetreex.f[d3filetreelocation[i]];
+                    lastFolderName = filetreex.n;
+                    folderdepth++;
+                } else {
+                    break;
+                }
+            }
+            d3filetreelocation = d3filetreelocation2;
+
+            var filetreexx = p5sort_files(filetreex.f);
+
+            var fileFilter = '';
+            if (d3fileoptions.filter) { fileFilter = Q(d3fileoptions.filter).value };
+
+            for (var i in filetreexx) {
+                var f = filetreexx[i], name = f.n, shortname;
+
+                if ((f.t == 3) && (fileFilter != '') && (f.nx.toLowerCase().endsWith(fileFilter) == false)) { continue; }
+                if (name.length > 70) { shortname = '<span title="' + EscapeHtml(name) + '">' + EscapeHtml(name.substring(0, 70)) + ("..." + '</span>'); } else { shortname = EscapeHtml(name); }
+
+                var fsize = '';
+                if (f.s != null) { fsize = getFileSizeStr(f.s); }
+
+                var h = '';
+                if (f.t != 3) {
+                    var title = '';
+                    h = '<div class=filelist file=999><span style=float:right title="' + title + '"></span><span><div class=fileIcon' + f.t + ' onclick=d3folderset("' + encodeURIComponentEx(f.nx) + '")></div>&nbsp;<a href=# style=cursor:pointer onclick=\'return d3folderset("' + encodeURIComponentEx(f.nx) + '")\'>' + shortname + '</a></span></div>';
+                } else {
+                    var link = shortname;
+                    h = '<div class=filelist file=3><input style=float:left name=fcx class=fcb type=checkbox onchange=d3setActions() value="' + f.nx + '">&nbsp;<span style=float:right>' + EscapeHtml(fsize) + '</span><span><div class=fileIcon' + f.t + '></div>' + link + '</span></div>';
+                }
+
+                if (f.t < 3) { html1 += h; } else { html2 += h; }
+            }
+
+            if (d3fileoptions.currentFolder) { QH(d3fileoptions.currentFolder, lastFolderName); }
+            QH(d3fileoptions.files, html1 + html2);
+            QE(d3fileoptions.folderup, d3filetreelocation.length > 0);
+            if (d3fileoptions.func) { d3fileoptions.func(); }
+        }
+
+        function d3folderset(x) { d3filetreelocation.push(decodeURIComponent(x)); d3updatefiles(); return false; }
+        function d3folderup(x) { if (x == null) { d3filetreelocation.pop(); } else { while (d3filetreelocation.length > x) { d3filetreelocation.pop(); } } d3updatefiles(); }
+        function d3getFileSel() { var cc = []; var checkboxes = document.getElementsByName('fcx'); for (var i = 0; i < checkboxes.length; i++) { if (checkboxes[i].checked) { cc.push(checkboxes[i].value) } } return cc; }
+        function d3setActions() {
+            if (d3fileoptions.dialog == 1) {
+                var mode = Q('d3uploadMode').value;
+                if (mode == 1) {
+                    QE('idx_dlgOkButton', Q('d3localFile').value.length > 0);
+                } else {
+                    QE('idx_dlgOkButton', d3getFileSel().length == 1);
+                }
+            } else if (d3fileoptions.dialog == 2) {
+                QE('idx_dlgOkButton', d3getFileSel().length == 1);
+            }
+        }
+
+        var filetreelinkpath;
+        var filetreelocation = [];
+
+        function p5refreshFiles() { meshserver.send({ action: 'files' }); }
+
+        function updateFiles() {
+            QV('MainMenuMyFiles', ((features & 8) == 0));
+            if ((features & 8) != 0) return;
+            var html1 = '', html2 = '', displayPath = '<a style=cursor:pointer;color:black onclick=p5folderup(0)>' + "Root" + '</a>', fullPath = 'Root', publicPath, filetreex = filetree, folderdepth = 1;
+
+            var filetreelocation2 = [], oldlinkpath = filetreelinkpath, checkedBoxes = [], checkboxes = document.getElementsByName('fc');
+            for (var i = 0; i < checkboxes.length; i++) { if (checkboxes[i].checked) { checkedBoxes.push(checkboxes[i].value) }; }
+
+            filetreelinkpath = '';
+            for (var i in filetreelocation) {
+                if ((filetreex.f != null) && (filetreex.f[filetreelocation[i]] != null)) {
+                    filetreelocation2.push(filetreelocation[i]);
+                    fullPath += ' / ' + filetreelocation[i];
+                    if ((folderdepth == 1)) {
+                        var sp = filetreelocation[i].split('/');
+                        publicPath = window.location.origin + domainUrl + sp[0] + 'files/' + sp[2];
+                        filetreelinkpath += filetreelocation[i];
+                    } else {
+                        if (filetreelinkpath != '') { filetreelinkpath += '/' + filetreelocation[i]; if (folderdepth > 2) { publicPath += '/' + filetreelocation[i]; } }
+                    }
+                    filetreex = filetreex.f[filetreelocation[i]];
+                    displayPath += ' / <a style=cursor:pointer;color:black onclick=p5folderup(' + folderdepth + ')>' + EscapeHtml(filetreex.n != null ? filetreex.n : filetreelocation[i]) + '</a>';
+                    folderdepth++;
+                } else {
+                    break;
+                }
+            }
+            filetreelocation = filetreelocation2;
+            var publicfolder = fullPath.toLowerCase().startsWith('root / ' + userinfo._id + ' / public');
+
+            var filetreexx = p5sort_files(filetreex.f);
+
+            for (var i in filetreexx) {
+                var f = filetreexx[i], name = f.n, shortname;
+                if (name.length > 40) { shortname = EscapeHtml(name.substring(0, 40)) + "..."; } else { shortname = EscapeHtml(name); }
+
+                var fsize = '';
+                if (f.s != null) { fsize = getFileSizeStr(f.s); }
+
+                var h = '';
+                if (f.t < 3 || f.t == 4) {
+                    var right = (f.t == 1 || f.t == 4) ? p5getQuotabar(f) : '';
+                    h = '<div class=filelist file=999><input file=999 style=float:left name=fc class=fcb type=checkbox onchange=p5setActions() value=\'' + EscapeHtml(name) + '\'>&nbsp;<span style=float:right;padding-right:4px>' + right + '</span><span><div class=fileIcon' + f.t + '></div><a style=cursor:pointer onclick=p5folderset("' + encodeURIComponent(f.nx) + '")>' + shortname + '</a></span></div>';
+                } else {
+                    var link = shortname;
+                    var publiclink = '';
+                    if (publicfolder) { publiclink = ' (<a style=cursor:pointer onclick=\'p5showPublicLink("' + publicPath + '/' + f.nx + '")\'>' + "Link" + '</a>)'; }
+                    if (f.s > 0) { link = '<a rel=\"noreferrer noopener\" target=\"_blank\" href=\"downloadfile.ashx?link=' + encodeURIComponent(filetreelinkpath + '/' + f.nx) + '\">' + shortname + '</a>' + publiclink; }
+                    h = '<div class=filelist file=3><input file=3 style=float:left name=fc class=fcb type=checkbox onchange=p5setActions() value=\'' + f.nx + '\'>&nbsp;<span style=float:right;padding-right:4px>' + EscapeHtml(fsize) + '</span><span><div class=fileIcon' + f.t + '></div>' + link + '</span></div>';
+                }
+
+                if (f.t < 3) { html1 += h; } else { html2 += h; }
+            }
+
+            QH('p5rightOfButtons', p5getQuotabar(filetreex));
+
+            QH('p5files', html1 + html2);
+            QH('p5currentpath', displayPath);
+            QE('p5FolderUp', filetreelocation.length != 0);
+            QV('p5PublicShare', publicfolder);
+
+            if (oldlinkpath == filetreelinkpath) {
+                checkboxes = document.getElementsByName('fc');
+                for (var i = 0; i < checkboxes.length; i++) {
+                    checkboxes[i].checked = (checkedBoxes.indexOf(checkboxes[i].value) >= 0);
+                }
+            }
+
+            p5setActions();
+        }
+
+        function getNiceSize(bytes) {
+            if (bytes <= 0) return "Storage exceed";
+            if (bytes < 2048) return format("{0}b left", bytes);
+            if (bytes < 2097152) return format("{0}k left", Math.round(bytes / 1024));
+            if (bytes < 2147483648) return format("{0}m left", Math.round(bytes / 1024 / 1024));
+            return format("{0}g left", Math.round(bytes / 1024 / 1024 / 1024));
+        }
+
+        function getNetworkSpeed(bitsPerSecond) {
+            if (bitsPerSecond <= 0) return "0 bps";
+            if (bitsPerSecond < 1000) return format("{0} bps", bitsPerSecond);
+            if (bitsPerSecond < 1000000) return format("{0} Kbps", Math.round(bitsPerSecond / 1000));
+            if (bitsPerSecond < 1000000000) return format("{0} Mbps", Math.round(bitsPerSecond / 1000000));
+            return format("{0} Gbps", (bitsPerSecond / 1000000000).toFixed(1));
+        }
+
+        function p5getQuotabar(f) {
+            while (f.t > 1 && f.t != 4) { f = f.parent; }
+            if ((f.t != 1 && f.t != 4) || (f.maxbytes == null)) return '';
+            return getNiceSize(f.maxbytes - f.s) + ' <progress style=height:10px;width:100px value=' + f.s + ' max=' + f.maxbytes + ' />';
+        }
+
+        function p5showPublicLink(u) { setDialogMode(2, "Public Link", 1, null, '<input type=text style=width:100% value="' + u + '" readonly />'); }
+
+        var sortorder;
+        function p5sort_filename(a, b) { if (a.ln > b.ln) return (1 * sortorder); if (a.ln < b.ln) return (-1 * sortorder); return 0; }
+        function p5sort_timestamp(a, b) { if (a.d > b.d) return (1 * sortorder); if (a.d < b.d) return (-1 * sortorder); return 0; }
+        function p5sort_bysize(a, b) { if (a.s == b.s) return p5sort_filename(a, b); return (((a.s - b.s)) * sortorder); }
+
+        function p5sort_files(files) {
+            var r = [], sortselection = Q('p5sortdropdown').value;
+            for (var i in files) { files[i].nx = i; if (files[i].n == null) { files[i].n = i; } files[i].ln = files[i].n.toLowerCase(); r.push(files[i]); }
+            sortorder = 1;
+            if (sortselection > 3) { sortorder = -1; sortselection -= 3; }
+            if (sortselection == 1) { r.sort(p5sort_filename); }
+            else if (sortselection == 2) { r.sort(p5sort_bysize); }
+            else if (sortselection == 3) { r.sort(p5sort_timestamp); }
+            return r;
+        }
+
+        function p5setActions() {
+            var cc = getFileSelCount(), tc = getFileCount(), sfc = getFileSelCount(false);
+            QE('p5DeleteFileButton', (cc > 0) && (filetreelocation.length > 0));
+            QE('p5NewFolderButton', filetreelocation.length > 0);
+            QE('p5UploadButton', filetreelocation.length > 0);
+            QE('p5RenameFileButton', (cc == 1) && (filetreelocation.length > 0));
+            QE('p5SelectAllButton', tc > 0);
+            Q('p5SelectAllButton').value = (cc > 0 ? "None" : "All");
+            QE('p5CutButton', (sfc > 0) && (cc == sfc));
+            QE('p5CopyButton', (sfc > 0) && (cc == sfc));
+            QE('p5PasteButton', (p5clipboard != null) && (p5clipboard.length > 0) && (filetreelocation.length > 0));
+        }
+
+        function getFileSelCount(includeDirs) { var cc = 0, checkboxes = document.getElementsByName('fc'); for (var i = 0; i < checkboxes.length; i++) { if ((checkboxes[i].checked) && ((includeDirs != false) || (checkboxes[i].attributes.file.value == '3'))) cc++; } return cc; }
+        function getFileSelDirCount() { var cc = 0, checkboxes = document.getElementsByName('fc'); for (var i = 0; i < checkboxes.length; i++) { if ((checkboxes[i].checked) && (checkboxes[i].attributes.file.value == '999')) cc++; } return cc; }
+        function getFileCount() { var cc = 0; var checkboxes = document.getElementsByName('fc'); return checkboxes.length; }
+        function p5selectallfile() { var nv = (getFileSelCount() == 0), checkboxes = document.getElementsByName('fc'); for (var i = 0; i < checkboxes.length; i++) { checkboxes[i].checked = nv; } p5setActions(); }
+        function setupBackPointers(x) { if (x.f != null) { var fs = 0, fc = 0; for (var i in x.f) { setupBackPointers(x.f[i]); x.f[i].parent = x; if (x.f[i].s) { fs += x.f[i].s; } if (x.f[i].c) { fc += x.f[i].c; } if (x.f[i].t == 3) { fc++; } } x.s = fs; x.c = fc; } return x; }
+        function getFileSizeStr(size) { if (size == 1) return "1 byte"; return format("{0} bytes", size); }
+        function p5folderup(x) { if (x == null) { filetreelocation.pop(); } else { while (filetreelocation.length > x) { filetreelocation.pop(); } } updateFiles(); return false; }
+        function p5folderset(x) { filetreelocation.push(decodeURIComponent(x)); updateFiles(); return false; }
+        function p5createfolder() { setDialogMode(2, "New Folder", 3, p5createfolderEx, '<input type=text id=p5renameinput maxlength=64 onkeyup=p5fileNameCheck(event) style=width:100% />'); focusTextBox('p5renameinput'); p5fileNameCheck(); }
+        function p5createfolderEx() { meshserver.send({ action: 'fileoperation', fileop: 'createfolder', path: filetreelocation, newfolder: Q('p5renameinput').value }); }
+        function p5deletefile() { var cc = getFileSelCount(), rec = (getFileSelDirCount() > 0) ? '<br /><br /><label><input type=checkbox id=p5recdeleteinput>' + "Recursive delete" + '</label><br>' : '<input type=checkbox id=p5recdeleteinput style=\'display:none\'>'; setDialogMode(2, "Delete", 3, p5deletefileEx, (cc > 1) ? (format("Delete {0} selected items?", cc) + rec) : ("Delete selected item?" + rec)); }
+        function p5deletefileEx() { var delfiles = [], checkboxes = document.getElementsByName('fc'); for (var i = 0; i < checkboxes.length; i++) { if (checkboxes[i].checked) { delfiles.push(checkboxes[i].value); } } meshserver.send({ action: 'fileoperation', fileop: 'delete', path: filetreelocation, delfiles: delfiles, rec: Q('p5recdeleteinput').checked }); }
+        function p5renamefile() { var renamefile, checkboxes = document.getElementsByName('fc'); for (var i = 0; i < checkboxes.length; i++) { if (checkboxes[i].checked) { renamefile = checkboxes[i].value; } } setDialogMode(2, "Rename", 3, p5renamefileEx, '<input type=text id=p5renameinput maxlength=64 onkeyup=p5fileNameCheck(event) style=width:100% value="' + renamefile + '" />', { action: 'fileoperation', fileop: 'rename', path: filetreelocation, oldname: renamefile }); focusTextBox('p5renameinput'); p5fileNameCheck(); }
+        function p5renamefileEx(b, t) { t.newname = Q('p5renameinput').value; meshserver.send(t); }
+        function p5fileNameCheck(e) { var x = isFilenameValid(Q('p5renameinput').value); QE('idx_dlgOkButton', x); if ((x == true) && (e && e.keyCode == 13)) { dialogclose(1); } }
+        var isFilenameValid = (function () { var x1 = /^[^\\/:\*\?"<>\|]+$/, x2 = /^\./, x3 = /^(nul|prn|con|lpt[0-9]|com[0-9])(\.|$)/i; return function isFilenameValid(fname) { return x1.test(fname) && !x2.test(fname) && !x3.test(fname) && (fname[0] != '.'); } })();
+        function p5uploadFile() { setDialogMode(2, "Upload File", 3, p5uploadFileEx, '<form method=post enctype=multipart/form-data action=uploadfile.ashx target=fileUploadFrame><input type=text name=link style=display:none id=p5uploadpath value="' + encodeURIComponent(filetreelinkpath) + '" /><input type=file name=files id=p5uploadinput style=width:100% multiple=multiple onchange="updateUploadDialogOk(\'p5uploadinput\')" /><input type=hidden name=authCookie value=' + authCookie + ' /><input type=submit id=p5loginSubmit style=display:none /></form>'); updateUploadDialogOk('p5uploadinput'); }
+        function p5uploadFileEx() { Q('p5loginSubmit').click(); }
+        function updateUploadDialogOk(x) { QE('idx_dlgOkButton', Q(x).value != ''); }
+
+        var p5clipboard = null, p5clipboardFolder = null, p5clipboardCut = 0;
+        function p5copyFile(cut) { var checkboxes = document.getElementsByName('fc'); p5clipboard = []; p5clipboardCut = cut, p5clipboardFolder = Clone(filetreelocation); for (var i = 0; i < checkboxes.length; i++) { if ((checkboxes[i].checked) && (checkboxes[i].attributes.file.value == '3')) { p5clipboard.push(checkboxes[i].value); } } p5updateClipview(); }
+        function p5pasteFile() { var x = ''; if ((p5clipboard != null) && (p5clipboard.length > 0)) { x = format("Confirm {0} of {1} entrie{2} to this location?", (p5clipboardCut == 0 ? 'copy' : 'move'), p5clipboard.length, ((p5clipboard.length > 1) ? 's' : '')) } setDialogMode(2, "Paste", 3, p5pasteFileEx, x); }
+        function p5pasteFileEx() { meshserver.send({ action: 'fileoperation', fileop: (p5clipboardCut == 0 ? 'copy' : 'move'), scpath: p5clipboardFolder, path: filetreelocation, names: p5clipboard }); p5folderup(999); if (p5clipboardCut == 1) { p5clipboard = null, p5clipboardFolder = null, p5clipboardCut = 0; p5updateClipview(); } }
+        function p5updateClipview() { var x = ''; if ((p5clipboard != null) && (p5clipboard.length > 0)) { x = format("Holding {0} entrie{1} for {2}", p5clipboard.length, ((p5clipboard.length > 1) ? 's' : ''), (p5clipboardCut == 0 ? "copy" : "move")) + ', <a href=# onclick="return p5clearClip()" style=cursor:pointer>' + "Clear" + '</a>.' } QH('p5bottomstatus', x); p5setActions(); }
+        function p5clearClip() { p5clipboard = null; p5clipboardFolder = null; p5clipboardCut = 0; p5updateClipview(); return false; }
+
+        function p5fileDragDrop(e) {
+            haltEvent(e);
+            QV('bigfail', false);
+            QV('bigok', false);
+            if (e.dataTransfer == null || e.dataTransfer.files.length == 0 || filetreelocation.length == 0) return;
+            var names = [], sizes = [], types = [], datas = [], readercount = e.dataTransfer.files.length;
+            for (var i = 0; i < e.dataTransfer.files.length; i++) {
+                var reader = new FileReader(), file = e.dataTransfer.files[i];
+                names.push(file.name);
+                sizes.push(file.size);
+                types.push(file.type);
+                reader.onload = function (event) {
+                    datas.push(event.target.result);
+                    if (--readercount == 0) {
+                        Q('p5fileDragName').value = names.join('*');
+                        Q('p5fileDragSize').value = sizes.join('*');
+                        Q('p5fileDragType').value = types.join('*');
+                        Q('p5fileDragData').value = datas.join('*');
+                        Q('p5fileDragLink').value = encodeURIComponent(filetreelinkpath);
+                        Q('p5loginSubmit2').click();
+                    }
+                }
+                reader.readAsDataURL(file);
+            }
+        }
+
+        var p5dragtimer = null;
+        function p5fileDragOver(e) {
+            haltEvent(e);
+            if (p5dragtimer != null) { clearTimeout(p5dragtimer); p5dragtimer = null; }
+            var ac = true;
+            if (filetreelocation.length == 0) { ac = false; }
+            QV('bigok', ac);
+            QV('bigfail', !ac);
+        }
+
+        function p5fileDragLeave(e) {
+            haltEvent(e);
+            if (e.target.id != 'p5filetable') {
+                QV('bigfail', false);
+                QV('bigok', false);
+            } else {
+                p5dragtimer = setTimeout('QV(\'bigfail\',false);QV(\'bigok\',false);p5dragtimer=null;', 200);
+            }
+        }
+
+        function onRealNameCheckBox() {
+            showRealNames = Q('RealNameCheckBox').checked;
+            putstore('showRealNames', showRealNames ? 1 : 0);
+            mainUpdate(5);
+        }
+
+        function onOnlineCheckBox(e) {
+            putstore('onlineOnly', Q('OnlineCheckBox').checked ? 1 : 0);
+            onSearchInputChanged();
+        }
+
+        function updateDevicePageState() {
+            if ((devicePagingState == null) || (devicePagingState.total <= devicePagingState.limit)) {
+                QV('devViewPageState', false);
+                QV('devViewPageButton2', false);
+                QV('devViewPageButton3', false);
+            } else {
+                var currentPage = Math.floor((devicePagingState.skip + devicePagingState.limit) / devicePagingState.limit);
+                var maxPage = Math.ceil(devicePagingState.total / devicePagingState.limit);
+                QV('devViewPageState', true);
+                QV('devViewPageButton2', true);
+                QV('devViewPageButton3', true);
+                QH('devViewPageState', currentPage + '/' + maxPage);
+            }
+        }
+
+        function onDeviceViewPageChange(i) {
+            if (devicePagingState == null) return;
+            var currentPage = (Math.floor((devicePagingState.skip + devicePagingState.limit) / devicePagingState.limit));
+            var maxPage = Math.ceil(devicePagingState.total / devicePagingState.limit);
+            switch (i) {
+                case 2: { if (currentPage > 1) meshserver.send({ action: 'nodes', skip: (currentPage - 2) * devicePagingState.limit }); break; }
+                case 3: { if (currentPage < maxPage) meshserver.send({ action: 'nodes', skip: currentPage * devicePagingState.limit }); break; }
+            }
+        }
+
+        function onSearchFocus(x) { 
+            searchFocus = x;
+            updateSearchClearButton();
+        }
+
+        function onDeviceSearchChanged(e) {
+            setTimeout(function () { onSearchInputChanged(); }, 10);
+            updateSearchClearButton();
+        }
+
+        function updateSearchClearButton() {
+            var searchInput = Q('SearchInput');
+            var clearButton = Q('SearchInputClearButton');
+            if (searchInput && clearButton) {
+                if (searchInput.value && searchInput.value.trim() != '') {
+                    clearButton.style.display = 'flex';
+                } else {
+                    clearButton.style.display = 'none';
+                }
+            }
+        }
+
+        function clearSearchInput() {
+            Q('SearchInput').value = '';
+            Q('OnlineCheckBox').checked = false;
+            updateSearchClearButton();
+            onSearchInputChanged();
+        }
+
+        function onSearchInputChanged() {
+            var x = Q('SearchInput').value.toLowerCase().trim(); putstore('_search', Q('SearchInput').value);
+            var userSearch = null, ipSearch = null, groupSearch = null, tagSearch = null, agentTagSearch = null, wscSearch = null, osSearch = null, amtSearch = null;
+            if (x.startsWith("user:".toLowerCase())) { userSearch = x.substring("user:".length); }
+            else if (x.startsWith("u:".toLowerCase())) { userSearch = x.substring("u:".length); }
+            else if (x.startsWith("ip:".toLowerCase())) { ipSearch = x.substring("ip:".length); }
+            else if (x.startsWith("group:".toLowerCase())) { groupSearch = x.substring("group:".length); }
+            else if (x.startsWith("g:".toLowerCase())) { groupSearch = x.substring("g:".length); }
+            else if (x.startsWith("tag:".toLowerCase())) { tagSearch = Q('SearchInput').value.trim().substring("tag:".length); }
+            else if (x.startsWith("t:".toLowerCase())) { tagSearch = Q('SearchInput').value.trim().substring("t:".length); }
+            else if (x.startsWith("atag:".toLowerCase())) { agentTagSearch = Q('SearchInput').value.trim().substring("atag:".length).toLowerCase(); }
+            else if (x.startsWith("a:".toLowerCase())) { agentTagSearch = Q('SearchInput').value.trim().substring("a:".length).toLowerCase(); }
+            else if (x.startsWith("os:".toLowerCase())) { osSearch = Q('SearchInput').value.trim().substring("os:".length).toLowerCase(); }
+            else if (x.startsWith("amt:".toLowerCase())) { amtSearch = Q('SearchInput').value.trim().substring("amt:".length).toLowerCase(); }
+            else if (x == 'wsc:ok') { wscSearch = 1; }
+            else if (x == 'wsc:noav') { wscSearch = 2; }
+            else if (x == 'wsc:noupdate') { wscSearch = 3; }
+            else if (x == 'wsc:nofirewall') { wscSearch = 4; }
+            else if (x == 'wsc:any') { wscSearch = 5; }
+
+            if (x == '') {
+                for (var d in nodes) { nodes[d].v = true; }
+            } else if (ipSearch != null) {
+                for (var d in nodes) { nodes[d].v = ((nodes[d].ip != null) && (nodes[d].ip.indexOf(ipSearch) >= 0)); }
+            } else if (groupSearch != null) {
+                for (var d in nodes) { nodes[d].v = (meshes[nodes[d].meshid].name.toLowerCase().indexOf(groupSearch) >= 0); }
+            } else if (tagSearch != null) {
+                for (var d in nodes) {
+                    nodes[d].v = ((nodes[d].tags == null) && (tagSearch == '')) || ((nodes[d].tags != null) && (nodes[d].tags.indexOf(tagSearch) >= 0));
+                }
+            } else if (agentTagSearch != null) {
+                for (var d in nodes) {
+                    nodes[d].v = (((nodes[d].agent != null) && (nodes[d].agent.tag == null)) && (agentTagSearch == '')) || ((nodes[d].agent != null) && (nodes[d].agent.tag != null) && (nodes[d].agent.tag.toLowerCase().indexOf(agentTagSearch) >= 0));
+                }
+            } else if (userSearch != null) {
+                for (var d in nodes) {
+                    nodes[d].v = false;
+                    if (nodes[d].users && nodes[d].users.length > 0) { for (var i in nodes[d].users) { if (nodes[d].users[i].toLowerCase().indexOf(userSearch) >= 0) { nodes[d].v = true; } } }
+                }
+            } else if (osSearch != null) {
+                for (var d in nodes) { nodes[d].v = ((nodes[d].osdesc != null) && (nodes[d].osdesc.toLowerCase().indexOf(osSearch) >= 0)); }
+            } else if (amtSearch != null) {
+                for (var d in nodes) { nodes[d].v = (nodes[d].intelamt != null) && ((amtSearch == '') || (nodes[d].intelamt.state == amtSearch)); }
+            } else if (wscSearch != null) {
+                for (var d in nodes) {
+                    nodes[d].v = false;
+                    if (nodes[d].wsc) {
+                        if ((wscSearch == 1) && (nodes[d].wsc.antiVirus == 'OK') && (nodes[d].wsc.autoUpdate == 'OK') && (nodes[d].wsc.firewall == 'OK')) { nodes[d].v = true; }
+                        else if (((wscSearch == 2) || (wscSearch == 5)) && (nodes[d].wsc.antiVirus != 'OK')) { nodes[d].v = true; }
+                        else if (((wscSearch == 3) || (wscSearch == 5)) && (nodes[d].wsc.autoUpdate != 'OK')) { nodes[d].v = true; }
+                        else if (((wscSearch == 4) || (wscSearch == 5)) && (nodes[d].wsc.firewall != 'OK')) { nodes[d].v = true; }
+                    }
+                }
+            } else if (x == '*') {
+                for (var d in nodes) { nodes[d].v = (stars[nodes[d]._id] == 1); }
+            } else {
+                try {
+                    var rs = x.split(/\s+/).join('|'), rx = new RegExp(rs);
+                    for (var d in nodes) {
+                        if (features2 & 0x00008000) {
+                            if(features2 & 0x10000000){
+                                nodes[d].v = (rx.test(nodes[d].name.toLowerCase())) || (rx.test(meshes[nodes[d].meshid].name.toLowerCase())) || ((nodes[d].rnamel != null) && rx.test(nodes[d].rnamel.toLowerCase()));
+                            }else {
+                                nodes[d].v = (rx.test(nodes[d].name.toLowerCase())) || ((nodes[d].rnamel != null) && rx.test(nodes[d].rnamel.toLowerCase()));
+                            }
+                        } else {
+                            if(features2 & 0x10000000){
+                                if (showRealNames) {
+                                    nodes[d].v = (nodes[d].rnamel != null) && rx.test(nodes[d].rnamel.toLowerCase()) || (rx.test(meshes[nodes[d].meshid].name.toLowerCase()));
+                                } else {
+                                    nodes[d].v = rx.test(nodes[d].name.toLowerCase()) || (rx.test(meshes[nodes[d].meshid].name.toLowerCase()));
+                                }
+                            }else{
+                                if (showRealNames) {
+                                    nodes[d].v = (nodes[d].rnamel != null) && rx.test(nodes[d].rnamel.toLowerCase());
+                                } else {
+                                    nodes[d].v = rx.test(nodes[d].name.toLowerCase());
+                                }
+                            }
+                        }
+                    }
+                } catch (ex) { for (var d in nodes) { nodes[d].v = true; } }
+            }
+
+            var onlineOnly = Q('OnlineCheckBox').checked;
+            if (onlineOnly) { for (var d in nodes) { if ((nodes[d].conn == null) || (nodes[d].conn == 0)) { nodes[d].v = false; } } }
+            mainUpdate(4);
+        }
+
+        var gotKeyPressEvent = false;
+        function ondeskkeypress(e, t) {
+            setSessionActivity();
+            if (desktop && !xxdialogMode && (xxcurrentView == 10) && (currentDevicePanel == 1)) {
+                gotKeyPressEvent = true;
+                Q('softKeyboard').value = '';
+                if (currentNode != null) {
+                    var meshrights = GetMeshRights(currentNode.meshid);
+                    var inputAllowed = ((features2 & 0x2000) == 0) && ((meshrights == 0xFFFFFFFF) || (((meshrights & 8) != 0) && ((meshrights & 256) == 0)));
+                    if (inputAllowed == false) return false;
+                    var limitedInputAllowed = ((meshrights != 0xFFFFFFFF) && (((meshrights & 8) != 0) && ((meshrights & 256) == 0) && ((meshrights & 4096) != 0)));
+                    if (limitedInputAllowed == true) { if ((e.altKey == true) || (e.ctrlKey == true) || ((e.keyCode < 32) && (e.keyCode != 8) && (e.keyCode != 13)) || (e.keyCode > 90)) return false; }
+                }
+                return desktop.m.handleKeys(e);
+            }
+            if (terminal && !xxdialogMode && (xxcurrentView == 10) && (currentDevicePanel == 5) && (t !== 1)) {
+                if (e.altKey == true) { return true; }
+                gotKeyPressEvent = true;
+                Q('softKeyboard').value = '';
+                var k = 0;
+                if (e.charCode != 0) { k = e.charCode; } else if (e.keyCode != 0) { k = e.keyCode; }
+                if (k != 0) {
+                    if (terminal.urlname == 'sshterminalrelay.ashx') {
+                        terminal.socket.send('~' + String.fromCharCode(k));
+                    } else {
+                        terminal.sendText(String.fromCharCode(k));
+                    }
+                }
+                return false;
+            }
+        }
+
+        function ondeskkeydown(e, t) {
+            setSessionActivity();
+            if (desktop && !xxdialogMode && (xxcurrentView == 10) && (currentDevicePanel == 1)) {
+                gotKeyPressEvent = false;
+                Q('softKeyboard').value = '';
+                if (currentNode != null) {
+                    var meshrights = GetMeshRights(currentNode.meshid);
+                    var inputAllowed = ((features2 & 0x2000) == 0) && ((meshrights == 0xFFFFFFFF) || (((meshrights & 8) != 0) && ((meshrights & 256) == 0)));
+                    if (inputAllowed == false) return false;
+                    var limitedInputAllowed = ((meshrights != 0xFFFFFFFF) && (((meshrights & 8) != 0) && ((meshrights & 256) == 0) && ((meshrights & 4096) != 0)));
+                    if (limitedInputAllowed == true) { if ((e.altKey == true) || (e.ctrlKey == true) || ((e.keyCode < 32) && (e.keyCode != 8) && (e.keyCode != 13)) || (e.keyCode > 90)) return false; }
+                }
+                return desktop.m.handleKeyDown(e);
+            }
+            if (terminal && !xxdialogMode && (xxcurrentView == 10) && (currentDevicePanel == 5) && (t !== 1)) {
+                if (e.altKey == true) { return true; }
+                Q('softKeyboard').value = '';
+                gotKeyPressEvent = false;
+                var k = 0;
+                if (e.charCode != 0) { k = e.charCode; } else if (e.keyCode != 0) { k = e.keyCode; }
+                if (k == 8) {
+                    if (terminal.urlname == 'sshterminalrelay.ashx') {
+                        terminal.socket.send('~' + String.fromCharCode(k));
+                    } else {
+                        terminal.sendText(String.fromCharCode(k));
+                    }
+                }
+                else if (e.ctrlKey && (k >= 64) && (k <= 95)) {
+                    if (terminal.urlname == 'sshterminalrelay.ashx') {
+                        terminal.socket.send('~' + String.fromCharCode(k - 64));
+                    } else {
+                        terminal.sendText(String.fromCharCode(k - 64));
+                    }
+                }
+            }
+        }
+
+        function ondeskkeyup(e, t) {
+            setSessionActivity();
+            if (desktop && !xxdialogMode && (xxcurrentView == 10) && (currentDevicePanel == 1)) {
+                var inputStr = Q('softKeyboard').value;
+                Q('softKeyboard').value = '';
+                if (currentNode != null) {
+                    var meshrights = GetMeshRights(currentNode.meshid);
+                    var inputAllowed = ((features2 & 0x2000) == 0) && ((meshrights == 0xFFFFFFFF) || (((meshrights & 8) != 0) && ((meshrights & 256) == 0)));
+                    if (inputAllowed == false) return false;
+                    var limitedInputAllowed = ((meshrights != 0xFFFFFFFF) && (((meshrights & 8) != 0) && ((meshrights & 256) == 0) && ((meshrights & 4096) != 0)));
+                    if (limitedInputAllowed == true) { if ((e.altKey == true) || (e.ctrlKey == true) || ((e.keyCode < 32) && (e.keyCode != 8) && (e.keyCode != 13)) || (e.keyCode > 90)) return false; }
+                }
+                if ((gotKeyPressEvent == false) && (inputStr.length > 0) && desktop.m.SendKeyUnicode) {
+                    var inputchar = inputStr[inputStr.length - 1].charCodeAt(0);
+                    desktop.m.SendKeyUnicode(desktop.m.KeyAction.DOWN, inputchar);
+                    desktop.m.SendKeyUnicode(desktop.m.KeyAction.UP, inputchar);
+                } else {
+                    return desktop.m.handleKeyUp(e);
+                }
+            }
+            if (terminal && !xxdialogMode && (xxcurrentView == 10) && (currentDevicePanel == 5) && (gotKeyPressEvent == false) && (t !== 1)) {
+                if (e.altKey == true) { return true; }
+                var inputStr = Q('softKeyboard').value;
+                Q('softKeyboard').value = '';
+                if (terminal.urlname == 'sshterminalrelay.ashx') {
+                    terminal.socket.send('~' + inputStr);
+                } else {
+                    if (inputStr)
+                        terminal.sendText(inputStr);
+                }
+                return false;
+            }
+        }
+
+        var sort = 0;
+        var searchFocus = 0;
+        var deviceHeaderId = 0;
+        var deviceHeaderCount;
+        var deviceHeaders = {};
+        var showRealNames = false;
+        var deviceHeaderTotal = 0;
+        var deviceHeaders = {};
+        var deviceHeadersTitles = {};
+        function updateDevices() {
+            var r = '', c = 0, current = null, count = 0, displayedMeshes = {}, groups = {}, groupCount = {};
+
+            deviceHeaderId = 0;
+            deviceHeaderCount = {};
+            deviceHeaderTotal = 0;
+            deviceHeaders = {};
+            deviceHeadersTitles = {};
+            var current;
+
+            if (sort == 0) { nodes.sort(meshSort); }
+            else if (sort == 1) { nodes.sort(powerSort); }
+            else if (sort == 2) { if (showRealNames == true) { nodes.sort(deviceHostSort); } else { nodes.sort(deviceSort); } }
+
+            for (var i in nodes) {
+                if (nodes[i].v == false) continue;
+
+                if (sort == 0) {
+                    nodes.sort(meshSort);
+                    if (((meshes[nodes[i].meshid]?nodes[i].meshid:'*') != current)) {
+                        deviceHeaderSet();
+                        var extra = '';
+                        if ((meshes[nodes[i].meshid] != null) && (meshes[nodes[i].meshid].mtype == 1)) { extra = '<span style=color:lightgray>' + ", Intel&reg; AMT only" + '</span>'; }
+                        if (current != null) { if (c == 2) { r += '<td><div style=width:301px></div></td>'; } if (r != '') { r += '</tr></table>'; } }
+                        r += '<div class=DevSt style=padding-top:4px><span style=float:right>';
+
+                        if (meshes[nodes[i].meshid]) {
+                            r += '</span><span id=MxMESH style=cursor:pointer onclick=goForward("' + nodes[i].meshid + '")>' + EscapeHtml(meshes[nodes[i].meshid].name) + '</span>' + extra + '<span id=DevxHeader' + deviceHeaderId + ' style=color:lightgray></span></div>';
+                            current = nodes[i].meshid;
+                        } else {
+                            r += '</span><span id=MxMESH><i>' + "Individual Devices" + '</i></span><span id=DevxHeader' + deviceHeaderId + ' style=color:lightgray></span></div>';
+                            current = '*';
+                        }
+                        
+                        displayedMeshes[current] = 1;
+                        c = 0;
+                    }
+                } else if (sort == 1) {
+                    if (nodes[i].pwr !== current) {
+                        deviceHeaderSet();
+                        if (current !== null) { if (c == 2) { r += '<td><div style=width:301px></div></td>'; } if (r != '') { r += '</tr></table>'; } }
+                        r += '<div class=DevSt style=width:100%;padding-top:4px><span>' + PowerStateStr2(nodes[i].pwr) + '</span><span id=DevxHeader' + deviceHeaderId + ' style=color:lightgray></span></div>';
+                        current = nodes[i].pwr;
+                        c = 0;
+                    }
+                } else if (sort == 2) {
+                    if (current == null) { current = '1'; }
+                }
+
+                count++;
+                r += '<div name=xxdevice onclick=goForward(\'' + nodes[i]._id + '\') class=devList1 id=\'' + nodes[i]._id + '\'></div>';
+
+
+                deviceHeaderTotal++;
+                if (typeof deviceHeaderCount[nodes[i].state] == 'undefined') { deviceHeaderCount[nodes[i].state] = 1; } else { deviceHeaderCount[nodes[i].state]++; }
+            }
+
+            var viewNothing = false;
+            if ((r == '') && (nodes.length > 0) && (Q('SearchInput').value != '')) {
+                viewNothing = true;
+                r = '<div style="margin:30px">' + "No devices matching this search." + '</div>';
+            }
+
+            if ((sort == 0) && (Q('SearchInput').value == '')) {
+                for (var i in meshes) {
+                    var mesh = meshes[i];
+                    if ((displayedMeshes[mesh._id] == null) && (IsMeshViewable(mesh))) {
+                        if ((current != '') && (r != '')) { r += '</tr></table>'; }
+                        r += '<div><div colspan=3 class=DevSt><span style=float:right>';
+                        r += '</span><span id=MxMESH style=cursor:pointer onclick=goForward("' + mesh._id + '")>' + EscapeHtml(mesh.name) + '</span></div>';
+                        if (mesh.mtype == 1) { r += '<div style=padding:10px><i>' + "No Intel&reg; AMT devices in this group"; }
+                        if (mesh.mtype > 1) { r += '<div style=padding:10px><i>' + "No devices in this group"; }
+                        r += '.</i></div></div>';
+                        current = mesh._id;
+                        count++;
+                    }
+                }
+            }
+
+            if (count == 0) {
+                if ((Q('SearchInput').value != '') || (Q('OnlineCheckBox').checked)) {
+                    QH('xdevices', '<div style="margin-top:50px;text-align:center"><span style="font-size:30px">' + "No devices" + '</span><br /><br />' + "No devices matching this search." + ' <a onclick=clearSearchInput() style=cursor:pointer>' + "Clear search filter" + '</a></div>');
+                } else {
+                    QH('xdevices', '<div style="margin-top:50px;text-align:center"><span style="font-size:30px">' + "No devices" + '</span><br /><br />' + "Use the desktop version of this website to add devices." + '</div>');
+                }
+            } else {
+                QH('xdevices', r);
+            }
+            deviceHeaderSet();
+            for (var i in deviceHeaders) { QH(i, deviceHeaders[i]); }
+            for (var i in deviceHeadersTitles) { Q(i).title = deviceHeadersTitles[i]; }
+            onDevicesScrollEx();
+        }
+
+        var onDevicesTouchActive = false;
+        var onDevicesScrollnagleTimer = null;
+        function onDevicesScroll() {
+            if (onDevicesScrollnagleTimer == null) { onDevicesScrollnagleTimer = setTimeout(onDevicesScrollEx, 250); }
+        }
+
+        function onDeviceTouch(x) {
+            if (onDevicesTouchActive == x) return;
+            onDevicesTouchActive = x;
+            if (x == false) onDevicesScrollEx();
+        }
+
+        function onDevicesScrollEx() {
+            var devdivs = document.getElementsByName('xxdevice');
+            onDevicesScrollnagleTimer = null;
+            for (var i = 0; i < devdivs.length; i++) {
+                var node = getNodeFromId(devdivs[i].id)
+                if (node == null) break;
+                updateDeviceViewHtml(devdivs[i], node);
+            }
+        }
+
+        function updateDeviceViewDevice(node) {
+            if (node == null) return;
+            var devdiv = Q(node._id);
+            if ((devdiv != null) && (devdiv.innerHTML != '')) { updateDeviceViewHtml(devdiv, node); }
+        }
+
+        function updateDeviceViewHtml(div, node) {
+            var visibleTop = Q('xdevices').scrollTop - 250, visibleBottom = Q('xdevices').scrollTop + Q('xdevices').clientHeight + 250;
+            if ((div.offsetTop >= visibleTop) && (div.offsetTop < visibleBottom)) {
+                var title = EscapeHtml(node.name);
+                if (title.length == 0) { title = '<i>' + "None" + '</i>'; }
+                if ((node.rname != null) && (node.rname.length > 0)) { title += ' / ' + EscapeHtml(node.rname); }
+                var name = EscapeHtml(node.name);
+                if (showRealNames == true && node.rname != null) name = EscapeHtml(node.rname);
+                if (name.length == 0) { name = '<i>' + "None" + '</i>'; }
+
+                var devNotify = '', devNotifySub = '';
+
+                if (stars[node._id] == 1) {
+                    devNotifySub += '<img class=deviceNotifyDotSub src=images/icon-star-notify-16.png width=16 height=16>';
+                }
+
+                if (node.sessions != null) {
+                    if (node.sessions.msg != null) {
+                        devNotifySub += '<div style="width:16;height:16" class=deviceNotifyDotSub>' + Object.keys(node.sessions.msg).length + '</div>';
+                    }
+
+                    if ((node.sessions.kvm != null) || (node.sessions.terminal != null) || (node.sessions.files != null) || (node.sessions.tcp != null) || (node.sessions.udp != null)) {
+                        devNotifySub += '<img class=deviceNotifyDotSub src=images/icon-relay-notify.png width=16 height=16>';
+                    }
+
+                    if (node.sessions.help != null) {
+                        devNotifySub += '<img class=deviceNotifyDotSub src=images/icon-help-notify-16.png width=16 height=16>';
+                    }
+
+                    if (node.sessions.battery != null) {
+                        var bat = node.sessions.battery;
+                        var statestr = '';
+                        if (bat.state == 'ac') { statestr = "Device is plugged-in"; }
+                        else if (bat.state == 'dc') { statestr = "Device is battery powered"; }
+
+                        var levelstr = '', levelnum = -1;
+                        if ((typeof bat.level == 'number') && (bat.level >= 0) && (bat.level <= 100)) {
+                            levelstr = bat.level + '%';
+                            levelnum = (Math.floor((bat.level + 10) / 25) + 1);
+                            if (levelnum > 5) { lvl = 5; }
+                            if (bat.state == 'ac') { if (bat.level == 100) { levelnum = 11; } else { levelnum += 5; } }
+                        }
+
+                        if (levelnum > 0) {
+                            devNotify += '<div class="deviceBatterySmall deviceBatterySmall' + levelnum + '" title="' + ((statestr != null) ? (statestr + ', ' + levelstr) : levelstr) + '"></div>';
+                        }
+                    }
+                }
+
+                if (devNotifySub != '') { devNotify += '<div class=deviceNotifyDot>' + devNotifySub + '</div>'; }
+
+                var icon = node.icon, nodestate = NodeStateStr(node);
+                if (((!node.conn) || (node.conn == 0)) && (node.mtype != 3)) { icon += ' gray'; }
+                div.innerHTML = '<div>' + devNotify + '<div class="i' + icon + ' devList2"></div><div class=devList3><div class=devList4><b>' + name + '</b></div><div class=devList5>' + nodestate + '</div></div></div>';
+            } else {
+                div.innerHTML = '';
+            }
+        }
+
+        function showDeviceHelpRequests(nodeid, force, e) {
+            if (e) haltEvent(e);
+            if (xxdialogMode && !force) return false;
+            var node = null, x = '';
+            if (nodeid == null) { node = currentNode; } else { node = getNodeFromId(nodeid); }
+            if ((node == null) || (node.sessions == null)) { setDialogMode(0); return false; }
+            if (node.sessions.help != null) { for (var j in node.sessions.help) { x += '<div style=margin-bottom:6px><b>' + EscapeHtml(j) + '</b></div><div style=margin-bottom:6px>' + EscapeHtml(node.sessions.help[j]) + '</div>'; } }
+            if (x != '') { setDialogMode(2, "Help Requests" + ' - ' + EscapeHtml(node.name), 1, null, x, 'HELPREQ-' + node._id); } else { setDialogMode(0); }
+            return false;
+        }
+
+        function showDeviceSessions(nodeid, force, e) {
+            if (((force !== true) && xxdialogMode) || (currentNode == null)) return;
+            var node = currentNode, x = '';
+            for (var i in node.sessions) {
+                if ((i == 'kvm') && (node.sessions.multidesk == null)) {
+                    x += '<u>' + "Remote Desktop" + '</u>';
+                    for (var j in node.sessions.kvm) {
+                        if (j.startsWith('user/')) {
+                            var trash = '';
+                            if ((j == userinfo._id) || (GetNodeRights(node) == 0xFFFFFFFF)) { trash = ' <a href=# onclick=\'return endDeviceSession("kvm", "' + encodeURIComponentEx(node._id) + '", "' + encodeURIComponentEx(j) + '")\' title="' + "Disconnect this session" + '" style=cursor:pointer><img src=images/trash.png border=0 height=10 width=10></a>'; }
+                            x += addHtmlValue4(getUserName(j), ((node.sessions.kvm[j] == 1) ? "1 session" : nobreak(format("{0} sessions", node.sessions.kvm[j]))) + trash);
+                        } else if (j == 'busy') {
+                            x += addHtmlValue2("Device is busy", ((node.sessions.kvm[j] == 1) ? "1 session" : nobreak(format("{0} sessions", node.sessions.kvm[j]))));
+                        }
+                    }
+                } else if (i == 'multidesk') {
+                    x += '<u>' + "Remote Desktop" + '</u>';
+                    for (var j in node.sessions.multidesk) {
+                        var trash = '';
+                        if ((j == userinfo._id) || (GetNodeRights(node) == 0xFFFFFFFF)) { trash = ' <a href=# onclick=\'return endDeviceSession("multidesk", "' + encodeURIComponentEx(node._id) + '", "' + encodeURIComponentEx(j) + '")\' title="' + "Disconnect this session" + '" style=cursor:pointer><img src=images/trash.png border=0 height=10 width=10></a>'; }
+                        x += addHtmlValue4(getUserName(j), ((node.sessions.multidesk[j] == 1) ? "1 session" : nobreak(format("{0} sessions", node.sessions.multidesk[j]))) + trash);
+                    }
+                } else if (i == 'terminal') {
+                    x += '<u>' + "Terminal" + '</u>';
+                    for (var j in node.sessions.terminal) {
+                        var trash = '';
+                        if ((j == userinfo._id) || (GetNodeRights(node) == 0xFFFFFFFF)) { trash = ' <a href=# onclick=\'return endDeviceSession("terminal", "' + encodeURIComponentEx(node._id) + '", "' + encodeURIComponentEx(j) + '")\' title="' + "Disconnect this session" + '" style=cursor:pointer><img src=images/trash.png border=0 height=10 width=10></a>'; }
+                        x += addHtmlValue4(getUserName(j), ((node.sessions.terminal[j] == 1) ? "1 session" : nobreak(format("{0} sessions", node.sessions.terminal[j]))) + trash);
+                    }
+                } else if (i == 'files') {
+                    x += '<u>' + "Files" + '</u>';
+                    for (var j in node.sessions.files) {
+                        var trash = '';
+                        if ((j == userinfo._id) || (GetNodeRights(node) == 0xFFFFFFFF)) { trash = ' <a href=# onclick=\'return endDeviceSession("files", "' + encodeURIComponentEx(node._id) + '", "' + encodeURIComponentEx(j) + '")\' title="' + "Disconnect this session" + '" style=cursor:pointer><img src=images/trash.png border=0 height=10 width=10></a>'; }
+                        x += addHtmlValue4(getUserName(j), ((node.sessions.files[j] == 1) ? "1 session" : nobreak(format("{0} sessions", node.sessions.files[j]))) + trash);
+                    }
+                } else if (i == 'tcp') {
+                    x += '<u>' + "TCP Routing" + '</u>';
+                    for (var j in node.sessions.tcp) {
+                        var trash = '';
+                        if ((j == userinfo._id) || (GetNodeRights(node) == 0xFFFFFFFF)) { trash = ' <a href=# onclick=\'return endDeviceSession("tcp", "' + encodeURIComponentEx(node._id) + '", "' + encodeURIComponentEx(j) + '")\' title="' + "Disconnect this session" + '" style=cursor:pointer><img src=images/trash.png border=0 height=10 width=10></a>'; }
+                        x += addHtmlValue4(getUserName(j), ((node.sessions.tcp[j] == 1) ? "1 session" : nobreak(format("{0} sessions", node.sessions.tcp[j]))) + trash);
+                    }
+                } else if (i == 'udp') {
+                    x += '<u>' + "UDP Routing" + '</u>';
+                    for (var j in node.sessions.udp) {
+                        var trash = '';
+                        if ((j == userinfo._id) || (GetNodeRights(node) == 0xFFFFFFFF)) { trash = ' <a href=# onclick=\'return endDeviceSession("udp", "' + encodeURIComponentEx(node._id) + '", "' + encodeURIComponentEx(j) + '")\' title="' + "Disconnect this session" + '" style=cursor:pointer><img src=images/trash.png border=0 height=10 width=10></a>'; }
+                        x += addHtmlValue4(getUserName(j), ((node.sessions.udp[j] == 1) ? "1 session" : nobreak(format("{0} sessions", node.sessions.udp[j]))) + trash);
+                    }
+                }
+            }
+            if (x != '') { setDialogMode(2, "Sessions" + ' - ' + EscapeHtml(node.name), 1, null, x, 'SESSIONS-' + node._id); } else { setDialogMode(0); }
+        }
+
+        function endDeviceSession(protocol, nodeid, userid) {
+            var userIdSplit = decodeURIComponent(userid).split('/'), uid = userIdSplit[0] + '/' + userIdSplit[1] + '/' + userIdSplit[2], guestname = null;
+            if ((userIdSplit.length == 4) && (userIdSplit[3].startsWith('guest:'))) { guestname = atob(userIdSplit[3].substring(6)); }
+            if (protocol == 'multidesk') {
+                meshserver.send({ action: 'endDesktopMultiplex', nodeid: decodeURIComponent(nodeid), xuserid: uid, guestname, guestname });
+            } else {
+                meshserver.send({ action: 'msg', type: 'endtunnel', nodeid: decodeURIComponent(nodeid), xuserid: uid, guestname, guestname, protocol: protocol });
+            }
+        }
+
+        function showDeviceMessages(nodeid, force, e) {
+            if (e) haltEvent(e);
+            if (xxdialogMode && !force) return false;
+            var node = null, x = '<div style=max-height:200px;width:100%;overflow-y:auto;overflow-x:hidden>', count = 0;
+            if (nodeid == null) { node = currentNode; } else { node = getNodeFromId(nodeid); }
+            if ((node == null) || (node.sessions == null) || (node.sessions.msg == null)) { setDialogMode(0); return false; }
+            for (var i in node.sessions.msg) {
+                var msg = i, icon = 5;
+                if (typeof node.sessions.msg[i].msg == 'string') { msg = node.sessions.msg[i].msg; }
+                if (typeof node.sessions.msg[i].icon == 'number') { icon = node.sessions.msg[i].icon; }
+                if ((icon < 1) || (icon > 9)) { icon = 5; }
+                x += '<table style=width:100%><td style=width:24px><div class=NotifyIconSmall' + icon + '></div><td><div style="border-radius:5px;background-color:#BBB;width:calc(100% - 18px);padding:8px">' + EscapeHtml(msg) + '</div></table>';
+                count++;
+            }
+            x += '</div>';
+            if (count > 0) setDialogMode(2, "Agent Messages" + ' - ' + EscapeHtml(node.name), 1, null, x, 'MESSAGES-' + node._id);
+            return false;
+        }
+
+        var powerStatetable = ['', "Powered", "Sleep", "Sleep", "Sleep", "Hibernating", "Power off", "Present", "Off"];
+        var powerStateStrings = ['', "Powered", "Sleeping", "Sleeping", "Deep Sleep", "Hibernating", "Soft-Off", "Present", "Off"];
+        var powerStateStrings2 = ['', "Device is powered", "Device is in sleep state (S1)", "Device is in sleep state (S2)", "Device is in deep sleep state (S3)", "Device is hibernating (S4)", "Device is in soft-off state (S5)", "Device is present, but power state cannot be determined", "The device is powered off"];
+        var powerColorTable = ['#00000000', 'green', 'blue', 'blue', 'lightblue', 'blueviolet', 'red', 'lightseagreen', 'red'];
+        function NodeStateStr(node) {
+            var states = [];
+            if (node.state > 0 && node.state < powerStatetable.length) state.push(powerStatetable[node.state]);
+            if (node.conn) {
+                if ((node.conn & 1) != 0) { states.push('<span>' + ((node.mtype == 4) ? ((node.porttype == 'PDU') ? "Switch" : "IP-KVM") : "Agent") + '</span>'); }
+                if ((node.conn & 2) != 0) { states.push('<span>' + "CIRA" + '</span>'); }
+                else if ((node.conn & 4) != 0) { states.push('<span>' + "Intel&reg; AMT" + '</span>'); }
+                if ((node.conn & 8) != 0) { states.push('<span>' + "Relay" + '</span>'); }
+                if ((node.conn & 16) != 0) { states.push('<span>' + "MQTT" + '</span>'); }
+            }
+            if ((node.pwr != null) && (node.pwr != 0)) { states.push(powerStateStrings[node.pwr]); }
+            return states.join(', ');
+        }
+
+        function PowerStateStr(x) {
+            if (x < powerStatetable.length) return powerStatetable[x];
+            return '';
+        }
+
+        function PowerStateStr2(x) {
+            if ((x != 0) && (x < powerStatetable.length)) return powerStatetable[x];
+            return "Unknown";
+        }
+
+        function onSortSelectChange(skipsave) {
+            sort = document.getElementById('sortselect').selectedIndex;
+            if (!skipsave) { putstore('sort', sort); }
+            mainUpdate(4);
+        }
+
+        function deviceHeaderSet() {
+            if (deviceHeaderId == 0) { deviceHeaderId = 1; return; }
+            deviceHeaders['DevxHeader' + deviceHeaderId] = ', ' + deviceHeaderTotal + ((deviceHeaderTotal == 1) ? " node" : " nodes");
+            var title = '';
+            for (var x in deviceHeaderCount) { if (title.length > 0) title += ', '; title += deviceHeaderCount[x] + ' ' + PowerStateStr2(x); }
+            deviceHeadersTitles['DevxHeader' + deviceHeaderId] = title;
+            deviceHeaderId++;
+            deviceHeaderCount = {};
+            deviceHeaderTotal = 0;
+        }
+
+
+        var sortCollator = new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' })
+        function meshSort(a, b) {
+            var x = sortCollator.compare(a.meshnamel, b.meshnamel);
+            if (x != 0) return x;
+            x = sortCollator.compare(a.meshid, b.meshid);
+            if (x != 0) return x;
+            if (showRealNames == true) { return sortCollator.compare(a.rnamel, b.rnamel); }
+            return sortCollator.compare(a.namel, b.namel);
+        }
+        function powerSort(a, b) { var ap = a.pwr ? a.pwr : 0; var bp = b.pwr ? b.pwr : 0; if (ap > bp) return -1; if (ap < bp) return 1; if (ap == bp) { if (showRealNames == true) { return sortCollator.compare(a.rnamel, b.rnamel); } else { return sortCollator.compare(a.namel, b.namel); } } }
+        function deviceSort(a, b) { return sortCollator.compare(a.namel, b.namel); }
+        function deviceHostSort(a, b) { return sortCollator.compare(a.rnamel, b.rnamel); }
+
+
+        function refreshDevice(nodeid) {
+            if (!currentNode || currentNode._id != nodeid) return;
+            gotoDevice(nodeid, xxcurrentView, true);
+        }
+
+        var currentDevicePanel = 0;
+        var currentNode;
+        var powerTimelineNode = null;
+        var powerTimelineReq = null;
+        var powerTimelineUpdate = null;
+        var powerTimeline = null;
+        function getCurrentNode() { return currentNode; };
+        function gotoDevice(nodeid, panel, refresh) {
+
+            if ((userinfo.emailVerified !== true) && (serverinfo.emailcheck == true) && (userinfo.siteadmin != 0xFFFFFFFF)) { setDialogMode(2, "Account Security", 1, null, "Unable to access a device until a email address is verified. This is required for password recovery. Go to the \"My Account\" to change and verify an email address."); return; }
+
+            if ((features & 0x00040000) && !((userinfo.otpsecret == 1) || (userinfo.otphkeys > 0) || (userinfo.otpkeys > 0) || (userinfo.otpduo > 0) || (userinfo.otpdev > 0) || ((features & 0x00800000) && (userinfo.otpekey == 1)))) { setDialogMode(2, "Account Security", 1, null, "Unable to access a device until two-factor authentication is enabled. This is required for extra security. Go to the \"My Account\" and look at the \"Account Security\" section."); return; }
+
+            var node = getNodeFromId(nodeid);
+            if (node == null) { goBack(); return; }
+            var mesh = meshes[node.meshid];
+            var meshrights = GetNodeRights(node);
+            var deviceSwitch = ((currentNode == null) || (currentNode._id != nodeid));
+            if (!currentNode || currentNode._id != node._id || refresh == true) {
+                currentNode = node;
+
+                QV('p10deviceNotify', (currentNode.sessions != null) && ((node.sessions.kvm != null) || (node.sessions.terminal != null) || (node.sessions.files != null) || (node.sessions.tcp != null) || (node.sessions.udp != null)));
+                QV('p10deviceStar', stars[currentNode._id] == 1);
+                QV('p10deviceHelp', (currentNode.sessions != null) && (currentNode.sessions.help != null))
+                if ((currentNode.sessions != null) && (currentNode.sessions.msg != null)) { QV('p10deviceMsg', true); QH('p10deviceMsg', Object.keys(currentNode.sessions.msg).length); } else { QV('p10deviceMsg', false); }
+
+                QV('p10deviceBattery', false);
+                if ((currentNode.sessions != null) && (currentNode.sessions.battery != null)) {
+                    var bat = currentNode.sessions.battery;
+
+                    var statestr = '';
+                    if (bat.state == 'ac') { statestr = "Device is plugged-in"; }
+                    if (bat.state == 'dc') { statestr = "Device is battery powered"; }
+
+                    var levelstr = '', levelnum = -1;
+                    if ((typeof bat.level == 'number') && (bat.level >= 0) && (bat.level <= 100)) {
+                        levelstr = bat.level + '%';
+                        levelnum = (Math.floor((bat.level + 10) / 25) + 1);
+                        if (levelnum > 5) { lvl = 5; }
+                        if (bat.state == 'ac') { if (bat.level == 100) { levelnum = 11; } else { levelnum += 5; } }
+                    }
+
+                    if (levelnum > 0) {
+                        Q('p10deviceBattery').title = (statestr != null) ? (statestr + ', ' + levelstr) : levelstr;
+                        QV('p10deviceBattery', true);
+                        Q('p10deviceBattery').className = 'deviceBatteryLarge deviceBatteryLarge' + levelnum;
+                    }
+                } else {
+                    QV('p10deviceBattery', false);
+                }
+
+                var nname = EscapeHtml(node.name);
+                if (nname.length == 0) { nname = '<i>' + "None" + '</i>'; }
+                if ((meshrights & 4) != 0) { nname = '<span onclick=showEditNodeValueDialog(0) style=cursor:pointer>' + nname + '</span>'; }
+                QH('p10deviceName', nname);
+
+                var x = '<table style=width:100%>';
+
+                if (mesh) { x += addDeviceAttribute('<span>' + "Group" + '</span>', '<a onclick=goForward("' + node.meshid + '") style=cursor:pointer>' + EscapeHtml(meshes[node.meshid].name) + '</a>'); }
+
+                if (node.rname != null) { x += addDeviceAttribute('<span>' + "Name" + '</span>', '<span>' + EscapeHtml(node.rname) + '</span>'); }
+
+                if ((((features & 1) == 0) && (node.mtype != 4)) || (node.mtype == 3)) {
+                    if ((meshrights & 4) != 0) {
+                        if (node.host) {
+                            x += addDeviceAttribute("Hostname", '<span onclick=showEditNodeValueDialog(1) style=cursor:pointer>' + EscapeHtml(node.host) + '</span>');
+                        } else {
+                            x += addDeviceAttribute("Hostname", '<span onclick=showEditNodeValueDialog(1) style=cursor:pointer><i>' + "None" + '</i></span>');
+                        }
+                    } else {
+                        x += addDeviceAttribute("Hostname", EscapeHtml(node.host));
+                    }
+                }
+
+                var description = node.desc ? EscapeHtml(node.desc) : '<i>' + "None" + '</i>';
+                if ((meshrights & 4) != 0) {
+                    x += addDeviceAttribute("Description", '<span onclick=showEditNodeValueDialog(2) style=cursor:pointer>' + description + '</span>');
+                } else {
+                    x += addDeviceAttribute("Description", description);
+                }
+
+                if (node.mtype == 4) {
+                    if (node.portnum != null) { x += addDeviceAttribute("Port Number", node.portnum); }
+                    if (node.porttype != null) { x += addDeviceAttribute("Port Type", node.porttype); }
+                }
+
+                if ((node.agent != null) && (node.agent.id != null) && (node.mtype == 3)) {
+                    if (node.agent.id == 4) { x += addDeviceAttribute("Device Type", "Windows"); }
+                    if (node.agent.id == 6) { x += addDeviceAttribute("Device Type", "Linux"); }
+                    if (node.agent.id == 29) { x += addDeviceAttribute("Device Type", "macOS"); }
+                } else if ((node.agent != null) && (node.agent.id != null) && (node.agent.ver != null)) {
+                    var str = '';
+                    if (node.agent.id <= agentsStr.length) { str = agentsStr[node.agent.id]; } else { str = agentsStr[0]; }
+                    if (node.agent.ver != 0) { str += ' v' + node.agent.ver; }
+                    if (node.agent.id == 14) { str = node.agent.core; }
+                    if ((node.agent.root === false) && ((node.conn & 1) != 0)) { str += ', ' + "Restricted"; }
+                    x += addDeviceAttribute("Mesh Agent", str);
+                }
+
+                if (node.intelamt != null) {
+                    var str = '';
+                    var provisioningStates = { 0: nobreak("Not Activated (Pre)"), 1: nobreak("Not Activated (In)"), 2: nobreak("Activated") };
+                    if (node.intelamt.ver != null && node.intelamt.state == null) { str += '<i>' + nobreak("Unknown State") + '</i>, v' + EscapeHtml(node.intelamt.ver); }
+                    else if ((node.intelamt.ver == null) && (node.intelamt.state == 2)) { str += '<i>' + "Activated" + '</i>'; }
+                    else if ((node.intelamt.ver == null) || (node.intelamt.state == null)) { str += '<i>' + "Unknown Version & State" + '</i>'; }
+                    else {
+                        str += provisioningStates[node.intelamt.state];
+                        if (node.intelamt.flags) { if (node.intelamt.flags & 2) { str = ' <span>' + "CCM" + '</span>'; } else if (node.intelamt.flags & 4) { str = ' <span>' + "ACM" + '</span>'; } }
+                        str += (', v' + EscapeHtml(node.intelamt.ver));
+                    }
+
+                    if (node.intelamt.state == 2) {
+                        if (node.intelamt.tls == 1) { str += ', <span title="' + "Intel&reg; AMT is setup with TLS network security" + '">' + "TLS" + '</span>'; }
+
+                        var editUserCredentialsIcon = false;
+                        if (node.intelamt.user == null || node.intelamt.user == '') {
+                            if ((meshrights & 4) != 0) {
+                                str += ', <i style=color:#FF0000;cursor:pointer title="' + "Edit Intel&reg; AMT credentials" + '" onclick=editDeviceAmtSettings("' + node._id + '")>' + "No Credentials" + '</i>';
+                                editUserCredentialsIcon = true;
+                            } else {
+                                str += ', <i style=color:#FF0000>' + "No Credentials" + '</i>';
+                            }
+                        } else if (((features2 & 1) != 0) && (node.intelamt.warn != null)) {
+                            var warn = null;
+                            if ((node.intelamt.warn & 1) != 0) { warn = "Invalid Credentials"; }
+                            if ((node.intelamt.warn & 8) != 0) { warn = "Trying Credentials"; }
+                            if (warn != null) {
+                                if ((meshrights & 4) != 0) {
+                                    str += ', <i style=color:#FF0000;cursor:pointer title="' + "Edit Intel&reg; AMT credentials" + '" onclick=editDeviceAmtSettings("' + node._id + '")>' + warn + '</i>';
+                                    editUserCredentialsIcon = true;
+                                } else {
+                                    str += ', <i style=color:#FF0000>' + warn + '</i>';
+                                }
+                            }
+                        }
+
+                        if (((meshrights & 4) != 0) && ((features2 & 1) == 0)) { editUserCredentialsIcon = true; }
+
+                        str += ' ';
+                        if (editUserCredentialsIcon) {
+                            str += '<img src=images/link4.png height=10 width=10 title="' + "Edit Intel&reg; AMT credentials" + '" style=cursor:pointer onclick=editDeviceAmtSettings("' + node._id + '")>';
+                        }
+                    }
+
+
+                    var meName = "Intel&reg; ME";
+                    if (typeof node.intelamt.sku == 'number') {
+                        if ((node.intelamt.sku & 8) != 0) { meName = "Intel&reg; AMT"; }
+                        else if ((node.intelamt.sku & 16) != 0) { meName = "Intel&reg; SM"; }
+                    }
+                    x += addDeviceAttribute(meName, str);
+                }
+
+                if ((node.agent != null) && (node.agent.tag != null) && (node.agent.tag != 'mailto:')) {
+                    var tag = EscapeHtml(node.agent.tag);
+                    if (tag.startsWith('mailto:')) { tag = '<a href="' + tag + '">' + tag.substring(7) + '</a>'; }
+                    x += addDeviceAttribute("Agent Tag", tag);
+                }
+
+                var connectivity = node.conn;
+                if (connectivity && connectivity > 1) {
+                    var cstate = [];
+                    if ((node.conn & 1) != 0) cstate.push('<span>' + ((node.mtype == 4) ? ((node.porttype == 'PDU') ? "Switch" : "IP-KVM") : "Agent") + '</span>');
+                    if ((node.conn & 2) != 0) cstate.push('<span>' + "Intel&reg; AMT CIRA" + '</span>');
+                    else if ((node.conn & 4) != 0) cstate.push('<span>' + "Intel&reg; AMT" + '</span>');
+                    if ((node.conn & 8) != 0) cstate.push('<span>' + "Agent Relay" + '</span>');
+                    if ((node.conn & 16) != 0) cstate.push('<span>' + "MQTT" + '</span>');
+                    x += addDeviceAttribute("Connectivity", cstate.join(', '));
+                }
+
+                var groupingTags = '<i>' + "None" + '</i>';
+                if (node.tags != null) { groupingTags = ''; for (var i in node.tags) { groupingTags += '<span class=tagSpan>' + EscapeHtml(node.tags[i]) + '</span> '; } }
+                if ((meshrights & 4) != 0) {
+                    x += addDeviceAttribute("Tags", '<span onclick=showEditNodeValueDialog(3) style=cursor:pointer;color:black>' + groupingTags + '</span>');
+                } else {
+                    x += addDeviceAttribute("Tags", '<span style=line-height:26px;color:black>' + groupingTags + '</span>');
+                }
+
+                if ((node.ssh != null) || (node.rdp != null)) {
+                    var y = [];
+                    if ((meshrights & 4) != 0) {
+                        if (node.ssh != null) { y.push('<span onclick=showClearSshDialog(3) style=cursor:pointer>' + ((node.ssh == 1) ? "SSH-User+Pass" : ((node.ssh == 2) ? "SSH-User+Key+Pass" : "SSH-User+Key")) + ' <img class=hoverButton src="images/link5.png" width=10 height=10 /></span>'); }
+                        if (node.rdp != null) { y.push('<span onclick=showClearRdpDialog(3) style=cursor:pointer>' + "RDP" + ' <img class=hoverButton src="images/link5.png" width=10 height=10 /></span>'); }
+                    } else {
+                        if (node.ssh != null) { y.push(((node.ssh == 1) ? "SSH-User+Pass" : ((node.ssh == 2) ? "SSH-User+Key+Pass" : "SSH-User+Key"))); }
+                        if (node.rdp != null) { y.push("RDP"); }
+                    }
+                    x += addDeviceAttribute("Credentials", y.join(', '));
+                }
+
+                x += '</table><br />';
+                if (((meshrights & (4 + 8 + 64 + 262144)) != 0) && (node.mtype < 3)) { x += '<input type=button value="' + "Actions" + '" onclick=deviceActionFunction() />'; }
+                x += '<input type=button value="' + "Notes" + '" onclick=showNotes(' + ((meshrights & 128) == 0) + ',"' + encodeURIComponent(node._id) + '") />';
+
+                if ((node.mtype == 4) && (connectivity & 1)) {
+                    if (node.porttype == 'PDU') {
+                        if (node.pwr == 1) {
+                            if (meshrights & 0x40000) { x += '<input type=button value="' + "Turn off" + '" title="' + "Turn off" + '" onclick=setIpPduState(0) />'; }
+                        } else if (node.pwr == 8) {
+                            if (meshrights & 0x40) { x += '<input type=button value="' + "Turn on" + '" title="' + "Turn on" + '" onclick=setIpPduState(1) />'; }
+                        }
+                    } else {
+                        if (meshrights & 8) { x += '<input type=button value="' + "Remote Control" + '" title="' + "Remote Control" + '" onclick=openIpKvmRemoteControl("' + encodeURIComponentEx(node._id) + '") />'; }x
+                    }
+                }
+
+                QH('p10html', x);
+
+                if ((node.mtype == 3) && (node.agent != null) && (node.agent.id > 4) && (features2 & 0x00000200)) { node.agent.caps = 6; }
+
+                setupTerminal();
+                setupFiles();
+                if (meshrights & 16) { setupConsole(); }
+
+                x = '<div class="p10html3-buttons">';
+                if (webRelayPort != 0) {
+                    x += '<a onclick=p10WebRouter("' + node._id + '",1,' + (node.httpport ? node.httpport : 80) + ')>' + "HTTP" + ((node.httpport && (node.httpport != 80)) ? '/' + node.httpport : '') + '</a>';
+                    x += '<a onclick=p10WebRouter("' + node._id + '",2,' + (node.httpsport ? node.httpsport : 443) + ')>' + "HTTPS" + ((node.httpsport && (node.httpsport != 443)) ? '/' + node.httpsport : '') + '</a>';
+                }
+
+                if ((((connectivity & 1) != 0) || (node.mtype == 3)) && (node.agent) && ((meshrights & 8) != 0) && ((features & 0x20000000) == 0)) {
+                    x += '<a id=rfbLink onclick=p10rfb("' + node._id + '")>' + "Web-VNC" + '</a>';
+                }
+
+                if ((((connectivity & 1) != 0) || (node.mtype == 3)) && (node.agent) && ((meshrights & 8) != 0) && ((features & 0x40000000) == 0)) {
+                    x += '<a id=mstscLink onclick=p10mstsc("' + node._id + '")>' + "Web-RDP" + '</a>';
+                }
+
+                if ((features2 & 0x200) && (((connectivity & 1) != 0) || (node.mtype == 3)) && (node.agent) && ((meshrights & 8) != 0)) {
+                    x += '<a id=sshLink onclick=p10ssh("' + node._id + '")>' + "Web-SSH" + '</a>';
+                }
+
+                if ((meshrights & 0x8000) != 0) { x += '<a class="p10html3-delete" onclick=p10showDeleteNodeDialog("' + node._id + '")>' + "Delete Device" + '</a>'; }
+                x += '</div>'
+
+                QH('p10html3', x);
+
+                var powerstate = PowerStateStr(node.state);
+                if ((connectivity & 1) != 0) { if (powerstate.length > 0) { powerstate += ', '; } powerstate += ((node.mtype == 4) ? ((node.porttype == 'PDU') ? "Switch" : "IP-KVM") : "Mesh Agent"); }
+                if ((connectivity & 2) != 0) { if (powerstate.length > 0) { powerstate += ', '; } powerstate += "Intel&reg; AMT connected"; }
+                else if ((connectivity & 4) != 0) { if (powerstate.length > 0) { powerstate += ', '; } powerstate += "Intel&reg; AMT detected"; }
+                if ((connectivity & 16) != 0) { if (powerstate.length > 0) { powerstate += ', '; } powerstate += "MQTT channel connected"; }
+                if ((node.porttype == 'PDU') || ((node.pwr > 1) && (node.pwr != 7))) { if (powerstate.length > 0) { powerstate += ', '; } powerstate += powerStateStrings[node.pwr]; }
+                QH('MainComputerState', '<span style=font-size:12px>' + powerstate + '</span>');
+
+                QH('MainComputerImage', '<div class="i' + node.icon + '"></div>');
+
+                if ((powerTimelineNode != currentNode._id) && (powerTimelineReq != currentNode._id)) {
+                    QH('p10html2', '');
+                    powerTimelineReq = currentNode._id;
+                    meshserver.send({ action: 'powertimeline', nodeid: currentNode._id });
+                    meshserver.send({ action: 'lastconnect', nodeid: currentNode._id });
+                    meshserver.send({ action: 'getsysinfo', nodeid: currentNode._id });
+                    meshserver.send({ action: 'getnetworkinfo', nodeid: currentNode._id });
+                    QH('p10detailshtml', '');
+                }
+
+                if (deviceSwitch) {
+                    p11clearConsoleMsg();
+                    p13clearConsoleMsg();
+                }
+
+                QV('p11DeskSessionSelector', false);
+                QH('p11DeskSessionSelector', '');
+            }
+            setupDesktop();
+            if (!panel) panel = 10;
+            go(panel);
+
+            if (xxcurrentView == 10) { setupDeviceMenu(); }
+        }
+
+        function setIpPduState(op) {
+            if (op == 0) {
+                setDialogMode(2, "Power Operation", 3, function () { meshserver.send({ action: 'poweraction', nodeids: [currentNode._id], actiontype: 2 }); }, "Perform power off?");
+            } else {
+                setDialogMode(2, "Power Operation", 3, function () { meshserver.send({ action: 'wakedevices', nodeids: [currentNode._id] }); }, "Perform power on?");
+            }
+        }
+
+        function openIpKvmRemoteControl(nodeid) {
+            if (xxdialogMode) return;
+            var nid = decodeURIComponent(nodeid).split('/')[2];
+            safeNewWindow('/ipkvm.ashx/' + nid + '/', 'ipkvm:' + nid);
+        }
+
+        function deviceToastFunction() {
+            if (xxdialogMode) return;
+            setDialogMode(2, "Device Toast", 3, deviceToastFunctionEx, '<textarea id=d2devToast style=width:100%;height:80px;resize:none;overflow-y:scroll></textarea>');
+        }
+
+        function deviceToastFunctionEx() {
+            meshserver.send({ action: 'toast', nodeids: [currentNode._id], title: 'MeshCentral', msg: Q('d2devToast').value });
+        }
+
+        function setupDeviceMenu(op, obj) {
+            var meshrights = GetNodeRights(currentNode);
+            if (op != null) { currentDevicePanel = op; }
+            QV('p10general', currentDevicePanel == 0);
+            QV('p10desktop', currentDevicePanel == 1);
+            QV('p10files', currentDevicePanel == 2);
+            QV('p10details', currentDevicePanel == 3);
+            QV('p10console', currentDevicePanel == 4);
+            QV('p10terminal', currentDevicePanel == 5);
+            
+            var menus = [
+                { n: "", f: '' },
+                { n: "", f: '' },
+                { n: "", f: '' },
+                { n: "", f: '' },
+                { n: "", f: '' },
+                { n: "", f: '' }
+            ];
+            
+            menus[0] = { n: "General", f: 'setupDeviceMenu(0)' };
+
+            if ((currentNode != null) &&
+                ((meshrights & 8) || (meshrights & 256)) && ((meshrights == 0xFFFFFFFF) || ((meshrights & 65536) == 0)) &&
+                (((currentNode.agent == null) && (currentNode.intelamt) && ((typeof currentNode.intelamt.sku !== 'number') || ((currentNode.intelamt.sku & 8) != 0))) || (currentNode.agent && (currentNode.agent.caps & 1)))
+            ) { menus[1] = { n: "Desktop", f: 'setupDeviceMenu(1)' }; }
+
+            if ((currentNode != null) &&
+                ((meshrights & 8) || (meshrights & 256)) && ((meshrights == 0xFFFFFFFF) || ((meshrights & 512) == 0)) &&
+                (((currentNode.agent == null) && (currentNode.intelamt) && ((typeof currentNode.intelamt.sku !== 'number') || ((currentNode.intelamt.sku & 8) != 0))) || (currentNode.agent && (currentNode.agent.caps & 2)))
+            ) { menus[2] = { n: "Terminal", f: 'setupDeviceMenu(5)' }; }
+
+            if ((currentNode != null) && (meshrights & 8) && ((meshrights == 0xFFFFFFFF) || ((meshrights & 1024) == 0)) && ((currentNode.mtype != 1) && (currentNode.agent) && (currentNode.agent.caps & 4))) { 
+                menus[3] = { n: "Files", f: 'setupDeviceMenu(2)' }; 
+            }
+
+            if ((currentNode != null) && (currentNode.mtype < 3) && ((meshrights & 1048576) != 0)) { 
+                menus[4] = { n: "Details", f: 'setupDeviceMenu(3)' }; 
+            }
+            
+            if ((currentNode != null) && (meshrights & 0x00000010) && (currentNode.mtype == 2)) { 
+                menus[5] = { n: "Console", f: 'setupDeviceMenu(4)' }; 
+            }
+            
+            updateFooterMenu(menus);
+            updateCurrentUrl();
+            if (currentDevicePanel == 1) { deskAdjust(); }
+        }
+
+        function deviceActionFunction() {
+            if (xxdialogMode) return;
+            var rights = GetNodeRights(currentNode), count = 0;
+            var x = "Select an operation to perform on this device." + '<br /><br />';
+            var y = '<select id=d2deviceop style=float:right;width:170px onchange=deviceActionFunctionValidate()>';
+            var z = '';
+            if ((currentNode.agent != null) && (currentNode.agent.id == 14)) {
+                if (((currentNode.conn & 1) != 0) && ((rights & 8) != 0)) {
+                    count++;
+                    y += '<option value=400>' + "Flash" + '</option>';
+                    y += '<option value=401>' + "Vibrate" + '</option>';
+                    z += '<div id=d2devicetimediv>' + addHtmlValue("Time", '<select id=d2devicetime style=float:right;width:170px><option value=1000>' + "1 second" + '</option><option value=5000>' + "5 seconds" + '</option><option value=10000>' + "10 seconds" + '</option></select>') + '</div>';
+                }
+            } else {
+                if ((rights & 64) != 0) { count++; y += '<option value=100>' + "Wake-up" + '</option>'; }
+                if ((currentNode.conn != 0) && ((rights & 262144) != 0)) { count++; y += '<option value=4>' + "Sleep" + '</option><option value=3>' + "Reset" + '</option><option value=2>' + "Power off" + '</option>'; }
+                if ((currentNode.intelamt != null) && (currentNode.intelamt.state == 2) && ((currentNode.conn & 6) != 0) && ((rights & 262144) != 0)) {
+                    count++;
+                    y += '<option value=310>' + "Intel&reg; AMT Reset" + '</option>';
+                    y += '<option value=308>' + "Intel&reg; AMT Power off" + '</option>';
+                }
+                if ((currentNode.intelamt != null) && (currentNode.intelamt.state == 2) && ((currentNode.conn & 6) != 0) && ((rights & 64) != 0)) {
+                    count++;
+                    y += '<option value=302>' + "Intel&reg; AMT Power on" + '</option>';
+                }
+            }
+            y += '</select>';
+            x += addHtmlValue("Operation", y);
+            if (count == 0) { x = "No actions currently available for this device."; }
+            setDialogMode(2, "Device Action", (count == 0) ? 2 : 3, deviceActionFunctionEx, x + z);
+            if (count > 0) { deviceActionFunctionValidate(); }
+        }
+
+        function deviceActionFunctionValidate() {
+            var op = Q('d2deviceop').value;
+            try { QV('d2devicetimediv', (op == 400) || (op == 401)); } catch (ex) { }
+        }
+
+        function deviceActionFunctionEx() {
+            var op = Q('d2deviceop').value;
+            if (op == 100) {
+                meshserver.send({ action: 'wakedevices', nodeids: [currentNode._id] });
+            } else if (op == 103) {
+            } else if (op == 104) {
+            } else if (op == 106) {
+            } else if (op == 107) {
+
+            } else if (op == 302) {
+                setDialogMode(2, "Intel&reg; AMT Power Operation", 3, function () { meshserver.send({ action: 'poweraction', nodeids: [currentNode._id], actiontype: parseInt(op) }); }, "Perform Intel&reg; AMT power on?");
+            } else if (op == 308) {
+                setDialogMode(2, "Intel&reg; AMT Power Operation", 3, function () { meshserver.send({ action: 'poweraction', nodeids: [currentNode._id], actiontype: parseInt(op) }); }, "Perform Intel&reg; AMT power off?<br><br><b>NOTE: If there is an active AMT session, then power off command will be rejected, so you must disconnect from the AMT session first!</b>");
+            } else if (op == 310) {
+                setDialogMode(2, "Intel&reg; AMT Power Operation", 3, function () { meshserver.send({ action: 'poweraction', nodeids: [currentNode._id], actiontype: parseInt(op) }); }, "Perform Intel&reg; AMT reset?");
+            } else if ((op == 400) || (op == 401)) {
+                meshserver.send({ action: 'poweraction', nodeids: [currentNode._id], actiontype: parseInt(op), time: parseInt(Q('d2devicetime').value) });
+            } else {
+                meshserver.send({ action: 'poweraction', nodeids: [currentNode._id], actiontype: parseInt(op) });
+            }
+        }
+
+        function showNotes(readonly, noteid) {
+            if (xxdialogMode) return;
+            if (noteid == null) { noteid = encodeURIComponentEx('p' + userinfo._id); }
+            var x = '<textarea id=d2devNotes ro=' + readonly + ' noteid=' + noteid + ' readonly style=background-color:#fcf3cf;width:100%;height:200px;resize:none;overflow-y:scroll></textarea>';
+            if (noteid.startsWith('node%2F%2F')) { x += '<span style=font-size:10px>' + "Device group notes can be viewed and changed by other device group administrators." + '<span>'; }
+            setDialogMode(2, "Notes", 3, showNotesEx, x, noteid);
+            meshserver.send({ action: 'getNotes', id: decodeURIComponent(noteid) });
+        }
+
+        function showNotesEx(buttons, tag) { meshserver.send({ action: 'setNotes', id: decodeURIComponent(tag), notes: encodeURIComponentEx(Q('d2devNotes').value) }); }
+
+        function deviceLockFunction() {
+            if ((xxdialogMode != null || xxdialogMode == 0) && (desktop != null) && (desktop.contype == 1)) { setDialogMode(2, "Lock Desktop", 3, function() { if ((desktop != null) && (desktop.contype == 1)) { desktop.sendCtrlMsg('{"ctrlChannel":"102938","type":"lock"}'); } }, "Lock user desktop?"); }
+        }
+
+        function deviceChat(e) {
+            if (xxdialogMode) return;
+            setDialogMode(2, "Device Action", 3, function () {
+                var url = '/messenger?id=meshmessenger/' + encodeURIComponentEx(currentNode._id) + '/' + encodeURIComponentEx(userinfo._id) + '&title=' + currentNode.name;
+                if (serverinfo.domainsuffix != '') { url = '/' + serverinfo.domainsuffix + url; }
+                if ((authCookie != null) && (authCookie != '')) { url += '&auth=' + authCookie; }
+                if (e && (e.shiftKey == true)) {
+                    safeNewWindow(url, 'meshmessenger:' + currentNode._id);
+                } else {
+                    safeNewWindow(url, 'meshmessenger:' + currentNode._id, 'directories=no,titlebar=no,toolbar=no,location=no,status=no,menubar=no,scrollbars=no,resizable=no,width=400,height=560');
+                }
+                meshserver.send({ action: 'meshmessenger', nodeid: decodeURIComponent(currentNode._id) });
+            }, "Start chat session?");
+        }
+
+        function deviceUrlFunction() {
+            if (xxdialogMode) return;
+            setDialogMode(2, "Open Page on Device", 3, deviceUrlFunctionEx, '<input id=d2devurl placeholder="http://server.com" style=width:100%;overflow-y:scroll onkeyup=deviceUrlFunctionValidate() onchange=deviceUrlFunctionValidate()></input>');
+            Q('d2devurl').focus();
+            deviceUrlFunctionValidate();
+        }
+
+        function deviceUrlFunctionValidate() {
+            var x = Q('d2devurl').value.toLowerCase();
+            QE('idx_dlgOkButton', ((x.startsWith('http://') && (x.length > 7)) || (x.startsWith('https://') && (x.length > 8))));
+        }
+
+        function deviceUrlFunctionEx() {
+            meshserver.send({ action: 'msg', type: 'openUrl', nodeid: currentNode._id, url: Q('d2devurl').value });
+        }
+
+        function runDeviceCmd(nodeid) { if (xxdialogMode) return; d2runCommandDialog({ nodeids: [ nodeid ? decodeURIComponent(nodeid) : currentNode._id ] }); }
+
+        function d2runCommandDialog(options) {
+            var wintype = false, linuxtype = false, agenttype = false;
+            for (var i in options.nodeids) {
+                var n = getNodeFromId(options.nodeids[i]);
+                if (n.agent) { if ((GetNodeRights(n) & 24) == 24) { agenttype = true; }
+                if ((n.agent.id > 0) && (n.agent.id < 5)) { wintype = true; } else { linuxtype = true; } }
+            }
+            if ((wintype == true) || (linuxtype == true) || (agenttype == true)) {
+                var runopt = { type:1, runAs:0, source:1, cmd:'' };
+                try { runopt = JSON.parse(getstore('runopt', runopt)); } catch (ex) {}
+
+                if (options.selectedFile) {
+                    var filename = options.selectedFile.name.toLowerCase();
+                    console.log('filename', filename);
+                    if (filename.endsWith('.bat')) { runopt.type = 1; }
+                    if (filename.endsWith('.ps1')) { runopt.type = 2; }
+                    if (filename.endsWith('.sh')) { runopt.type = 3; }
+                    if (filename.endsWith('.agentconsole')) { runopt.type = 4; }
+                }
+
+                var x = '';
+                if (options.title) { x += options.title + '<br />'; }
+                x += '<select id=d2cmdtype onclick=d2runCommandValidate() style=width:100%;margin-bottom:4px;margin-top:4px>';
+                if (wintype == true) { x += '<option value=1' + ((runopt.type == 1)?' selected':'') + '>' + "Windows Command Prompt" + '</option><option value=2' + ((runopt.type == 2)?' selected':'') + '>' + "Windows PowerShell" + '</option>'; }
+                if (linuxtype == true) { x += '<option value=3' + ((runopt.type == 3)?' selected':'') + '>' + "Linux/BSD/macOS Command Shell" + '</option>'; }
+                if (agenttype == true) { x += '<option value=4' + ((runopt.type == 4)?' selected':'') + '>' + "Agent Console" + '</option>'; }
+                x += '</select>';
+                x += '<select id=d2cmduser style=width:100%;margin-bottom:4px><option value=0' + ((runopt.runAs == 0)?' selected':'') + '>' + "Run as agent" + '</option><option value=1' + ((runopt.runAs == 1)?' selected':'') + '>' + "Run as user, agent if no user" + '</option><option value=2' + ((runopt.runAs == 2)?' selected':'') + '>' + "Must run as user" + '</option></select>';
+                if (options.selectedFile == null) {
+                    x += '<select id=d2cmdsource onclick=d2runCommandValidate() style=width:100%;margin-bottom:4px><option value=0' + ((runopt.source == 0)?' selected':'') + '>' + "Commands from text box" + '</option><option value=1' + ((runopt.source == 1)?' selected':'') + '>' + "Commands from file" + '</option>';
+                    if (userinfo.siteadmin & 8) { x += '<option value=2' + ((runopt.source == 2)?' selected':'') + '>' + "Commands from file on server" + '</option>'; }
+                    x += '</select><textarea id=d2runcmd onkeyup=d2runCommandValidate() style=background-color:#fcf3cf;width:100%;height:200px;resize:none;overflow-y:scroll>' + (runopt.cmd ? EscapeHtml(decodeURIComponent(runopt.cmd)) : '') + '</textarea>';
+                    x += '<div id=d2runfile style=display:none><input id=d2runfileex type=file onchange=d2runCommandValidate() id=d2localFile name=files onchange=d2runCommandValidate() /></div>';
+                    if (userinfo.siteadmin & 8) { x += '<div id=d2runsfile style=display:none><div id=d2serveraction valign=bottom><input type=button id=p2FolderUp disabled="disabled" onclick=d3folderup() value="Up" />&nbsp;<span id=p2CurrentFolder></span></div><div id=d2serverfiles></div></div>'; }
+                }
+                setDialogMode(2, "Run Commands", 3, d2groupActionFunctionRunCommands, x, options);
+                if (options.selectedFile == null) {
+                    Q('d2runcmd').focus();
+                    if (userinfo.siteadmin & 8) { d3fileoptions = { dialog: 2, files: 'd2serverfiles', folderup: 'p2FolderUp', currentFolder: 'p2CurrentFolder', func: null }; d3updatefiles(); }
+                }
+                d2runCommandValidate();
+            }
+        }
+
+        function d2runCommandValidate() {
+            QV('d2cmduser', Q('d2cmdtype').value < 4);
+            if (xxdialogTag.selectedFile == null) {
+                QV('d2runcmd', Q('d2cmdsource').value == 0);
+                QV('d2runfile', Q('d2cmdsource').value == 1);
+                QV('d2runsfile', Q('d2cmdsource').value == 2);
+                var ok = false;
+                if (Q('d2cmdsource').value == 0) { if (Q('d2runcmd').value.length > 0) { ok = true; } }
+                if (Q('d2cmdsource').value == 1) { if (Q('d2runfileex').files.length == 1) { ok = true; } }
+                if (Q('d2cmdsource').value == 2) { ok = false; }
+                QE('idx_dlgOkButton', ok);
+            } else {
+                QE('idx_dlgOkButton', true);
+            }
+        }
+
+        function d2groupActionFunctionRunCommands(b, options) {
+            var type = 3;
+            try { type = parseInt(Q('d2cmdtype').value); } catch (ex) { }
+            if (options.selectedFile == null) { putstore('runopt', JSON.stringify({ type: type, runAs: parseInt(Q('d2cmduser').value), source: parseInt(Q('d2cmdsource').value), cmd: encodeURIComponent(Q('d2runcmd').value) })); }
+            var cmd = { action: 'runcommands', nodeids: options.nodeids, type: type, runAsUser: parseInt(Q('d2cmduser').value) };
+            if (options.selectedFile) {
+                var reader = new FileReader();
+                reader.onload = function (e) { cmd.cmds = e.target.result; meshserver.send(cmd); if (options.func) { options.func(); } }
+                reader.readAsText(options.selectedFile);
+            } else if (Q('d2cmdsource').value == 0) {
+                cmd.cmds = Q('d2runcmd').value;
+                meshserver.send(cmd);
+                if (options.func) { options.func(); }
+            } else if (Q('d2cmdsource').value == 1) {
+                var reader = new FileReader();
+                reader.onload = function (e) { cmd.cmds = e.target.result; meshserver.send(cmd); if (options.func) { options.func(); } }
+                reader.readAsText(Q('d2runfileex').files[0]);
+            } else if (Q('d2cmdsource').value == 2) {
+                var files = d3getFileSel();
+                if (files.length != 1) return;
+                cmd.cmdpath = d3filetreelocation.join('/') + '/' + files[0];
+                meshserver.send(cmd);
+                if (options.func) { options.func(); }
+            }
+        }
+
+        function updateDeviceTimeline() {
+            if ((meshserver.State != 2) || (powerTimelineNode == null) || (powerTimelineUpdate == null) || (currentNode == null) || (currentNode.mtype == 3)) return;
+            if ((powerTimelineNode == powerTimelineReq) && (currentNode._id == powerTimelineNode) && (powerTimelineUpdate < Date.now())) { powerTimelineUpdate = null; meshserver.send({ action: 'powertimeline', nodeid: currentNode._id }); }
+        }
+
+        function drawDeviceTimeline() {
+            if (currentNode.mtype == 3 || hidePowerTimeline === 'true') { QH('p10html2', '<br />'); return; }
+            var timeline = null, now = Date.now();
+            if (currentNode._id == powerTimelineNode) { timeline = powerTimeline; }
+
+            var d = new Date();
+            d.setHours(0, 0, 0, 0);
+            d = new Date(d.getTime() - (1000 * 60 * 60 * 24 * 6));
+            var timelineStart = d.getTime();
+
+            var timeline2 = [];
+            if (timeline != null && timeline.length > 1) {
+                timeline2.push([0, timeline[1], timeline[0]]);
+                var ct = timeline[1];
+                for (var i = 2; i < timeline.length; i += 2) {
+                    var power = timeline[i], dt = now;
+                    if (timeline.length > (i + 1)) { dt = timeline[i + 1]; }
+                    timeline2.push([ct, ct + dt, power]);
+                    ct = ct + dt;
+                }
+            }
+
+            var x = '', count = 1, date = new Date();
+            var totalWidth = Q('masthead').offsetWidth - (90 + 9 + 9 + 14);
+            date.setHours(0, 0, 0, 0);
+            for (var i = 0; i < 7; i++) {
+                var datavalue = '', start = date.getTime(), end = start + (1000 * 60 * 60 * 24);
+                for (var j in timeline2) {
+                    var block = timeline2[j];
+                    if (isTimeBlockInside(start, end, block[0], block[1]) == true) {
+                        var ts = Math.max(start, block[0]);
+                        var te = Math.min(Math.min(end, block[1]), now);
+                        var width = Math.round(((te - ts) * totalWidth) / 86400000);
+                        if (width > 0) { datavalue += '<div style=display:table-cell;width:' + width + 'px;background-color:' + powerColor(block[2]) + ';height:16px></div>'; }
+                    }
+                }
+                x += '<tr style=' + (((count % 2) == 0) ? 'background-color:#DDD' : '') + '><td><div>&nbsp;' + printDate(date) + '<div></div></div></td><td><div>' + datavalue + '</div></td></tr>';
+                ++count;
+                date = new Date(date.getFullYear(), date.getMonth(), date.getDate() - 1);
+            }
+            QH('p10html2', '<table style="color:black;background-color:#EEE;border-color:#AAA;border-width:1px;border-style:solid;border-collapse:collapse;width:calc(100% - 18px);margin:9px" border=0 cellpadding=2 cellspacing=0><tbody><tr style=background-color:#AAAAAA;font-weight:bold><th scope=col style=text-align:center;width:90px>' + "Day" + '</th><th scope=col style=text-align:center>' + "Power State" + '</th></tr>' + x + '</tbody></table>');
+        }
+
+        function powerColor(x) { if (x < powerColorTable.length) { return powerColorTable[x]; } return 'yellow'; }
+
+        function isTimeBlockInside(start, end, blockStart, blockEnd) {
+            if ((blockStart < start) && (blockEnd > end)) return true;
+            if ((blockStart > start) && (blockStart < end)) return true;
+            if ((blockEnd > start) && (blockEnd < end)) return true;
+            return false;
+        }
+
+        function addDeviceAttribute(name, value) {
+            return '<tr><td style=width:100px;color:gray>' + name + '</td><td style=overflow:hidden>' + value + '</td></tr>';
+        }
+
+        function editDeviceAmtSettings(nodeid, func) {
+            if (xxdialogMode) return;
+            var x = '', node = getNodeFromId(nodeid), buttons = 3, meshrights = GetNodeRights(node);
+            if ((meshrights & 4) == 0) return;
+            x += addHtmlValue("Username", '<input id=dp10username style=width:170px maxlength=32 autocomplete=nope placeholder="admin" onchange=validateDeviceAmtSettings() onkeyup=validateDeviceAmtSettings() />');
+            x += addHtmlValue("Password", '<input id=dp10password type=password style=width:170px autocomplete=nope maxlength=32 onchange=validateDeviceAmtSettings() onkeyup=validateDeviceAmtSettings() />');
+            if ((features2 & 1) == 0) { x += addHtmlValue("Security", '<select id=dp10tls style=width:176px><option value=0>' + "No TLS security" + '</option><option value=1>' + "TLS security required" + '</option></select>'); }
+            if ((node.intelamt.user != null) && (node.intelamt.user != '')) { buttons = 7; }
+            setDialogMode(2, "Edit Intel&reg; AMT credentials", buttons, editDeviceAmtSettingsEx, x, { node: node, func: func });
+            if ((node.intelamt.user != null) && (node.intelamt.user != '')) { Q('dp10username').value = node.intelamt.user; } else { Q('dp10username').value = 'admin'; }
+            if ((features2 & 1) == 0) { Q('dp10tls').value = node.intelamt.tls; }
+            validateDeviceAmtSettings();
+        }
+
+        function validateDeviceAmtSettings() {
+            QE('idx_dlgOkButton', passwordcheck(Q('dp10password').value));
+        }
+
+        function editDeviceAmtSettingsEx(button, tag) {
+            if (button == 2) {
+                meshserver.send({ action: 'changedevice', nodeid: tag.node._id, intelamt: { user: '', pass: '' } });
+            } else {
+                var amtuser = Q('dp10username').value;
+                if (amtuser == '') amtuser = 'admin';
+                var amtpass = Q('dp10password').value;
+                if (amtpass == '') amtuser = '';
+                var x = { action: 'changedevice', nodeid: tag.node._id, intelamt: { user: amtuser, pass: amtpass } };
+                if ((features2 & 1) == 0) { x.intelamt.tls = parseInt(Q('dp10tls').value); }
+                meshserver.send(x);
+                if (tag.func) { setTimeout(tag.func, 1000); }
+            }
+        }
+
+        function p10showDeleteNodeDialog(nodeid) {
+            if (xxdialogMode) return;
+            setDialogMode(2, "Delete Node", 3, p10showDeleteNodeDialogEx, format("Delete {0}?", EscapeHtml(currentNode.name)) + '<br /><br /><label><input id=p10check type=checkbox onchange=p10validateDeleteNodeDialog() />' + "Confirm" + '</label>', nodeid);
+            p10validateDeleteNodeDialog();
+        }
+
+        function p10validateDeleteNodeDialog() {
+            QE('idx_dlgOkButton', Q('p10check').checked);
+        }
+
+        function p10showDeleteNodeDialogEx(buttons, nodeid) {
+            meshserver.send({ action: 'removedevices', nodeids: [nodeid] });
+        }
+
+        function p10WebRouter(nodeid, protocol, port, addr) {
+            var relayid = null;
+            var node = getNodeFromId(nodeid);
+            if (node.mtype == 3) {
+                var mesh = meshes[node.meshid];
+                if (mesh && mesh.relayid) { relayid = mesh.relayid; addr = node.host; }
+            }
+            var servername = serverinfo.name;
+            if ((servername.indexOf('.') == -1) || ((features & 2) != 0)) { servername = window.location.hostname; }
+            if (webRelayDns != '') { servername = webRelayDns; }
+            var url = 'https://' + servername + ':' + webRelayPort + '/control-redirect.ashx?n=' + nodeid + '&p=' + port + '&appid=' + protocol + '&c=' + authRelayCookie;
+            if (addr != null) { url += '&addr=' + addr; }
+            if (relayid != null) { url += '&relayid=' + relayid; }
+            safeNewWindow(url, 'WebRelay');
+            return false;
+        }
+
+        function p10rfb(nodeid, port) {
+            var node = getNodeFromId(nodeid), addr = null;
+            var mesh = meshes[node.meshid];
+            if (port == null) { if (node.rfbport != null) { port = node.rfbport; } else { port = 5900; } }
+            if (node.mtype == 3) { if (mesh && mesh.relayid) { nodeid = mesh.relayid; addr = node.host; } }
+            meshserver.send({ action: 'getcookie', nodeid: nodeid, tcpport: port, tcpaddr: addr, tag: 'novnc', name: mesh ? mesh.name : null });
+        }
+
+        function p10mstsc(nodeid, port) {
+            var node = getNodeFromId(nodeid);
+            var mesh = meshes[node.meshid];
+            if (port == null) { if (node.rdpport != null) { port = node.rdpport; } else { port = 3389; } }
+            meshserver.send({ action: 'getcookie', nodeid: nodeid, tcpport: port, tag: 'mstsc', name: mesh ? mesh.name : null });
+        }
+
+        function p10ssh(nodeid, port) {
+            var node = getNodeFromId(nodeid);
+            var mesh = meshes[node.meshid];
+            if (port == null) { if (node.sshport != null) { port = node.sshport; } else { port = 22; } }
+            meshserver.send({ action: 'getcookie', nodeid: nodeid, tcpport: port, tag: 'ssh', name: mesh ? mesh.name : null });
+        }
+
+        function p10showiconselector() {
+            if (xxdialogMode) return;
+            var rights = GetNodeRights(currentNode);
+            if ((rights & 4) == 0) return;
+
+            var x = '<table align=center><td style=text-align:center>';
+            x += '<div style=display:inline-block class=i1 onclick=p10setIcon(1)></div>';
+            x += '<div style=display:inline-block class=i2 onclick=p10setIcon(2)></div>';
+            x += '<div style=display:inline-block class=i3 onclick=p10setIcon(3)></div>';
+            x += '<div style=display:inline-block class=i4 onclick=p10setIcon(4)></div><br />';
+            x += '<div style=display:inline-block class=i5 onclick=p10setIcon(5)></div>';
+            x += '<div style=display:inline-block class=i6 onclick=p10setIcon(6)></div>';
+            x += '<div style=display:inline-block class=i7 onclick=p10setIcon(7)></div>';
+            x += '<div style=display:inline-block class=i8 onclick=p10setIcon(8)></div></table>';
+            setDialogMode(2, "Icon Selection", 0, null, x);
+            QV('id_dialogclose', true);
+        }
+
+        function p10setIcon(icon) {
+            setDialogMode(0);
+            meshserver.send({ action: 'changedevice', nodeid: currentNode._id, icon: icon });
+        }
+
+        function showClearSshDialog() { setDialogMode(2, "Edit Device", 3, showClearSshDialogEx, "Clear SSH credentials?"); }
+        function showClearSshDialogEx(button, mode) { meshserver.send({ action: 'changedevice', nodeid: currentNode._id, ssh: 0 }); }
+        function showClearRdpDialog() { setDialogMode(2, "Edit Device", 3, showClearRdpDialogEx, "Clear RDP credentials?"); }
+        function showClearRdpDialogEx(button, mode) { meshserver.send({ action: 'changedevice', nodeid: currentNode._id, rdp: 0 }); }
+
+        var showEditNodeValueDialog_modes = ["Device Name", "Hostname", "Description", "Tags"];
+        var showEditNodeValueDialog_modes2 = ['name', 'host', 'desc', 'tags'];
+        var showEditNodeValueDialog_modes3 = ['', '', '', "Group1, Group2, Group3"];
+        function showEditNodeValueDialog(mode) {
+            if (xxdialogMode) return;
+            var x = addHtmlValue(showEditNodeValueDialog_modes[mode], '<input id=dp10devicevalue style=width:170px maxlength=64 placeholder="' + showEditNodeValueDialog_modes3[mode] + '" onchange=p10editdevicevalueValidate(' + mode + ',event) onkeyup=p10editdevicevalueValidate(' + mode + ',event) />');
+            if (mode == 3) {
+                var allTags = [], y = '';
+                for (var i in nodes) { if (nodes[i].tags) { for (var j in nodes[i].tags) { if (allTags.indexOf(nodes[i].tags[j]) == -1) { allTags.push(nodes[i].tags[j]); } } } }
+                if (allTags.length > 0) {
+                    allTags.sort();
+                    for (var i in allTags) { y += '<span style=padding:4px;background-color:#BBB;border-radius:3px;cursor:pointer onclick=showEditNodeValueDialogAddTag("' + encodeURIComponentEx(allTags[i]) + '")>' + EscapeHtml(allTags[i]) + '</span> '; }
+                    x += '<div style=margin-top:8px;width:280px;line-height:26px;max-height:160px;overflow-y:auto>' + y + '</div>';
+                }
+            }
+            setDialogMode(2, "Edit Device", 3, showEditNodeValueDialogEx, x, mode);
+            var v = currentNode[showEditNodeValueDialog_modes2[mode]];
+            if (v == null) v = '';
+            if (Array.isArray(v)) { v = v.join(', '); }
+            Q('dp10devicevalue').value = v;
+            p10editdevicevalueValidate();
+            Q('dp10devicevalue').focus();
+        }
+
+        function showEditNodeValueDialogAddTag(t) {
+            var tt = Q('dp10devicevalue').value.split(','), t2 = [];
+            for (var i in tt) { t2.push(tt[i].trim()); }
+            if (t2.indexOf(t) >= 0) return;
+            Q('dp10devicevalue').value += ((Q('dp10devicevalue').value.length == 0) ? '' : ', ') + decodeURIComponent(t);
+            setTimeout(function () { Q('dp10devicevalue').selectionStart = Q('dp10devicevalue').selectionEnd = 90000; }, 0);
+            p10editdevicevalueValidate();
+        }
+
+        function showEditNodeValueDialogEx(button, mode) {
+            var x = { action: 'changedevice', nodeid: currentNode._id };
+            x[showEditNodeValueDialog_modes2[mode]] = Q('dp10devicevalue').value;
+            meshserver.send(x);
+        }
+
+        function p10editdevicevalueValidate(mode, e) {
+            var x = ((mode > 1) || (Q('dp10devicevalue').value.length > 0));
+            QE('idx_dlgOkButton', x);
+            if ((e != null) && (x == true) && (e.keyCode == 13)) { dialogclose(1); }
+        }
+
+        var desktop;
+        var desktopNode;
+        var desktopsettings = { encoding: 2, showfocus: false, showmouse: true, showcad: true, quality: 40, scaling: 1024, framerate: 50, autolock: false, agentencoding: 4 };
+        function setupDesktop() {
+            if ((desktopNode != currentNode) && (desktop != null)) { desktop.Stop(); desktopNode = null; desktop = null; }
+
+            if ((desktopNode != currentNode) || (desktop == null)) {
+                desktopNode = currentNode;
+                Q('Desk').addEventListener('DOMMouseScroll', function (e) { return dmousewheel(e); });
+                Q('Desk').addEventListener('mousewheel', function (e) { return dmousewheel(e); });
+            }
+            desktopNode = currentNode;
+            updateDesktopButtons();
+
+            if (!Q('Desk')['toBlob']) { QV('deskSaveBtn', false); }
+        }
+
+        function updateDesktopButtons() {
+            var mesh = meshes[currentNode.meshid];
+            var deskState = 0;
+            if (desktop != null) { deskState = desktop.State; }
+            var meshrights = GetNodeRights(currentNode);
+
+            QV('disconnectbutton1', (deskState != 0));
+            QE('deskFullScreen', (deskState != 0));
+            QV('connectbutton1', (deskState == 0) && ((meshrights & 8) || (meshrights & 256)) && (currentNode.agent != null) && (currentNode.agent.caps & 1));
+            QV('connectbutton1h',
+                (deskState == 0) &&
+                (meshrights & 8) &&
+                (
+                  ((currentNode.intelamt != null) &&
+                  (currentNode.intelamt.state == 2) &&
+                  (currentNode.intelamt.ver != null) &&
+                  ((currentNode.intelamt.sku == null) ||
+                  ((typeof currentNode.intelamt.sku == 'number') &&
+                  ((currentNode.intelamt.sku & 8) != 0))))
+                )
+            );
+
+            QV('d7amtkvm', (currentNode.intelamt != null && ((typeof currentNode.intelamt.sku != 'number') || ((currentNode.intelamt.sku & 16) == 0)) && ((currentNode.intelamt.ver != null) || (currentNode.agent == null))) && ((deskState == 0) || (desktop.contype == 2)));
+            QV('d7meshkvm', ((currentNode.agent != null) && (currentNode.agent.caps & 1) && ((deskState == false) || (desktop.contype == 1))));
+
+            var online = ((currentNode.conn & 1) != 0);
+            QE('connectbutton1', online);
+            var hwonline = ((currentNode.conn & 6) != 0);
+            QE('connectbutton1h', hwonline);
+            QV('DeskToastButton', ((meshrights & 16384) != 0) && (currentNode.agent) && (currentNode.agent.id < 5) && (meshrights & 8));
+            QV('deskActionsBtn', meshrights & 8);
+            Q('DeskControl').checked = ((meshrights & 8) != 0);
+            if (online == false) QV('DeskTools', false);
+        }
+
+        var agentConsoleMessages = ['', "Waiting for user to grant access...", "Denied", "Failed to start remote terminal session, {0} ({1})", "Timeout", "Received invalid network data"];
+        function formatAgentConsoleMessage(msg, msgid, msgargs) {
+            var r;
+            if (msgargs == null) { msgargs = []; }
+            while (msgargs.length < 3) { msgargs.push(''); }
+            if (msgid && (msgid < agentConsoleMessages.length)) { r = EscapeHtml(format(agentConsoleMessages[msgid], (msgargs[0]), (msgargs[1]), (msgargs[2]))); } else { r = EscapeHtml(msg); }
+            return r.split('\n').join('<br />') + '<br /><br />';
+        }
+
+        function connectDesktop(e, contype, tsid, consent) {
+            setSessionActivity();
+            QV('p11DeskSessionSelector', false);
+            p11clearConsoleMsg();
+            if (desktop == null) {
+                desktopNode = currentNode;
+                if (contype == 2) {
+                    if ((desktopNode.intelamt.user == null) || (desktopNode.intelamt.user == '')) { editDeviceAmtSettings(desktopNode._id, connectDesktop); return; }
+                    desktop = CreateAmtRedirect(CreateAmtRemoteDesktop('Desk'), authCookie);
+                    desktop.debugmode = debugmode;
+                    desktop.onStateChanged = onDesktopStateChange;
+                    desktop.m.bpp = (desktopsettings.encoding == 1 || desktopsettings.encoding == 3) ? 1 : 2;
+                    desktop.m.useZRLE = (desktopsettings.encoding < 3);
+                    desktop.m.showmouse = true;
+                    desktop.m.onScreenSizeChange = function (o, x, y) { if (fullscreen) { QS('deskarea3').width = (x * fullscreenzoom) + 'px'; QS('deskarea3').height = (y * fullscreenzoom) + 'px'; } deskAdjust(); }
+                    if (desktopNode.conn==4 && desktopNode.intelamt!=null && desktopNode.intelamt.tls==1) {
+                        desktop.Start(desktopNode._id, 16995, '*', '*', 1);
+                    } else {
+                        desktop.Start(desktopNode._id, 16994, '*', '*', 0);
+                    }
+                    desktop.contype = 2;
+                } else if ((contype == null) || (contype == 1) || ((contype == 3) && (currentNode.agent.id > 4))) {
+                    desktop = CreateAgentRedirect(meshserver, CreateAgentRemoteDesktop('Desk'), serverPublicNamePort, authCookie, authRelayCookie, domainUrl);
+                    desktop.debugmode = debugmode;
+                    desktop.m.debugmode = debugmode;
+                    desktop.attemptWebRTC = attemptWebRTC;
+                    desktop.webrtcconfig = webrtcconfiguration;
+                    desktop.options = {};
+                    if (tsid != null) { desktop.options.tsid = tsid; }
+                    if (consent != null) { desktop.options.consent = consent; }
+                    if (desktopsettings.autolock == true) { desktop.options.autolock = true; }
+                    desktop.onStateChanged = onDesktopStateChange;
+                    if ((features2 & 0x2000) != 0) desktop.m.stopInput = true;
+                    desktop.onConsoleMessageChange = function () {
+                        if (desktop.consoleMessage) {
+                            Q('p11DeskConsoleMsg').innerHTML += formatAgentConsoleMessage(desktop.consoleMessage, desktop.consoleMessageId, desktop.consoleMessageArgs);
+                            QV('p11DeskConsoleMsg', true);
+                            if (p11DeskConsoleMsgTimer != null) { clearTimeout(p11DeskConsoleMsgTimer); }
+                            if (desktop.consoleMessageTimeout) { p11DeskConsoleMsgTimer = setTimeout(p11clearConsoleMsg, desktop.consoleMessageTimeout * 1000); }
+                        } else {
+                            p11clearConsoleMsg();
+                        }
+                    }
+                    desktop.m.ImageType = desktopsettings.agentencoding;
+                    desktop.m.CompressionLevel = desktopsettings.quality;
+                    desktop.m.ScalingLevel = desktopsettings.scaling;
+                    desktop.m.FrameRateTimer = desktopsettings.framerate;
+                    desktop.m.onDisplayinfo = deskDisplayInfo;
+                    desktop.m.onScreenSizeChange = function (o, x, y) { if (fullscreen) { QS('deskarea3').width = (x * fullscreenzoom) + 'px'; QS('deskarea3').height = (y * fullscreenzoom) + 'px'; } deskAdjust(); }
+                    desktop.Start(desktopNode._id);
+                    desktop.contype = 1;
+                } else if (contype == 3) {
+                    meshserver.send({ action: 'msg', type: 'userSessions', nodeid: currentNode._id, tag: consent });
+                }
+            } else {
+                desktop.Stop();
+                desktopNode = desktop = null;
+            }
+        }
+
+        function p11clearConsoleMsg() { QH('p11DeskConsoleMsg', ''); QV('p11DeskConsoleMsg', false); if (p11DeskConsoleMsgTimer) { clearTimeout(p11DeskConsoleMsgTimer); p11DeskConsoleMsgTimer = null; } }
+        function p12clearConsoleMsg() { QH('p12TermConsoleMsg', ''); QV('p12TermConsoleMsg', false); if (p12TermConsoleMsgTimer) { clearTimeout(p12TermConsoleMsgTimer); p12TermConsoleMsgTimer = null; } }
+        function p13clearConsoleMsg() { QH('p13FilesConsoleMsg', ''); QV('p13FilesConsoleMsg', false); if (p13FilesConsoleMsgTimer) { clearTimeout(p13FilesConsoleMsgTimer); p13FilesConsoleMsgTimer = null; } }
+
+        function p12setConsoleMsg(msg, timeout) {
+            if (msg) {
+                Q('p12TermConsoleMsg').innerHTML += msg;
+                QV('p12TermConsoleMsg', true);
+                if (p12TermConsoleMsgTimer != null) { clearTimeout(p12TermConsoleMsgTimer); }
+                if (timeout) { p12TermConsoleMsgTimer = setTimeout(p12clearConsoleMsg, timeout); }
+            } else {
+                p12clearConsoleMsg();
+            }
+        }
+
+        function p13setConsoleMsg(msg, timeout) {
+            if (msg) {
+                Q('p13FilesConsoleMsg').innerHTML += msg;
+                QV('p13FilesConsoleMsg', true);
+                if (p13FilesConsoleMsgTimer != null) { clearTimeout(p13FilesConsoleMsgTimer); }
+                if (timeout) { p13FilesConsoleMsgTimer = setTimeout(p13clearConsoleMsg, timeout); }
+            } else {
+                p13clearConsoleMsg();
+            }
+        }
+
+        function onDesktopStateChange(xdesktop, state) {
+            var xstate = state;
+            if ((xstate == 3) && (xdesktop.contype == 2)) { xstate++; }
+            var str = StatusStrs[xstate];
+            if ((desktop != null) && (desktop.webRtcActive == true)) { str += ", WebRTC"; }
+            QH('deskstatus', str);
+            switch (state) {
+                case 0:
+                    desktop.Stop();
+                    desktopNode = desktop = null;
+                    QV('DeskScreens', false);
+                    if (fullscreen == true) { deskToggleFull(); }
+                    break;
+                case 2:
+                    break;
+                default:
+                    break;
+            }
+            updateDesktopButtons();
+            deskAdjust();
+            setTimeout(deskAdjust, 50);
+        }
+
+        function showDesktopSettings() {
+            if (xxdialogMode) return;
+            applyDesktopSettings();
+            updateDesktopButtons();
+            setDialogMode(7, "Remote Desktop Settings", 3, showDesktopSettingsChanged);
+        }
+
+        function showDesktopSettingsChanged() {
+            desktopsettings.encoding = d7desktopmode.value;
+            desktopsettings.quality = d7bitmapquality.value;
+            desktopsettings.scaling = d7bitmapscaling.value;
+            desktopsettings.framerate = d7framelimiter.value;
+            desktopsettings.autolock = d7deskAutoLock.checked;
+            desktopsettings.agentencoding = d7encoding.value;
+            localStorage.setItem('desktopsettings', JSON.stringify(desktopsettings));
+            applyDesktopSettings();
+            if (desktop) {
+                if (desktop.contype == 1) {
+                    if (desktop.State != 0) { desktop.m.SendCompressionLevel(desktopsettings.agentencoding, desktopsettings.quality, desktopsettings.scaling, desktopsettings.framerate); }
+                    desktop.sendCtrlMsg('{"ctrlChannel":"102938","type":"autolock","value":' + desktopsettings.autolock + '}');
+                    desktop.m.SendRefresh();
+                }
+                if (desktop.contype == 2) {
+                    if (desktop.State != 0) { desktop.Stop(); setTimeout(function () { connectDesktop(null, 2); }, 50); }
+                }
+            }
+        }
+
+        function applyDesktopSettings() {
+            var r = '', ops = (features & 512) ? [100, 90, 70, 50, 40, 30, 20, 10, 5, 1] : [50, 40, 30, 20, 10, 5, 1];
+            for (var i in ops) { r += '<option value=' + ops[i] + '>' + ops[i] + '%</option>'; }
+            QH('d7bitmapquality', r);
+            d7desktopmode.value = desktopsettings.encoding;
+            d7bitmapquality.value = 40;
+            if (desktopsettings.agentencoding) { d7encoding.value = desktopsettings.agentencoding; } else { desktopsettings.agentencoding = 4; }
+            if (ops.indexOf(parseInt(desktopsettings.quality)) >= 0) { d7bitmapquality.value = desktopsettings.quality; }
+            d7bitmapscaling.value = desktopsettings.scaling;
+            if (desktopsettings.framerate) { d7framelimiter.value = desktopsettings.framerate; }
+            if (desktopsettings.autolock != null) { d7deskAutoLock.checked = desktopsettings.autolock; }
+        }
+
+
+        var keyboardShown = false;
+        var keyboardShownTimer = null;
+        var fullScreenMode = false;
+        function toggleKeyboard() {
+            if (xxdialogMode) return;
+            if (keyboardShownTimer != null) { clearTimeout(keyboardShownTimer); }
+            if (keyboardShown) { Q('softKeyboard').blur(); keyboardShown = false; } else { Q('softKeyboard').focus(); keyboardShown = true; }
+            QV('deskkeybutton2a', fullscreen && !keyboardShown);
+            QV('deskkeybutton2b', fullscreen && keyboardShown);
+        }
+
+        function keyboardFocusChange() {
+            keyboardShownTimer = setTimeout(function () {
+                keyboardShownTimer = null;
+                keyboardShown = (Q('softKeyboard') == document.activeElement);
+                QV('deskkeybutton2a', fullscreen && !keyboardShown);
+                QV('deskkeybutton2b', fullscreen && keyboardShown);
+            }, 10);
+        }
+
+        function exitButton() {
+            if (xxdialogMode) return;
+            QV('deskButtonMenu', false);
+            QV('termButtonMenu', false);
+            deskToggleFull();
+        }
+
+        function deskMenuButton(x) {
+            toggleMenu(true);
+            deskSendKeys(x);
+        }
+
+        function updateDeskShortcutKeys() {
+            var x = '<div class="menuButton" onclick="deskMenuButton(-1)">' + "Customize" + '</div>';
+            for (var i in deskKeyboardShortcuts) { x += '<div class="menuButton" onclick="deskMenuButton(' + deskKeyboardShortcuts[i] + ')">' + keyShortcutTotext(deskKeyboardShortcuts[i]) + '</div>'; }
+            QH('deskButtonMenu', x);
+        }
+
+        var keyStrings = { 8: "BackSpace", 9: "Tab", 13: "Enter", 27: "Escape", 32: "Space", 44: "Print Screen", 45: "Insert", 46: "Del", 36: "Home", 35: "End", 32: "Espace", 33: "Page Up", 34: "Page Down", 37: "Left", 38: "Up", 39: "Right", 40: "Down", 0: "None" }
+
+        function keyShortcutTotext(n) {
+            var x = [];
+            if (n & 0x010000) { x.push("Shift"); }
+            if (n & 0x020000) { x.push("Alt"); }
+            if (n & 0x080000) { x.push("Ctrl"); }
+            if (n & 0x100000) { x.push("Win"); }
+            n = (n & 0xFFFF);
+            if ((n >= 112) && (n <= 123)) { x.push('F' + (n - 111)); }
+            else if ((n != 0) && (keyStrings[n])) { x.push(keyStrings[n]); }
+            else { if (n != 0) { x.push(String.fromCharCode(n)); } }
+            return x.join(' + ');
+        }
+
+        function deskCustomizeKeys() {
+            if (xxdialogMode) return;
+            var x = '<div id=d2shortcuts style="width:100%;height:180px;padding:4px;overflow-y:auto;border:1px solid gray"></div><div style=width:100%;padding:5px>';
+            x += '<label><input id=d1kshift type=checkbox /> ' + "Shift" + '</label><label> <input id=d1kalt type=checkbox /> ' + "Alt" + '</label><label> <input id=d1kctrl type=checkbox /> ' + "Ctrl" + '</label> <input id=d1kwin type=checkbox /> ' + "Win" + '</label>';
+            x += ' <select id=d2keySelect>';
+            for (var i in keyStrings) { x += '<option value=' + i + '>' + keyStrings[i] + '</option>'; }
+            for (var i = 1; i <= 12; i++) { x += '<option value=' + (i + 111) + '>F' + i + '</option>'; }
+            for (var i = 0; i < 10; i++) { x += '<option value=' + (i + 48) + '>' + i + '</option>'; }
+            for (var i = 0; i < 26; i++) { x += '<option value=' + (i + 65) + '>' + String.fromCharCode(i + 65) + '</option>'; }
+            x += '</select> <input type=button value=' + "Add" + ' onclick=addDeskCustomizeKey() /></div>';
+            QH('p10dialog2', x);
+            xxdialogMode = 2;
+            QV('p10dialog', true);
+            deskUpdateShortcutList();
+        }
+
+        function deskCustomizeKeysEx() {
+            QV('p10dialog', false);
+            xxdialogMode = 0;
+            putstore('deskKeyShortcuts', deskKeyboardShortcuts.join(','));
+            updateDeskShortcutKeys();
+        }
+
+        function restoreDeskCustomizeKey() {
+            deskKeyboardShortcuts = [];
+            putstore('deskKeyShortcuts', null);
+            var deskKeyboardShortcutsStr = getstore('deskKeyShortcuts', '0x0A002E,0x100000,0x100028,0x100026,0x10004C,0x10004D,0x11004D,0x100052,0x020073,0x080057,0x020009,0x100025,0x100027').split(',');
+            for (var i in deskKeyboardShortcutsStr) { if (deskKeyboardShortcutsStr[i] != "") { deskKeyboardShortcuts.push(parseInt(deskKeyboardShortcutsStr[i])); } }
+            updateDeskShortcutKeys();
+            deskUpdateShortcutList();
+        }
+
+        function deskUpdateShortcutList() {
+            var x = '';
+            for (var i in deskKeyboardShortcuts) {
+                var kt = keyShortcutTotext(deskKeyboardShortcuts[i]), orderButtons = '';
+                if (i != (deskKeyboardShortcuts.length - 1)) { orderButtons += '<img width=8 height=8 style=float:right;cursor:pointer;padding:3px src="images/c2.png" onclick=deskCustomizeKeyDown(' + deskKeyboardShortcuts[i] + ')>'; }
+                if (i != 0) { orderButtons += '<img width=8 height=8 style=float:right;cursor:pointer;padding:3px src="images/c3.png" onclick=deskCustomizeKeyUp(' + deskKeyboardShortcuts[i] + ')>'; }
+                x += '<div style="width:100%;background-color:#AAA;border-radius:4px;margin-bottom:4px;padding:4px;text-align:left;box-sizing:border-box" value=' + deskKeyboardShortcuts[i] + '>' + kt + '<img width=10 height=10 style=float:right;cursor:pointer;padding:2px;margin-left:8px src="images/trash.png" onclick=removeDeskCustomizeKey(' + deskKeyboardShortcuts[i] + ')>' + orderButtons + '</div>';
+            }
+            if (x == '') { x = '<i>' + "No keyboard shortcuts defined" + '</i>'; }
+            QH('d2shortcuts', x);
+        }
+
+        function deskCustomizeKeyDown(k) {
+            var i = deskKeyboardShortcuts.indexOf(k), x = deskKeyboardShortcuts[i + 1];
+            deskKeyboardShortcuts[i + 1] = deskKeyboardShortcuts[i];
+            deskKeyboardShortcuts[i] = x;
+            deskUpdateShortcutList();
+        }
+
+        function deskCustomizeKeyUp(k) {
+            var i = deskKeyboardShortcuts.indexOf(k), x = deskKeyboardShortcuts[i];
+            deskKeyboardShortcuts[i] = deskKeyboardShortcuts[i - 1];
+            deskKeyboardShortcuts[i - 1] = x;
+            deskUpdateShortcutList();
+        }
+
+        function removeDeskCustomizeKey(k) {
+            var na = [];
+            for (var i in deskKeyboardShortcuts) { if (deskKeyboardShortcuts[i] != k) { na.push(deskKeyboardShortcuts[i]); } }
+            deskKeyboardShortcuts = na;
+            deskUpdateShortcutList();
+        }
+
+        function addDeskCustomizeKey() {
+            var k = parseInt(Q('d2keySelect').value);
+            if (Q('d1kshift').checked) { k |= 0x010000; }
+            if (Q('d1kalt').checked) { k |= 0x020000; }
+            if (Q('d1kctrl').checked) { k |= 0x080000; }
+            if (Q('d1kwin').checked) { k |= 0x100000; }
+            if ((k > 0) && (deskKeyboardShortcuts.indexOf(k) == -1)) { deskKeyboardShortcuts.push(k); deskUpdateShortcutList(); }
+        }
+
+        function deskSendKeys(ks) {
+            if (xxdialogMode || desktop == null || desktop.State != 3) return;
+
+            if (ks == -1) { deskCustomizeKeys(); return; }
+            if (ks == 0x0A002E) { desktop.m.sendcad(); return; }
+
+            var flags = (ks & 0xFF0000) >> 16, key = (ks & 0xFFFF), keyArray = [], keyArray2 = [];
+            var amtTranslate = {
+                8: 0xff08,
+                9: 0xff09,
+                13: 0xff0d,
+                27: 0xff1b,
+                45: 0xff63,
+                46: 0xffff,
+                36: 0xff50,
+                35: 0xff57,
+                33: 0xff55,
+                34: 0xff56,
+                37: 0xff51,
+                38: 0xff52,
+                39: 0xff53,
+                40: 0xff54,
+                112: 0xffbe,
+                113: 0xffbf,
+                114: 0xffc0,
+                115: 0xffc1,
+                116: 0xffc2,
+                117: 0xffc3,
+                118: 0xffc4,
+                119: 0xffc5,
+                120: 0xffc6,
+                121: 0xffc7,
+                122: 0xffc8,
+                123: 0xffc9
+            }
+
+            if (desktop.contype == 2) {
+                if (flags & 1) { keyArray.push([0xffe1, 1]); keyArray2.push([0xffe1, 0]); }
+                if (flags & 2) { keyArray.push([0xffe9, 1]); keyArray2.push([0xffe9, 0]); }
+                if (flags & 8) { keyArray.push([0xffe3, 1]); keyArray2.push([0xffe3, 0]); }
+                if (flags & 16) { keyArray.push([0xffe7, 1]); keyArray2.push([0xffe7, 0]); }
+                if (amtTranslate[key]) { key = amtTranslate[key]; }
+                if ((key >= 65) && (key <= 90)) { key += 32; }
+                if (key != 0) { keyArray.push([key, 1]); keyArray2.push([key, 0]); }
+                keyArray2.reverse();
+                for (var i = 0; i < keyArray2.length; i++) { keyArray.push(keyArray2[i]); }
+                desktop.m.sendkey(keyArray);
+            } else {
+                if (flags & 1) { keyArray.push([desktop.m.KeyAction.DOWN, 16]); keyArray2.push([desktop.m.KeyAction.UP, 16]); }
+                if (flags & 2) { keyArray.push([desktop.m.KeyAction.EXDOWN, 18]); keyArray2.push([desktop.m.KeyAction.EXUP, 18]); }
+                if (flags & 8) { keyArray.push([desktop.m.KeyAction.EXDOWN, 17]); keyArray2.push([desktop.m.KeyAction.EXUP, 17]); }
+                if (flags & 16) { keyArray.push([desktop.m.KeyAction.EXDOWN, 0x5B]); keyArray2.push([desktop.m.KeyAction.EXUP, 0x5B]); }
+                if (key != 0) { keyArray.push([desktop.m.KeyAction.DOWN, key]); keyArray2.push([desktop.m.KeyAction.UP, key]); }
+                keyArray2.reverse();
+                for (var i = 0; i < keyArray2.length; i++) { keyArray.push(keyArray2[i]); }
+                desktop.m.SendKeyMsgKC(keyArray);
+            }
+        }
+
+        function toggleMenu(x) {
+            if (xxdialogMode) return;
+            QV('deskButtonMenu', fullscreen && !x && (currentDevicePanel == 1));
+            QV('termButtonMenu', fullscreen && !x && (currentDevicePanel == 5));
+            QV('deskkeybutton3a', fullscreen && x);
+            QV('deskkeybutton3b', fullscreen && !x);
+        }
+
+        function deskChangeMouseButton(x) {
+            if (xxdialogMode) return;
+            if (desktop == null) return;
+            desktop.m.SwapMouse = !desktop.m.SwapMouse;
+            QV('deskkeybutton4a', fullscreen && (!desktop.m.SwapMouse));
+            QV('deskkeybutton4b', fullscreen && (desktop.m.SwapMouse));
+        }
+
+        function deskChangeFullscreenZoom() {
+            if (xxdialogMode) return;
+            if (currentDevicePanel == 1) {
+                if (desktop == null) return;
+                if (fullscreenzoom == 1) { fullscreenzoom = 0.5; } else { fullscreenzoom = 1; }
+                QV('deskkeybutton5a', fullscreen && (fullscreenzoom == 1));
+                QV('deskkeybutton5b', fullscreen && (fullscreenzoom != 1));
+                QS('deskarea3').width = (desktop.m.ScreenWidth * fullscreenzoom) + 'px';
+                QS('deskarea3').height = (desktop.m.ScreenHeight * fullscreenzoom) + 'px';
+                deskAdjust();
+            }
+            if (currentDevicePanel == 5) {
+                if (terminal == null) return;
+                xterm.setOption('fontSize', (xterm.getOption('fontSize') == 15) ? 10 : 15)
+            }
+        }
+
+        var fullscreen = false;
+        var fullscreenzoom = 1;
+        function deskToggleFull() {
+            fullscreen = !fullscreen;
+            QV('mastheadx', !fullscreen);
+            QV('masthead', !fullscreen);
+            QV('topbar', !fullscreen);
+            QV('p11deviceNameHeader', !fullscreen);
+            QV('top-bar', !fullscreen && xxcurrentView == 10);
+            QV('column_l_bottomgap', !fullscreen);
+            QV('idx_deskFullBtn2', fullscreen);
+            QV('deskFullBtn', !fullscreen);
+            QV('p10deskTopTable', !fullscreen);
+            QV('deskarea1', !fullscreen);
+            QV('deskarea4', !fullscreen);
+            QV('termarea1', !fullscreen);
+            QV('termarea4', !fullscreen);
+
+            var rights = GetNodeRights(currentNode);
+            var inputAllowed = ((features2 & 0x2000) == 0) && (currentNode.agent.id != 14) && ((rights == 0xFFFFFFFF) || (((rights & 8) != 0) && ((rights & 256) == 0) && ((rights & 4096) == 0)));
+
+            QV('deskkeybutton1', fullscreen);
+            if (currentDevicePanel == 1) {
+                QS('deskkeybutton2a').top = QS('deskkeybutton2b').top = '210px';
+                QS('deskkeybutton5a').top = QS('deskkeybutton5b').top = (inputAllowed) ? '160px' : '60px';
+                QV('deskkeybutton2a', fullscreen && inputAllowed);
+                QV('deskkeybutton2b', false);
+                QV('deskkeybutton3a', fullscreen && inputAllowed);
+                QV('deskkeybutton3b', false);
+                QV('deskkeybutton4a', fullscreen && inputAllowed && (!desktop.m.SwapMouse));
+                QV('deskkeybutton4b', fullscreen && inputAllowed && (desktop.m.SwapMouse));
+                QV('deskkeybutton5a', fullscreen && (fullscreenzoom == 1));
+                QV('deskkeybutton5b', fullscreen && (fullscreenzoom != 1));
+            }
+            if (currentDevicePanel == 5) {
+                QS('deskkeybutton2a').top = QS('deskkeybutton2b').top = '110px';
+                QV('deskkeybutton2a', fullscreen);
+                QV('deskkeybutton2b', false);
+                QV('deskkeybutton3a', fullscreen);
+                QV('deskkeybutton3b', false);
+                QV('deskkeybutton4a', false);
+                QV('deskkeybutton4b', false);
+                QV('deskkeybutton5a', false);
+                QV('deskkeybutton5a', false);
+            }
+
+            if (fullscreen) {
+                QS('DeskParent').height = null;
+                QS('page_content').top = '0px';
+                QS('page_content').bottom = '0px';
+                if (currentDevicePanel == 1) {
+                    QS('p10desktop').top = '0px';
+                    QS('p10desktop').bottom = null;
+                    QS('p10desktop').overflow = 'scroll';
+                    QS('deskarea3').top = '0px';
+                    QS('deskarea3').left = null;
+                    QS('deskarea3').width = (desktop.m.ScreenWidth * fullscreenzoom) + 'px';
+                    QS('deskarea3').height = (desktop.m.ScreenHeight * fullscreenzoom) + 'px';
+                    QS('deskarea3')['padding-right'] = '55px';
+                    QS('Desk')['touch-action'] = 'pan-x pan-y';
+                    QS('Desk')['-ms-touch-action'] = 'pan-x pan-y';
+                    QS('Desk')['pointer-events'] = 'auto';
+                }
+                if (currentDevicePanel == 5) {
+                    QS('p10terminal').top = '0px';
+                    QS('p10terminal').bottom = '0px';
+                    QS('p10terminal').overflow = 'scroll';
+                    QS('termarea3').top = '0px';
+                    QS('termarea3').bottom = null;
+                    QS('termarea3').right = null;
+                    QS('termarea3')['padding-right'] = '55px';
+                    QS('termarea3')['height'] = '100%';
+                }
+                QS('body')['background-color'] = '#000';
+                QS('p10')['background-color'] = '#000';
+            } else {
+                QS('DeskParent').height = '100%';
+                QS('page_content').top = 'calc(82px + env(safe-area-inset-top))';
+                QS('page_content').bottom = 'calc(0px + env(safe-area-inset-bottom))';
+                if (currentDevicePanel == 1) {
+                    QS('p10desktop').top = '55px';
+                    QS('p10desktop').overflow = 'hidden';
+                    QS('deskarea3').top = '53px';
+                    QS('deskarea3').bottom = '53px';
+                    QS('deskarea3').left = null;
+                    QS('deskarea3').width = '100%';
+                    QS('deskarea3').height = null;
+                    QS('deskarea3')['padding-right'] = '';
+                    QS('DeskParent')['margin-top'] = null;
+                    QS('DeskParent')['margin-left'] = null;
+                    QS('Desk')['touch-action'] = 'none';
+                    QS('Desk')['-ms-touch-action'] = 'none';
+                    QS('Desk')['pointer-events'] = 'none';
+                }
+                if (currentDevicePanel == 5) {
+                    QS('p10terminal').top = '55px';
+                    QS('p10terminal').overflow = 'hidden';
+                    Q('p10terminal').scrollTop = 0;
+                    Q('p10terminal').scrollLeft = 0;
+                    QS('termarea3').top = '45px';
+                    QS('termarea3').bottom = '45px';
+                    QS('termarea3').left = null;
+                    QS('termarea3').width = '100%';
+                    QS('termarea3').height = null;
+                    QS('termarea3')['padding-right'] = null;
+                }
+                QS('body')['background-color'] = nightMode ? '#000' : '#FFF';
+                QS('p10')['background-color'] = null;
+            }
+            if (currentDevicePanel == 1) { deskAdjust(); }
+        }
+
+        function deskAdjust() {
+            if (currentDevicePanel != 1) return;
+            if (fullscreen) {
+                QS('Desk')['margin-top'] = null;
+                QS('Desk')['margin-bottom'] = null;
+                QS('Desk').width = '100%';
+                QS('Desk').height = '100%';
+                var parentH = Q('p10desktop').clientHeight, parentW = Q('p10desktop').clientWidth;
+                var deskH = Q('deskarea3').clientHeight, deskW = Q('deskarea3').clientWidth - 55;
+                if (parentH > deskH) { QS('deskarea3').top = ((parentH - deskH) / 2) + 'px'; } else { QS('deskarea3').top = null; }
+                if (parentW > deskW) { QS('deskarea3').left = ((parentW - deskW) / 2) + 'px'; } else { QS('deskarea3').left = null; }
+            } else {
+                var parentH = Q('DeskParent').clientHeight, parentW = Q('DeskParent').clientWidth;
+                var deskH = Q('Desk').height, deskW = Q('Desk').width;
+                var webPageFullScreen = false;
+
+                if ((parentH / parentW) > (deskH / deskW)) {
+                    var hNew = ((deskH * parentW) / deskW) + 'px';
+                    QS('Desk').height = hNew;
+                    QS('Desk').width = '100%';
+                } else {
+                    var wNew = ((deskW * parentH) / deskH) + 'px';
+                    QS('Desk').width = wNew;
+                    QS('Desk').height = '100%';
+                }
+                QS('DeskParent').overflow = 'hidden';
+
+                var x = (Q('DeskParent').clientHeight - Q('Desk').clientHeight) / 2;
+                QS('Desk')['margin-top'] = x + 'px';
+                QS('Desk')['margin-bottom'] = x + 'px';
+            }
+        }
+
+        function sendSpecialKeys() {
+            if (xxdialogMode || desktop == null || desktop.State != 3) return;
+            setDialogMode(3, "Special Keys", 3, deskSendKeys);
+        }
+
+        function deskSaveImage() {
+            setSessionActivity();
+            if (xxdialogMode || desktop == null || desktop.State != 3) return;
+            var d = new Date(), n = 'Desktop-' + currentNode.name + '-' + d.getFullYear() + '-' + ('0' + (d.getMonth() + 1)).slice(-2) + '-' + ('0' + d.getDate()).slice(-2) + '-' + ('0' + d.getHours()).slice(-2) + '-' + ('0' + d.getMinutes()).slice(-2);
+            Q('Desk')['toBlob'](function (blob) { saveAs(blob, n + '.png'); });
+        }
+
+        function deskSelectScreens() {
+            if (xxdialogMode || desktop == null || desktop.State != 3) return;
+            var x = '', info = desktop.m.displays;
+            for (var i in info) { x += '<option value=' + i + ' ' + ((desktop.m.selectedDisplay == i) ? ' selected' : '') + '>' + info[i] + '</option>'; }
+            x = addHtmlValue4("Screen", '<select style=width:100% id=deskdisplays>' + x + '</select>');
+            setDialogMode(2, "Screen Selection", 3, deskSelectScreensEx, x);
+        }
+
+        function deskSelectScreensEx() {
+            if (desktop == null || desktop.State != 3) return;
+            desktop.m.SetDisplay(parseInt(Q('deskdisplays').value));
+        }
+
+        function deskDisplayInfo(sender, info, selDisplay, selItem) {
+            var displayCount = 0;
+            for (var x in info) { displayCount++; }
+            QV('DeskScreens', displayCount > 1);
+        }
+
+        function dmousedown(e) { setSessionActivity(); if ((!xxdialogMode && desktop != null)) { if (fullscreen) { e.addx = Q('p10desktop').scrollLeft * (1 / fullscreenzoom); e.addy = Q('p10desktop').scrollTop * (1 / fullscreenzoom); } desktop.m.mousedown(e); } }
+        function dmouseup(e) { setSessionActivity(); if ((!xxdialogMode && desktop != null)) { if (fullscreen) { e.addx = Q('p10desktop').scrollLeft * (1 / fullscreenzoom); e.addy = Q('p10desktop').scrollTop * (1 / fullscreenzoom); } desktop.m.mouseup(e); } }
+        function dmousemove(e) { setSessionActivity(); if ((!xxdialogMode && desktop != null)) { if (fullscreen) { e.addx = Q('p10desktop').scrollLeft * (1 / fullscreenzoom); e.addy = Q('p10desktop').scrollTop * (1 / fullscreenzoom); } desktop.m.mousemove(e); } }
+        function dmousewheel(e) { setSessionActivity(); if ((!xxdialogMode && desktop != null) && desktop.m.mousewheel) { if (fullscreen) { e.addx = Q('p10desktop').scrollLeft * (1 / fullscreenzoom); e.addy = Q('p10desktop').scrollTop * (1 / fullscreenzoom); } desktop.m.mousewheel(e); haltEvent(e); return true; } return false; }
+        function drotate(x) { if (!xxdialogMode && desktop != null) { desktop.m.setRotation(desktop.m.rotation + x); deskAdjust(); } }
+
+
+        var terminalNode;
+        function setupTerminal() {
+            if ((terminalNode != currentNode) && (terminal != null)) { terminal.Stop(); terminal = null; }
+            terminalNode = currentNode;
+            updateTerminalButtons();
+        }
+
+        function updateTerminalButtons() {
+            var mtype = (currentNode.agent == 1) ? 1 : 2;
+            var termState = ((terminal != null) && (terminal.state != 0));
+            QE('termFullScreen', (termState != 0));
+
+            if ((terminalNode.mtype == 3) && (terminalNode.agent != null) && (terminalNode.agent.id > 4) && (features2 & 0x00000200)) { terminalNode.agent.caps = 6; }
+
+            QV('disconnectbutton2span', (termState == true));
+            QV('connectbutton2span', (termState == false) && (terminalNode.agent != null) && (terminalNode.agent.caps & 2) && (terminalNode.mtype != 3));
+            QV('connectbutton2sspan', (termState == false) && (terminalNode.agent != null) && (terminalNode.agent.caps & 2) && (terminalNode.agent.id != 3));
+
+            var online = ((terminalNode.conn & 1) != 0) || (terminalNode.mtype == 3);
+            QE('connectbutton2', online);
+            QE('connectbutton2s', online);
+
+            QV('termActionsBtn', terminalNode.mtype != 3);
+            QE('ctrlcbutton', termState);
+            QE('ctrlxbutton', termState);
+            QE('escbutton', termState);
+            if (((termState == true) && (terminal.contype != 3)) || (terminalNode.agent == null) || (terminalNode.agent.id == 3) || (terminalNode.agent.id == 4)) {
+                QH('terminalCustomUpperRight', '');
+            } else {
+                QH('terminalCustomUpperRight', '<a style=cursor:pointer onclick=cmsshportaction(1,event)>' + format("SSH Port {0}", (terminalNode.sshport ? terminalNode.sshport : 22)) + '</a>');
+            }
+        }
+
+        function cmsshportaction(action) {
+            if (xxdialogMode) return;
+            var x = "SSH remote connection port:" + '<br /><br /><input type=text placeholder="22" inputmode="numeric" pattern="[0-9]*" onkeypress="return (event.keyCode == 8) || (event.charCode >= 48 && event.charCode <= 57)" maxlength=5 id=d10sshport type=text>';
+            setDialogMode(2, "SSH Connection", 3, function () {
+                var sshport = ((Q('d10sshport').value.length > 0) ? parseInt(Q('d10sshport').value) : 22);
+                meshserver.send({ action: 'changedevice', nodeid: currentNode._id, sshport: sshport });
+            }, x, currentNode);
+            Q('d10sshport').focus();
+            if (currentNode.sshport != null) { Q('d10sshport').value = currentNode.sshport; }
+        }
+
+        function onTerminalStateChange(xterminal, state) {
+            var xstate = state;
+            if ((xstate == 3) && (xterminal.contype == 2)) { xstate++; }
+            var str = StatusStrs[xstate];
+            if (terminal.webRtcActive == true) { str += ", WebRTC"; }
+            QH('termstatus', str);
+            switch (state) {
+                case 0:
+                    xterm.dispose();
+                    xterm = null;
+                    if (terminal != null) { terminal.Stop(); terminal = null; }
+                    break;
+                case 3:
+                    xterm.focus();
+                    break;
+                default:
+                    break;
+            }
+            updateTerminalButtons();
+        }
+
+        function CreateRemoteTunnel(onTunnelUpdate, options) {
+            var obj = { protocol: 1 };
+            if ((options != null) && (typeof options.protocol == 'number')) { obj.protocol = options.protocol; }
+            obj.onTunnelUpdate = onTunnelUpdate;
+            obj.xxStateChange = function (state) { }
+            obj.ProcessBinaryData = function (data) { obj.onTunnelUpdate(data); }
+            obj.ProcessData = function (data) { obj.onTunnelUpdate(data); }
+            obj.terminalEmulation = 1;
+            obj.fxEmulation = 0;
+            obj.lineFeed = '\r\n';
+            return obj;
+        }
+
+        function tunnelUpdate(data) {
+            if (xterm != null) {
+                if (xterm.writeUtf8) {
+                    if (typeof data == 'string') { xterm.writeUtf8(data); } else { xterm.writeUtf8(new Uint8Array(data)); }
+                } else {
+                    if (typeof data == 'string') { xterm.write(data); } else { xterm.write(new Uint8Array(data)); }
+                }
+            }
+        }
+
+        function sshTunnelAuthDialog(j, func) {
+            var x = '';
+            if (j.askkeypass) {
+                x += addHtmlValue("Authentication", '<select id=dp2authmethod style=width:150px onchange=sshAuthUpdate(event)><option value=3 selected>' + "Stored Key" + '</option><option value=1>' + "Username & Password" + '</option><option value=2>' + "Username and Key" + '</option></select>');
+            } else {
+                x += addHtmlValue("Authentication", '<select id=dp2authmethod style=width:150px onchange=sshAuthUpdate(event)><option value=1 selected>' + "Username & Password" + '</option><option value=2>' + "Username and Key" + '</option></select>');
+            }
+            x += '<div id=d2userauth style=display:none>';
+            x += addHtmlValue("Username", '<input id=dp2user style=width:150px maxlength=64 autocomplete=off onkeyup=sshAuthUpdate(event) />');
+            x += '</div>';
+            x += '<div id=d2passauth style=display:none>';
+            x += addHtmlValue("Password", '<input type=password id=dp2pass style=width:150px maxlength=64 autocomplete=off onkeyup=sshAuthUpdate(event) />');
+            if ((features2 & 0x00400000) == 0) { x += '<label><input id=dp2keep type=checkbox>' + "Remember credentials" + '</label>'; }
+            x += '</div><div id=d2keyauth style=display:none>';
+            x += addHtmlValue("Key File", '<input type=file id=dp2key style=width:150px maxlength=64 autocomplete=off onchange=sshAuthUpdate(event) />' + '<div id=d2badkey style=font-size:x-small>' + "Key file must be in OpenSSH format." + '</div>');
+            x += addHtmlValue("Key Password", '<input type=password id=dp2keypass style=width:150px maxlength=64 autocomplete=off onkeyup=sshAuthUpdate(event) />');
+            if ((features2 & 0x00400000) == 0) {
+                x += '<label><input id=dp2keep1 type=checkbox onchange=sshAuthUpdate(event)>' + "Remember user & key" + '</label><br/>';
+                x += '<label><input id=dp2keep2 type=checkbox>' + "Remember password" + '</label>';
+            }
+            x += '</div>';
+            if (j.askkeypass) {
+                x += '<div id=d2keyauth2 style=display:none>';
+                x += addHtmlValue("Password", '<input type=password id=dp2keypass2 style=width:150px maxlength=64 autocomplete=off onkeyup=sshAuthUpdate(event) />');
+                x += '</div>';
+            }
+            setDialogMode(2, "Authentication", 11, func, x, 'ssh');
+            Q('dp2user').focus();
+            sshAuthUpdate();
+            setTimeout(sshAuthUpdate, 50);
+        }
+
+        function sshTunnelUpdate(data) {
+            if (typeof data == 'string') {
+                if (data[0] == '{') {
+                    var j = JSON.parse(data);
+                    switch (j.action) {
+                        case 'sshauth': {
+                            sshTunnelAuthDialog(j, sshConnectEx);
+                            break;
+                        }
+                        case 'sshautoauth': {
+                            terminal.socket.send(JSON.stringify({ action: 'sshautoauth', cols: xterm.cols, rows: xterm.rows, width: Q('termarea3xdiv').offsetWidth, height: Q('termarea3xdiv').offsetHeight }));
+                            break;
+                        }
+                        case 'autherror': { p12setConsoleMsg("Authentication Error", 5000); break; }
+                        case 'sessionerror': { p12setConsoleMsg("Session expired", 5000); break; }
+                        case 'sessiontimeout': { p12setConsoleMsg("Session timeout", 5000); break; }
+                    }
+                } else if (data[0] == '~') {
+                    if (xterm.writeUtf8) { xterm.writeUtf8(data.substring(1)); } else { xterm.write(data.substring(1)); }
+                }
+            }
+        }
+
+        function sshAuthUpdate(e) {
+            QV('d2userauth', Q('dp2authmethod').value != 3);
+            QV('d2passauth', Q('dp2authmethod').value == 1);
+            QV('d2keyauth', Q('dp2authmethod').value == 2);
+            QV('d2keyauth2', Q('dp2authmethod').value == 3);
+            if (Q('dp2authmethod').value == 1) {
+                QE('idx_dlgOkButton', (Q('dp2user').value.length > 0) && (Q('dp2pass').value.length > 0));
+            } else if (Q('dp2authmethod').value == 3) {
+                QE('idx_dlgOkButton', Q('dp2keypass2').value.length > 0);
+            } else {
+                QE('idx_dlgOkButton', false);
+                if ((features2 & 0x00400000) == 0) { QE('dp2keep2', Q('dp2keep1').checked); }
+                var ok = (Q('dp2user').value.length > 0) && (Q('dp2key').files != null) && (Q('dp2key').files.length == 1) && (Q('dp2key').files[0].size < 8000);
+                if (ok == true) {
+                    var reader = new FileReader();
+                    reader.onload = function (e) {
+                        var validkey =
+                            ((e.target.result.indexOf('-----BEGIN OPENSSH PRIVATE KEY-----') >= 0) && (e.target.result.indexOf('-----END OPENSSH PRIVATE KEY-----') >= 0)) ||
+                            ((e.target.result.indexOf('-----BEGIN RSA PRIVATE KEY-----') >= 0) && (e.target.result.indexOf('-----END RSA PRIVATE KEY-----') >= 0));
+                        QE('idx_dlgOkButton', validkey);
+                        QS('d2badkey')['color'] = validkey ? '#000' : '#F00';
+                    }
+                    reader.readAsText(Q('dp2key').files[0]);
+                }
+            }
+
+            if (e && (e.keyCode == 13) && (e.target) && (Q('dp2authmethod').value == 1)) {
+                if (e.target.id == 'dp2user') { Q('dp2pass').focus(); }
+                if (e.target.id == 'dp2pass') { dialogclose(1); }
+            }
+        }
+
+        function sshConnectEx(b) {
+            if (b == 0) {
+                if (terminal != null) { connectTerminal(); }  
+            } else {
+                var keep = 0;
+                if (Q('dp2authmethod').value == 1) {
+                    if ((features2 & 0x00400000) == 0) { keep = (Q('dp2keep').checked ? 1 : 0); }
+                    terminal.socket.send(JSON.stringify({ action: 'sshauth', username: Q('dp2user').value, password: Q('dp2pass').value, keep: keep, cols: xterm.cols, rows: xterm.rows, width: Q('termarea3xdiv').offsetWidth, height: Q('termarea3xdiv').offsetHeight }));
+                } else if (Q('dp2authmethod').value == 3) {
+                    terminal.socket.send(JSON.stringify({ action: 'sshkeyauth', keypass: Q('dp2keypass2').value, cols: xterm.cols, rows: xterm.rows, width: Q('termarea3xdiv').offsetWidth, height: Q('termarea3xdiv').offsetHeight }));
+                } else {
+                    if ((features2 & 0x00400000) == 0) { keep = (Q('dp2keep1').checked ? 1 : 0); if (keep == 1) { keep += (Q('dp2keep2').checked ? 1 : 0); } }
+                    var reader = new FileReader(), username = Q('dp2user').value, keypass = Q('dp2keypass').value;
+                    reader.onload = function (e) { terminal.socket.send(JSON.stringify({ action: 'sshauth', username: username, keypass: keypass, key: e.target.result, keep: keep, cols: xterm.cols, rows: xterm.rows, width: Q('termarea3xdiv').offsetWidth, height: Q('termarea3xdiv').offsetHeight })); }
+                    reader.readAsText(Q('dp2key').files[0]);
+                }
+            }
+        }
+
+        function xTermSendResize() {
+            xtermResizeTimer = null;
+            if ((xterm != null) && (terminal != null) && (terminal.sendCtrlMsg != null)) {
+                if (terminal.urlname == 'sshterminalrelay.ashx') {
+                    terminal.socket.send(JSON.stringify({ action: 'resize', cols: xterm.cols, rows: xterm.rows, width: Q('termarea3xdiv').offsetWidth, height: Q('termarea3xdiv').offsetHeight }));
+                } else {
+                    terminal.sendCtrlMsg(JSON.stringify({ ctrlChannel: '102938', type: 'termsize', cols: xterm.cols, rows: xterm.rows }));
+                }
+            }
+        }
+
+        function connectTerminal(e, contype, options) {
+            p12clearConsoleMsg();
+            if (!terminal) {
+                var termoptions = { protocol: ((options != null) && (typeof options.protocol == 'number')) ? options.protocol : 1 };
+                if (options && options.requireLogin) { termoptions.requireLogin = true; }
+
+                if ((serverinfo.linuxshell) != null && (currentNode.agent.id > 4)) {
+                    if (serverinfo.linuxshell == 'root') { termoptions.protocol = 1; delete termoptions.requireLogin; }
+                    if (serverinfo.linuxshell == 'user') { termoptions.protocol = 8; delete termoptions.requireLogin; }
+                    if (serverinfo.linuxshell == 'login') { termoptions.protocol = 1; termoptions.requireLogin = true; }
+                }
+
+                QV('termarea3xdiv', true);
+
+                if (xterm != null) { xterm.dispose(); }
+                xterm = new Terminal();
+                xtermfit = new FitAddon.FitAddon();
+                if (xtermfit) { xterm.loadAddon(xtermfit); }
+                xterm.open(Q('termarea3xdiv'));
+                xterm.onData(function (data) { if (terminal.urlname == 'sshterminalrelay.ashx') { terminal.socket.send('~' + data); } else { terminal.sendText(data); } })
+                if (xtermfit) { xtermfit.fit(); }
+                xterm.onResize(function (size) {
+                    if (xtermResizeTimer) clearTimeout(xtermResizeTimer);
+                    xtermResizeTimer = setTimeout(xTermSendResize, 200);
+                });
+
+                document.getElementsByClassName('xterm-helper-textarea')[0].onfocus = () => { xterm.blur(); if (!fullscreen) toggleKeyboard(); };
+                document.getElementsByClassName('xterm-viewport')[0].style.overflow = 'hidden';
+
+                terminal = CreateAgentRedirect(meshserver, CreateRemoteTunnel((contype == 3) ? sshTunnelUpdate : tunnelUpdate, termoptions), serverPublicNamePort, authCookie, authRelayCookie, domainUrl);
+                if (contype == 3) { terminal.urlname = 'sshterminalrelay.ashx'; }
+                terminal.debugmode = debugmode;
+                terminal.m.debugmode = debugmode;
+                terminal.options = termoptions;
+                terminal.options = { cols: xterm.cols, rows: xterm.rows };
+                if (termoptions.requireLogin) { terminal.options.requireLogin = true; }
+                terminal.Start(terminalNode._id);
+                terminal.onStateChanged = onTerminalStateChange;
+                terminal.contype = contype;
+                terminal.attemptWebRTC = false;
+                terminal.onConsoleMessageChange = function () { p12setConsoleMsg(terminal.consoleMessage ? formatAgentConsoleMessage(terminal.consoleMessage, terminal.consoleMessageId, terminal.consoleMessageArgs) : null, terminal.consoleMessageTimeout); }
+            } else {
+                terminal.Stop();
+                terminal = null;
+                if (fullscreen) { deskToggleFull(); }
+            }
+            Q('connectbutton2').blur();
+        }
+
+        function termSendKey(key, id) {
+            if (!terminal || xxdialogMode) return;
+            if (xterm != null) {
+                if (terminal.urlname == 'sshterminalrelay.ashx') {
+                    terminal.socket.send('~' + String.fromCharCode(key));
+                } else if (terminal.sendText) {
+                    terminal.sendText(String.fromCharCode(key));
+                } else {
+                    terminal.send(String.fromCharCode(key));
+                }
+                xterm.focus();
+            } else if (terminal != null) {
+                terminal.m.TermSendKey(key);
+                Q(id).blur();
+            }
+        }
+
+        function updateTermShortcutKeys() {
+            var x = '';
+            for (var i = 64; i <= 95; i++) { x += '<div class="menuButton" style="width:70px" onclick="termMenuButton(' + i + ')">' + "Ctrl + " + String.fromCharCode(i) + '</div>'; }
+            QH('termButtonMenu', x);
+        }
+
+        function termMenuButton(c) {
+            toggleMenu(true);
+            if (terminal.urlname == 'sshterminalrelay.ashx') {
+                terminal.socket.send('~' + String.fromCharCode(c - 64));
+            } else {
+                terminal.sendText(String.fromCharCode(c - 64));
+            }
+        }
+
+        var filesNode;
+        function setupFiles() {
+            var samenode = (filesNode == currentNode);
+            filesNode = currentNode;
+            var online = ((filesNode.conn & 1) != 0) || (filesNode.mtype == 3);
+            QE('p13Connect', online);
+            QE('p13Connects', online);
+            QV('p13Connect', (files == null) && (filesNode.mtype == 2));
+            QV('p13Connects', (files == null) && (filesNode.agent != null) && (filesNode.agent.id != 3) && (filesNode.agent.id != 4));
+            QV('p13Disconnect', files != null);
+            if (((samenode == false) || (online == false)) && files) { files.Stop(); files = null; }
+            p13setActions();
+        }
+
+        function onFilesStateChange(xfiles, state) {
+            setSessionActivity();
+            QV('p13Connect', (state == 0) && (filesNode.mtype == 2));
+            QV('p13Connects', (state == 0) && (filesNode.agent != null) && (filesNode.agent.id != 3) && (filesNode.agent.id != 4));
+            QV('p13Disconnect', state != 0);
+            var str = StatusStrs[state];
+            if (state == 3) {
+                if (files.contype == 2) { str += ", SFTP"; }
+                if (files.webRtcActive == true) { str += ", WebRTC"; }
+            }
+            Q('p13Status').textContent = str;
+            switch (state) {
+                case 0:
+                    QH('p13files', '');
+                    p13filetree = null;
+                    p13filetreelocation = [];
+                    QH('p13currentpath', '');
+                    QE('p13FolderUp', false);
+                    p13setActions();
+                    if (files != null) { files.Stop(); files = null; }
+                    if (uploadFile != null) { p13uploadFileTransferDone(); uploadFile = null; }
+                    break;
+                case 3:
+                    p13filetreelocation = [];
+                    p13targetpath = '';
+                    if (files) {
+                        var filepaths = [];
+                        try { filepaths = JSON.parse(getstore('_devFilePaths', '[]')); } catch (ex) { }
+                        for (var i = 0; i < filepaths.length; i++) { if (filepaths[i].n == currentNode._id) { p13targetpath = filepaths[i].p; } }
+                        p13filetreelocation = p13targetpath.split('/');
+                        files.sendText({ action: 'ls', reqid: 1, path: p13targetpath });
+                    }
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        function CreateRemoteFiles(onFileUpdate) {
+            var obj = { protocol: 5 };
+            obj.onFileUpdate = onFileUpdate;
+            obj.xxStateChange = function (state) { }
+            obj.ProcessData = function (data) { obj.onFileUpdate(data); }
+            return obj;
+        }
+
+        var autoConnectFilesTimer = null;
+        function autoConnectFiles(e) { if (autoConnectFilesTimer == null) { autoConnectFilesTimer = setInterval(connectFiles, 100); } else { clearInterval(autoConnectFilesTimer); autoConnectFilesTimer = null; } }
+
+        function connectFiles(e, contype) {
+            p13clearConsoleMsg();
+            if (!files) {
+                files = CreateAgentRedirect(meshserver, CreateRemoteFiles(p13gotFiles), serverPublicNamePort, authCookie, authRelayCookie, domainUrl);
+                if (contype == 2) { files.urlname = 'sshfilesrelay.ashx'; }
+                files.contype = contype;
+                files.attemptWebRTC = attemptWebRTC;
+                files.webrtcconfig = webrtcconfiguration;
+                files.onStateChanged = onFilesStateChange;
+                files.onConsoleMessageChange = function () {
+                    if (files.consoleMessage) {
+                        Q('p13FilesConsoleMsg').innerHTML += formatAgentConsoleMessage(files.consoleMessage, files.consoleMessageId, files.consoleMessageArgs);
+                        QV('p13FilesConsoleMsg', true);
+                        if (p13FilesConsoleMsgTimer != null) { clearTimeout(p13FilesConsoleMsgTimer); }
+                        if (files.consoleMessageTimeout) { p13FilesConsoleMsgTimer = setTimeout(p13clearConsoleMsg, files.consoleMessageTimeout * 1000); }
+                    } else {
+                        p13clearConsoleMsg();
+                    }
+                }
+                files.Start(filesNode._id);
+            } else {
+                files.Stop();
+                files = null;
+            }
+            p13clipboard = p13clipboardFolder = null;
+            p13clipboardCut = 0;
+            p13updateClipview();
+        }
+
+        var p13filetree = null;
+        var p13targetpath = null;
+        var p13filetreelocation = [];
+
+        function p13gotFiles(data) {
+            if ((data.length > 0) && (data.charCodeAt(0) != 123)) { p13gotDownloadBinaryData(data); return; }
+            try { data = JSON.parse(decode_utf8(data)); } catch (ex) { data = JSON.parse(data); }
+            if (data.action == 'download') { p13gotDownloadCommand(data); return; }
+
+            switch (data.action) {
+                case 'sshauth': { sshTunnelAuthDialog(data, p13sshConnectEx); break; }
+                case 'autherror': { p13setConsoleMsg("Authentication Error", 5000); return; }
+                case 'connectionerror': { p13setConsoleMsg("Connection Error", 5000); return; }
+                case 'sessionerror': { p13setConsoleMsg("Session expired", 5000); return; }
+                case 'sessiontimeout': { p13setConsoleMsg("Session timeout", 5000); return; }
+            }
+
+            if ((data.action != null) && (data.action.startsWith('upload'))) { p13gotUploadData(data); return; }
+
+            if (data.path != null) {
+                if (data.dir == null) {
+                    if (p13targetpath != '') { p13folderup(); }
+                } else {
+                    data.path = data.path.replace(/\//g, '\\');
+                    if ((p13filetree != null) && (data.path == p13filetree.path)) {
+                        var checkedNames = p13getCheckedNames();
+                        p13filetree = data;
+                        p13updateFiles(checkedNames);
+                    } else {
+                        var x1 = data.path.replace(/\//g, '\\'), x2 = p13targetpath.replace(/\//g, '\\');
+                        while ((x1.length > 0) && (x1[0] == '\\')) { x1 = x1.substring(1); }
+                        while ((x2.length > 0) && (x2[0] == '\\')) { x2 = x2.substring(1); }
+                        if ((x1 == x2) || ((data.path == '\\') && (p13targetpath == ''))) {
+                            p13filetree = data;
+                            p13updateFiles();
+                        }
+                    }
+                }
+            }
+        }
+
+        function p13sshConnectEx(b) {
+            if (b == 0) {
+                if (files != null) { connectFiles(); }
+            } else {
+                var keep = 0;
+                if (Q('dp2authmethod').value == 1) {
+                    if ((features2 & 0x00400000) == 0) { keep = (Q('dp2keep').checked ? 1 : 0); }
+                    files.socket.send(JSON.stringify({ action: 'sshauth', username: Q('dp2user').value, password: Q('dp2pass').value, keep: keep }));
+                } else if (Q('dp2authmethod').value == 3) {
+                    files.socket.send(JSON.stringify({ action: 'sshkeyauth', keypass: Q('dp2keypass2').value }));
+                } else {
+                    if ((features2 & 0x00400000) == 0) { keep = (Q('dp2keep1').checked ? 1 : 0); if (keep == 1) { keep += (Q('dp2keep2').checked ? 1 : 0); } }
+                    var reader = new FileReader(), username = Q('dp2user').value, keypass = Q('dp2keypass').value;
+                    reader.onload = function (e) { files.socket.send(JSON.stringify({ action: 'sshauth', username: username, keypass: keypass, key: e.target.result, keep: keep })); }
+                    reader.readAsText(Q('dp2key').files[0]);
+                }
+            }
+        }
+
+        function p13getCheckedNames() {
+            var checkedNames = [], checkboxes = document.getElementsByName('fd');
+            for (var i = 0; i < checkboxes.length; i++) { if (checkboxes[i].checked) { checkedNames.push(p13filetree.dir[checkboxes[i].value].n) }; }
+            return checkedNames;
+        }
+
+        function p13updateFiles(checkedNames) {
+            var html1 = '', html2 = '', displayPath = '<a style=cursor:pointer;color:black onclick=p13folderup(0)>' + "Root" + '</a>', fullPath = 'Root';
+
+
+            var x = p13filetree.path.split('\\');
+            p13filetreelocation = [];
+            for (var i in x) { if (x[i] != '') { p13filetreelocation.push(x[i]); } }
+            for (var i in p13filetreelocation) { displayPath += ' / <a style=cursor:pointer;color:black onclick=p13folderup(' + (parseInt(i) + 1) + ')>' + EscapeHtml(p13filetreelocation[i]) + '</a>' }
+            var newlinkpath = p13filetreelocation.join('/');
+
+            var filetreexx = p13sort_files(p13filetree.dir);
+
+            for (var i in filetreexx) {
+                var f = filetreexx[i], name = f.n, shortname;
+                if (name.length > 40) { shortname = EscapeHtml(name.substring(0, 70)) + "..."; } else { shortname = EscapeHtml(name); }
+
+                var fsize = '';
+                if (f.s != null) { fsize = getFileSizeStr(f.s); }
+
+                var h = '';
+                if (f.t < 3) {
+                    var right = '';
+                    h = '<div class=filelist file=999><input file=999 style=float:left name=fd class=fcb type=checkbox onchange=p13setActions() value=\'' + f.nx + '\'>&nbsp;<span style=float:right>' + right + '</span><span><div class=fileIcon' + f.t + '></div><a style=cursor:pointer onclick=p13folderset("' + encodeURIComponent(f.nx) + '")>' + shortname + '</a></span></div>';
+                } else {
+                    var link = shortname;
+                    if (f.s > 0) { link = '<a rel=\"noreferrer noopener\" target=\"_blank\" style=cursor:pointer onclick=\"p13downloadfile(\'' + encodeURIComponent(newlinkpath + '/' + name) + '\',\'' + encodeURIComponent(name) + '\',' + f.s + ')\">' + shortname + '</a>'; }
+                    h = '<div class=filelist file=3><input file=3 style=float:left name=fd class=fcb type=checkbox onchange=p13setActions() value=\'' + f.nx + '\'>&nbsp;<span style=float:right;padding-right:4px>' + fsize + '</span><span><div class=fileIcon' + f.t + '></div>' + link + '</span></div>';
+                }
+
+                if (f.t < 3) { html1 += h; } else { html2 += h; }
+            }
+
+            QH('p13files', html1 + html2);
+            QH('p13currentpath', displayPath);
+            QE('p13FolderUp', p13filetreelocation.length != 0);
+
+            if (checkedNames != null) { var checkboxes = document.getElementsByName('fd'); for (var i = 0; i < checkboxes.length; i++) { if (checkedNames.indexOf(p13filetree.dir[checkboxes[i].value].n) >= 0) { checkboxes[i].checked = true; } } }
+
+            p13setActions();
+        }
+
+        function p13folderset(x) {
+            p13targetpath = joinPaths(p13filetree.path, p13filetree.dir[x].n).split('\\').join('/');
+            if (files) {
+                p13storeCurrentPath(p13targetpath);
+                files.sendText({ action: 'ls', reqid: 1, path: p13targetpath });
+            }
+        }
+
+        function p13folderup(x) {
+            if (x == null) { p13filetreelocation.pop(); } else { while (p13filetreelocation.length > x) { p13filetreelocation.pop(); } }
+            p13targetpath = p13filetreelocation.join('/');
+            if (files) {
+                p13storeCurrentPath(p13targetpath);
+                files.sendText({ action: 'ls', reqid: 1, path: p13targetpath });
+            }
+        }
+
+        function p13storeCurrentPath(path) {
+            var filepaths = [], j = -1;
+            try { filepaths = JSON.parse(getstore('_devFilePaths', '[]')); } catch (ex) { }
+            for (var i = 0; i < filepaths.length; i++) { if (filepaths[i].n == currentNode._id) { j = i; } }
+            if (j >= 0) { filepaths.splice(j, 1); }
+            filepaths.push({ n: currentNode._id, p: path });
+            while (filepaths.length > 40) { filepaths.shift(); }
+            putstore('_devFilePaths', JSON.stringify(filepaths));
+        }
+
+        var p13sortorder;
+        function p13sort_filename(a, b) { if (a.ln > b.ln) return (1 * p13sortorder); if (a.ln < b.ln) return (-1 * p13sortorder); return 0; }
+        function p13sort_timestamp(a, b) { if (a.d > b.d) return (1 * p13sortorder); if (a.d < b.d) return (-1 * p13sortorder); return 0; }
+        function p13sort_bysize(a, b) { if (a.s == b.s) return p13sort_filename(a, b); return (((a.s - b.s)) * p13sortorder); }
+
+        function p13sort_files(files) {
+            var r = [], sortselection = Q('p13sortdropdown').value;
+            for (var i in files) { files[i].nx = i; if (files[i].s == null) { files[i].s = 0; } if (files[i].n == null) { files[i].n = i; } files[i].ln = files[i].n.toLowerCase(); r.push(files[i]); }
+            p13sortorder = 1;
+            if (sortselection > 3) { p13sortorder = -1; sortselection -= 3; }
+            if (sortselection == 1) { r.sort(p13sort_filename); }
+            else if (sortselection == 2) { r.sort(p13sort_bysize); }
+            else if (sortselection == 3) { r.sort(p13sort_timestamp); }
+            return r;
+        }
+
+        function p13setActions() {
+            var advancedFeatures = ((currentNode.agent) && (currentNode.agent.id != 14));
+            if (p13filetree == null) {
+                QE('p13DeleteFileButton', false);
+                QE('p13NewFolderButton', false);
+                QE('p13UploadButton', false);
+                QE('p13RenameFileButton', false);
+                QE('p13SelectAllButton', false);
+                Q('p13SelectAllButton').value = "All";
+                QE('p13RefreshButton', false);
+                QE('p13CutButton', false);
+                QE('p13CopyButton', false);
+                QE('p13PasteButton', false);
+            } else {
+                var cc = p13getFileSelCount(), tc = p13getFileCount(), sfc = p13getFileSelCount(false);
+                var winAgent = ((currentNode.agent.id > 0) && (currentNode.agent.id < 5)) || (currentNode.agent.id == 14) || (currentNode.agent.id == 34);
+                QE('p13DeleteFileButton', advancedFeatures && (cc > 0) && ((p13filetreelocation.length > 0) || (winAgent == false)));
+                QE('p13NewFolderButton', advancedFeatures && ((p13filetreelocation.length > 0) || (winAgent == false)));
+                QE('p13UploadButton', advancedFeatures && ((p13filetreelocation.length > 0) || (winAgent == false)));
+                QE('p13RenameFileButton', advancedFeatures && (cc == 1) && ((p13filetreelocation.length > 0) || (winAgent == false)));
+                QE('p13SelectAllButton', tc > 0);
+                Q('p13SelectAllButton').value = (cc > 0 ? "None" : "All");
+                QE('p13RefreshButton', true);
+                QE('p13CutButton', advancedFeatures && (cc > 0) && (cc == sfc) && (currentNode.mtype != 3) && ((p13filetreelocation.length > 0) || (winAgent == false)));
+                QE('p13CopyButton', advancedFeatures && (cc > 0) && (cc == sfc) && (currentNode.mtype != 3) && ((p13filetreelocation.length > 0) || (winAgent == false)));
+                QE('p13PasteButton', advancedFeatures && (currentNode.mtype != 3) && ((p13filetreelocation.length > 0) || (winAgent == false)) && ((p13clipboard != null) && (p13clipboard.length > 0)));
+            }
+            var filesState = ((files != null) && (files.state != 0));
+            if (((filesState == true) && (files.contype != 2)) || (filesNode.agent == null) || (filesNode.agent.id == 3) || (filesNode.agent.id == 4)) {
+                QH('filesCustomUpperRight', '');
+            } else {
+                QH('filesCustomUpperRight', '<a style=cursor:pointer onclick=cmsshportaction(1,event)>' + format("SSH Port {0}", (filesNode.sshport ? filesNode.sshport : 22)) + '</a>');
+            }
+            QV('filesActionsBtn', filesNode.mtype != 3);
+        }
+
+        function p13getFileSelCount(includeDirs) { var cc = 0; var checkboxes = document.getElementsByName('fd'); for (var i = 0; i < checkboxes.length; i++) { if ((checkboxes[i].checked) && ((includeDirs != false) || (checkboxes[i].attributes.file.value == '3'))) cc++; } return cc; }
+        function p13getFileSelDirCount() { var cc = 0, checkboxes = document.getElementsByName('fd'); for (var i = 0; i < checkboxes.length; i++) { if ((checkboxes[i].checked) && (checkboxes[i].attributes.file.value == '999')) cc++; } return cc; }
+        function p13getFileCount() { var cc = 0; var checkboxes = document.getElementsByName('fd'); return checkboxes.length; }
+        function p13selectallfile() { var nv = (p13getFileSelCount() == 0), checkboxes = document.getElementsByName('fd'); for (var i = 0; i < checkboxes.length; i++) { checkboxes[i].checked = nv; } p13setActions(); }
+        function p13createfolder() { setDialogMode(2, "New Folder", 3, p13createfolderEx, '<input type=text id=p13renameinput maxlength=64 onkeyup=p13fileNameCheck(event) style=width:100% />'); focusTextBox('p13renameinput'); p13fileNameCheck(); }
+        function p13createfolderEx() { files.sendText({ action: 'mkdir', reqid: 1, path: p13filetreelocation.join('/') + '/' + Q('p13renameinput').value }); p13folderup(999); }
+        function p13deletefile() { var cc = p13getFileSelCount(), rec = (p13getFileSelDirCount() > 0) ? '<br /><br /><label><input type=checkbox id=p13recdeleteinput>' + "Recursive delete" + '</label><br>' : '<input type=checkbox id=p13recdeleteinput style=\'display:none\'>'; setDialogMode(2, "Delete", 3, p13deletefileEx, (cc > 1) ? (format("Delete {0} selected items?", cc) + rec) : ("Delete selected item?" + rec)); }
+        function p13deletefileEx() { var delfiles = [], checkboxes = document.getElementsByName('fd'); for (var i = 0; i < checkboxes.length; i++) { if (checkboxes[i].checked) { delfiles.push(p13filetree.dir[checkboxes[i].value].n); } } files.sendText({ action: 'rm', reqid: 1, path: p13filetreelocation.join('/'), delfiles: delfiles, rec: Q('p13recdeleteinput').checked }); p13folderup(999); }
+        function p13renamefile() { var renamefile, checkboxes = document.getElementsByName('fd'); for (var i = 0; i < checkboxes.length; i++) { if (checkboxes[i].checked) { renamefile = p13filetree.dir[checkboxes[i].value].n; } } setDialogMode(2, "Rename", 3, p13renamefileEx, '<input type=text id=p13renameinput maxlength=64 onkeyup=p13fileNameCheck(event) style=width:100% value="' + renamefile + '" />', { action: 'rename', path: p13filetreelocation.join('/'), oldname: renamefile }); focusTextBox('p13renameinput'); p13fileNameCheck(); }
+        function p13renamefileEx(b, t) { t.newname = Q('p13renameinput').value; files.sendText(t); p13folderup(999); }
+        function p13fileNameCheck(e) { var x = isFilenameValid(Q('p13renameinput').value); QE('idx_dlgOkButton', x); if ((x == true) && (e != null) && (e.keyCode == 13)) { dialogclose(1); } }
+        function p13uploadFile() { setDialogMode(2, "Upload File", 3, p13uploadFileEx, '<input type=file name=files id=p13uploadinput style=width:100% multiple=multiple onchange="updateUploadDialogOk(\'p13uploadinput\')" />'); updateUploadDialogOk('p13uploadinput'); }
+        function p13uploadFileEx() { p13doUploadFiles(Q('p13uploadinput').files); }
+        function p13viewfile() {
+            var checkboxes = document.getElementsByName('fd');
+            for (var i = 0; i < checkboxes.length; i++) {
+                if (checkboxes[i].checked) {
+                    if (p13filetree.dir[checkboxes[i].value].s <= 204800) {
+                        p13downloadfile(encodeURIComponent(p13filetreelocation.join('/') + '/' + p13filetree.dir[checkboxes[i].value].n), encodeURIComponent(p13filetree.dir[checkboxes[i].value].n), p13filetree.dir[checkboxes[i].value].s, 'viewer');
+                    } else { messagebox("File Editor", "Only files less than 200k can be edited."); }
+                    break;
+                }
+            }
+        }
+
+        var p13clipboard = null, p13clipboardFolder = null, p13clipboardCut = 0;
+        function p13copyFile(cut) { var checkboxes = document.getElementsByName('fd'); p13clipboard = []; p13clipboardCut = cut, p13clipboardFolder = p13targetpath; for (var i = 0; i < checkboxes.length; i++) { if ((checkboxes[i].checked) && (checkboxes[i].attributes.file.value == '3')) { p13clipboard.push(p13filetree.dir[checkboxes[i].value].n); } } p13updateClipview(); }
+        function p13pasteFile() {
+            var x = '';
+            if ((p13clipboard != null) && (p13clipboard.length > 0)) {
+                if (p13clipboardCut == 0) {
+                    if (p13clipboard.length > 1) { x = format("Confirm copy of {0} entries's to this location?", p13clipboard.length); } else { x = format("Confirm copy of 1 entrie to this location?"); }
+                } else {
+                    if (p13clipboard.length > 1) { x = format("Confirm move of {0} entries's to this location?", p13clipboard.length); } else { x = format("Confirm move of 1 entrie to this location?"); }
+                }
+            }
+            setDialogMode(2, "Paste", 3, p13pasteFileEx, x);
+        }
+        function p13pasteFileEx() { files.sendText({ action: (p13clipboardCut == 0 ? 'copy' : 'move'), reqid: 1, scpath: p13clipboardFolder, dspath: p13targetpath, names: p13clipboard }); p13folderup(999); if (p13clipboardCut == 1) { p13clipboard = null, p13clipboardFolder = null, p13clipboardCut = 0; p13updateClipview(); } }
+        function p13updateClipview() {
+            var x = '';
+            if ((p13clipboard != null) && (p13clipboard.length > 0)) {
+                if (p13clipboardCut == 0) {
+                    if (p13clipboard.length > 1) {
+                        x = format("Holding {0} entries for copy" + ', <a href=# onclick="return p13clearClip()" style=cursor:pointer>' + "Clear" + '</a>.', p13clipboard.length);
+                    } else {
+                        x = format("Holding 1 entrie for copy" + ', <a href=# onclick="return p13clearClip()" style=cursor:pointer>' + "Clear" + '</a>.');
+                    }
+                } else {
+                    if (p13clipboard.length > 1) {
+                        x = format("Holding {0} entries for move" + ', <a href=# onclick="return p13clearClip()" style=cursor:pointer>' + "Clear" + '</a>.', p13clipboard.length);
+                    } else {
+                        x = format("Holding 1 entrie for move" + ', <a href=# onclick="return p13clearClip()" style=cursor:pointer>' + "Clear" + '</a>.');
+                    }
+                }
+            }
+            QH('p13bottomstatus', x);
+            p13setActions();
+        }
+        function p13clearClip() { p13clipboard = null; p13clipboardFolder = null; p13clipboardCut = 0; p13updateClipview(); return false; } function updateUploadDialogOk(x) { QE('idx_dlgOkButton', Q(x).value != ''); }
+        function getFileSelCount(includeDirs) { var cc = 0; var checkboxes = document.getElementsByName('fc'); for (var i = 0; i < checkboxes.length; i++) { if ((checkboxes[i].checked) && ((includeDirs != false) || (checkboxes[i].attributes.file.value == "3"))) cc++; } return cc; }
+        function getFileCount() { var cc = 0; var checkboxes = document.getElementsByName('fc'); return checkboxes.length; }
+
+
+        var downloadFile;
+
+        function p13downloadfile(x, y, z) {
+            if (xxdialogMode || downloadFile || !files) return;
+            downloadFile = { path: decodeURIComponent(x), file: decodeURIComponent(y), size: z, tsize: 0, data: '', state: 0, id: Math.random() }
+            files.sendText({ action: 'download', sub: 'start', id: downloadFile.id, path: downloadFile.path });
+            setDialogMode(2, "Download File", 10, p13downloadFileCancel, '<div>' + EscapeHtml(downloadFile.file) + '</div><br /><progress id=d2progressBar style=width:100% value=0 max=' + z + ' />');
+        }
+
+        function p13downloadFileCancel() { setDialogMode(0); files.sendText({ action: 'download', sub: 'cancel', id: downloadFile.id }); downloadFile = null; }
+
+        function p13gotDownloadCommand(cmd) {
+            if ((downloadFile == null) || (cmd.id != downloadFile.id)) return;
+            if (cmd.sub == 'start') { downloadFile.state = 1; files.sendText({ action: 'download', sub: 'startack', id: downloadFile.id }); }
+            else if (cmd.sub == 'cancel') { downloadFile = null; setDialogMode(0); }
+        }
+
+        function p13gotDownloadBinaryData(data) {
+            if (!downloadFile || downloadFile.state == 0) return;
+            if (data.length > 4) {
+                downloadFile.tsize += (data.length - 4);
+                downloadFile.data += data.substring(4);
+                Q('d2progressBar').value = downloadFile.tsize;
+            }
+            if ((ReadInt(data, 0) & 1) != 0) {
+                saveAs(data2blob(downloadFile.data), downloadFile.file); downloadFile = null; setDialogMode(0);
+            } else {
+                files.sendText({ action: 'download', sub: 'ack', id: downloadFile.id });
+            }
+        }
+
+        var uploadFile;
+        function p13doUploadFiles(files) {
+            if (xxdialogMode) return;
+
+            var winAgent = ((currentNode.agent.id > 0) && (currentNode.agent.id < 5)) || (currentNode.agent.id == 14) || (currentNode.agent.id == 34);
+            var targetFiles = [], overWriteCount = 0;
+            for (var i in p13filetree.dir) { if (winAgent) { targetFiles.push(p13filetree.dir[i].n.toLowerCase()); } else { targetFiles.push(p13filetree.dir[i].n); } }
+            for (var i = 0; i < files.length; i++) {
+                if (winAgent) {
+                    if (targetFiles.indexOf(files[i].name.toLowerCase()) >= 0) { overWriteCount++; }
+                } else {
+                    if (targetFiles.indexOf(files[i].name) >= 0) { overWriteCount++; }
+                }
+            }
+
+            if (overWriteCount == 0) {
+                p13uploadFileContinue(1, files);
+            } else {
+                setDialogMode(2, "Upload File", 3, p13uploadFileContinue, format((overWriteCount == 1) ? "Upload will overwrite 1 file. Continue?" : "Upload will overwrite {0} files. Continue?", overWriteCount), files);
+            }
+        }
+
+        function p13uploadFileContinue(b, files) {
+            uploadFile = {};
+            uploadFile.xpath = p13filetreelocation.join('/');
+            uploadFile.xfiles = files;
+            uploadFile.xfilePtr = -1;
+            setDialogMode(2, "Upload File", 10, p13uploadFileCancel, '<div id=p13dfileName>' + "Connecting..." + '</div><br /><progress id=d2progressBar style=width:100% value=0 max=0 />');
+            p13uploadNextFile();
+        }
+
+        const byteToHex = [];
+        for (var n = 0; n <= 0xff; ++n) { var hexOctet = n.toString(16).padStart(2, '0'); byteToHex.push(hexOctet); }
+        function arrayBufferToHex(arrayBuffer) { return Array.prototype.map.call(new Uint8Array(arrayBuffer), n => byteToHex[n]).join(''); }
+        function performHash(data, f) { window.crypto.subtle.digest('SHA-384', data).then(function (v) { f(arrayBufferToHex(v)); }, function () { f(null); }); }
+        function performHashOnFile(file, f) {
+            var reader = new FileReader();
+            reader.onerror = function (err) { f(null); }
+            reader.onload = function () { window.crypto.subtle.digest('SHA-384', reader.result).then(function (v) { f(arrayBufferToHex(v)); }, function () { f(null); }); };
+            reader.readAsArrayBuffer(file);
+        }
+
+        function p13uploadNextFile() {
+            uploadFile.xfilePtr++;
+            if (uploadFile.xfiles.length > uploadFile.xfilePtr) {
+                uploadFile.xptr = 0;
+                var file = uploadFile.xfiles[uploadFile.xfilePtr];
+                QH('p13dfileName', EscapeHtml(file.name));
+                Q('d2progressBar').max = file.size;
+                Q('d2progressBar').value = 0;
+                if (file.xdata == null) {
+                    uploadFile.xfile = file;
+                    var f = null;
+                    for (var i in p13filetree.dir) { if (p13filetree.dir[i].n == file.name) { f = p13filetree.dir[i]; } }
+                    if ((f != null) && (f.s <= uploadFile.xfile.size)) {
+                        performHashOnFile(uploadFile.xfile, function (hash) { files.sendText(JSON.stringify({ action: 'uploadhash', reqid: uploadFile.xfilePtr, path: uploadFile.xpath, name: file.name, tag: { h: hash.toUpperCase(), s: f.s, skip: f.s == uploadFile.xfile.size } })); });
+                    } else {
+                        files.sendText(JSON.stringify({ action: 'upload', reqid: uploadFile.xfilePtr, path: uploadFile.xpath, name: file.name, size: uploadFile.xfile.size }));
+                    }
+                } else {
+                    uploadFile.xdata = file.xdata;
+                    files.sendText(JSON.stringify({ action: 'upload', reqid: uploadFile.xfilePtr, path: uploadFile.xpath, name: file.name, size: uploadFile.xdata.byteLength }));
+                }
+            } else {
+                p13uploadFileTransferDone();
+            }
+        }
+
+        function p13uploadFileCancel(button, tag) {
+            if (uploadFile != null) { files.sendText(JSON.stringify({ action: 'uploadcancel', reqid: uploadFile.xfilePtr })); uploadFile = null; }
+            p13uploadFileTransferDone();
+        }
+
+        function p13uploadFileTransferDone() {
+            uploadFile = null;
+            setDialogMode(0); 
+            p13folderup(9999);
+        }
+
+        function p13gotUploadData(cmd) {
+            if ((uploadFile == null) || (parseInt(uploadFile.xfilePtr) != parseInt(cmd.reqid))) { return; }
+            switch (cmd.action) {
+                case 'uploadstart': { uploadFile.xdataPriming = 8; p13uploadNextPart(false); break; }
+                case 'uploadack': { p13uploadNextPart(false); break; }
+                case 'uploaddone': { if (uploadFile.xfiles.length > uploadFile.xfilePtr + 1) { p13uploadNextFile(); } else { p13uploadFileTransferDone(); } break; }
+                case 'uploaderror': { p13uploadFileCancel(); break; }
+                case 'uploadhash': {
+                    var file = uploadFile.xfiles[uploadFile.xfilePtr];
+                    if (file) {
+                        if (cmd.tag.h === cmd.hash) {
+                            if (cmd.tag.skip) {
+                                p13uploadNextFile();
+                            } else {
+                                uploadFile.xptr = cmd.tag.s;
+                                files.sendText(JSON.stringify({ action: 'upload', reqid: uploadFile.xfilePtr, path: uploadFile.xpath, name: file.name, size: uploadFile.xfile.size, append: true }));
+                            }
+                        } else {
+                            files.sendText(JSON.stringify({ action: 'upload', reqid: uploadFile.xfilePtr, path: uploadFile.xpath, name: file.name, size: uploadFile.xfile.size, append: false }));
+                        }
+                    }
+                    break;
+                }
+            }
+        }
+
+        function p13uploadNextPart(dataPriming) {
+            if (uploadFile.xdata) {
+                var data = uploadFile.xdata, start = uploadFile.xptr;
+                if (start >= data.byteLength) {
+                    files.sendText(JSON.stringify({ action: 'uploaddone', reqid: uploadFile.xfilePtr }));
+                } else {
+                    var end = uploadFile.xptr + (attemptWebRTC ? 16384 : 65536);
+                    if (end > data.byteLength) { if (dataPriming == true) { return; } end = data.byteLength; }
+                    var dataslice = new Uint8Array(data.slice(start, end))
+                    if ((dataslice[0] == 123) || (dataslice[0] == 0)) {
+                        var datapart = new Uint8Array(end - start + 1);
+                        datapart.set(dataslice, 1);
+                        files.send(datapart);
+                    } else {
+                        files.send(dataslice);
+                    }
+                    uploadFile.xptr = end;
+                    Q('d2progressBar').value = end;
+                }
+            } else if (uploadFile.xfile) {
+                if (uploadFile.xreader != null) return;
+                if (uploadFile.xptr >= uploadFile.xfile.size) return;
+                var end = uploadFile.xptr + (attemptWebRTC ? 16384 : 65536);
+                if (end > uploadFile.xfile.size) { if (dataPriming == true) { return; } end = uploadFile.xfile.size; }
+                uploadFile.xreader = new FileReader();
+                uploadFile.xreader.onerror = function (err) { console.log(err); }
+                uploadFile.xreader.onload = function () {
+                    var data = uploadFile.xreader.result;
+                    delete uploadFile.xreader;
+                    if (data == null) return;
+                    var dataslice = new Uint8Array(data)
+                    if ((dataslice[0] == 123) || (dataslice[0] == 0)) {
+                        var datapart = new Uint8Array(data.byteLength + 1);
+                        datapart.set(dataslice, 1);
+                        files.send(datapart);
+                    } else {
+                        files.send(dataslice);
+                    }
+                    uploadFile.xptr = end;
+                    Q('d2progressBar').value = end;
+                    if (uploadFile.xptr >= uploadFile.xfile.size) {
+                        files.sendText(JSON.stringify({ action: 'uploaddone', reqid: uploadFile.xfilePtr }));
+                    } else {
+                        if (uploadFile.xdataPriming > 0) { uploadFile.xdataPriming--; p13uploadNextPart(true); }
+                    }
+                };
+                uploadFile.xreader.readAsArrayBuffer(uploadFile.xfile.slice(uploadFile.xptr, end));
+            }
+        }
+
+        var DeviceDetailsHardware = null;
+        var DeviceDetailsNetwork = null;
+        var DeviceDetailsNodeId = null;
+        function updateDeviceDetails(node, hardware, network) {
+            if (currentNode == null) return;
+            if (node == null) { node = currentNode; }
+            if (currentNode._id != node._id) return;
+            if (DeviceDetailsNodeId != node._id) { DeviceDetailsHardware = null; DeviceDetailsNetwork = null; DeviceDetailsNodeId = node._id; }
+            if (hardware != null) { DeviceDetailsHardware = hardware; }
+            if (network != null) { DeviceDetailsNetwork = network; }
+            hardware = DeviceDetailsHardware;
+            network = DeviceDetailsNetwork;
+            if (hardware == null) { hardware = {}; }
+            if (network == null) { network = {}; }
+            var sections = [], s = {};
+
+            var x = '';
+            if (node.rname) { x += addDetailItem("Name", EscapeHtml(node.rname), s); }
+            if (hardware.windows && hardware.windows.osinfo && hardware.windows.osinfo.Description) { x += addDetailItem("Description", EscapeHtml(hardware.windows.osinfo.Description), s); }
+            if (node.osdesc) { x += addDetailItem("Version", EscapeHtml(node.osdesc), s); }
+            if (hardware.windows && hardware.windows.osinfo) {
+                var m = hardware.windows.osinfo;
+                if (m.OSArchitecture) {
+                    if (m.OSArchitecture.startsWith('32')) { x += addDetailItem("Architecture", "32-bit", s); }
+                    else if (m.OSArchitecture.startsWith('64')) { x += addDetailItem("Architecture", "64-bit", s); }
+                    else { x += addDetailItem("Architecture", EscapeHtml(m.OSArchitecture), s); }
+                }
+                if(m.LastBootUpTime){
+                    var thedate = {
+                        year: parseInt(m.LastBootUpTime.substring(0, 4)),
+                        month: parseInt(m.LastBootUpTime.substring(4, 6)) - 1,
+                        day: parseInt(m.LastBootUpTime.substring(6, 8)),
+                        hours: parseInt(m.LastBootUpTime.substring(8, 10)),
+                        minutes: parseInt(m.LastBootUpTime.substring(10, 12)),
+                        seconds: parseInt(m.LastBootUpTime.substring(12, 14)),
+                    };
+                    const date = printDateTime(new Date(thedate.year, thedate.month, thedate.day, thedate.hours, thedate.minutes, thedate.seconds));
+                    x += addDetailItem("Last Boot Up Time", date);
+                }
+            }
+            if(hardware.linux && hardware.linux.LastBootUpTime){
+                var lastBootUpTime = new Date(hardware.linux.LastBootUpTime);
+                var thedate = {
+                    year: lastBootUpTime.getFullYear(),
+                    month: lastBootUpTime.getMonth(),
+                    day: lastBootUpTime.getDate(),
+                    hours: lastBootUpTime.getHours(),
+                    minutes: lastBootUpTime.getMinutes(),
+                    seconds: lastBootUpTime.getSeconds()
+                };
+                const date = printDateTime(new Date(thedate.year, thedate.month, thedate.day, thedate.hours, thedate.minutes, thedate.seconds));
+                x += addDetailItem("Last Boot Up Time", date);
+            }
+            if(hardware.darwin && hardware.darwin.LastBootUpTime){
+                var lastBootUpTime = new Date(hardware.darwin.LastBootUpTime * 1000);
+                var thedate = {
+                    year: lastBootUpTime.getFullYear(),
+                    month: lastBootUpTime.getMonth(),
+                    day: lastBootUpTime.getDate(),
+                    hours: lastBootUpTime.getHours(),
+                    minutes: lastBootUpTime.getMinutes(),
+                    seconds: lastBootUpTime.getSeconds()
+                };
+                const date = printDateTime(new Date(thedate.year, thedate.month, thedate.day, thedate.hours, thedate.minutes, thedate.seconds));
+                x += addDetailItem("Last Boot Up Time", date);
+            }
+                    
+            if (node.wsc) {
+                var y = [];
+                if (node.wsc.antiVirus != null) { if (node.wsc.antiVirus == 'OK') { y.push("AV" + ' - <span style=color:green>' + "OK" + '</span>'); } else { y.push("AV" + ' - <span style=color:red>' + "BAD" + '</span>'); } }
+                if (node.wsc.autoUpdate != null) { if (node.wsc.autoUpdate == 'OK') { y.push("Update" + ' - <span style=color:green>' + "OK" + '</span>'); } else { y.push("Update" + ' - <span style=color:red>' + "BAD" + '</span>'); } }
+                if (node.wsc.firewall != null) { if (node.wsc.firewall == 'OK') { y.push("Firewall" + ' - <span style=color:green>' + "OK" + '</span>'); } else { y.push("Firewall" + ' - <span style=color:red>' + "BAD" + '</span>'); } }
+                x += addDetailItem("Windows Security", y.join(', '));
+            }
+
+            if(node.defender) {
+                var y = [];
+                if (node.defender.RealTimeProtection != null) { if (node.defender.RealTimeProtection == true) { y.push("RealTimeProtection" + ' - <span style=color:green>' + "On" + '</span>'); } else { y.push("RealTimeProtection" + ' - <span style=color:red>' + "Off" + '</span>'); } }
+                if (node.defender.TamperProtected != null) { if (node.defender.TamperProtected == true) { y.push("TamperProtection" + ' - <span style=color:green>' + "On" + '</span>'); } else { y.push("TamperProtection" + ' - <span style=color:red>' + "Off" + '</span>'); } }
+                if (y.length > 0) x += addDetailItem("Windows Defender", y.join(', '));
+            }
+
+            if (node.av && node.av.length > 0) {
+                var y = [];
+                for (var i in node.av) {
+                    if (node.av[i].product) {
+                        var avx = EscapeHtml(node.av[i].product);
+                        if (node.av[i].enabled !== true) { avx += ' - <span style=color:red>' + "Disabled" + '</span>'; }
+                        if (node.av[i].updated !== true) { avx += ' - <span style=color:red>' + "Out of date" + '</span>'; }
+                        if ((node.av[i].enabled == true) && (node.av[i].updated == true)) { avx += ' - <span style=color:green>' + "OK" + '</span>'; }
+                        y.push(avx);
+                    }
+                }
+                x += addDetailItem("Antivirus", y.join('<br />'));
+            }
+
+           if (node.users && node.users.length > 0) {
+                var u = node.users.map(function(user) {
+                    return addKeyLinkConditional(EscapeHtml(user), "Locked", (node.lusers && node.lusers.indexOf(user) >= 0));
+                }).join(', ');
+                x += addDetailItem((node.users.length > 1 ? "Active Users" : "Active User"), u);
+            }
+
+            if (x != '') { sections.push({ name: "Operating System", html: x, img: 'software' }); }
+
+            if (node.agent) {
+                var x = '';
+                if ((node.agent != null) && (node.agent.id != null) && (node.agent.ver != null)) {
+                    var str = '';
+                    if (node.agent.id <= agentsStr.length) { str = agentsStr[node.agent.id]; } else { str = agentsStr[0]; }
+                    if (node.agent.ver != 0) { str += ' v' + node.agent.ver; }
+                    if (node.agent.id == 14) { str = node.agent.core; }
+                    x += addDetailItem("Mesh Agent", str);
+                }
+                if ((node.conn & 1) != 0) {
+                    x += addDetailItem("Last agent connection", "Connected now");
+                } else {
+                    if (node.lastconnect) { x += addDetailItem("Last agent connection", printDateTime(new Date(node.lastconnect))); }
+                }
+                if (node.lastaddr) {
+                    var splitip = node.lastaddr.split(':');
+                    if (splitip.length > 2) {
+                        x += addDetailItem("Last agent address", node.lastaddr);
+                    } else {
+                        if (isPrivateIP(node.lastaddr)) {
+                            x += addDetailItem("Last agent address", splitip[0]);
+                        } else {
+                            x += addDetailItem("Last agent address", '<a href="https://iplocation.com/?ip=' + splitip[0] + '" rel="noreferrer noopener" target="MeshIPLoopup">' + splitip[0] + '</a>');
+                        }
+                    }
+                }
+                if (hardware.agentvers != null) {
+                    if (hardware.agentvers.compileTime) {
+                        try {
+                            var d = Date.parse(hardware.agentvers.compileTime)
+                            x += addDetailItem("Compile time", printDateTime(new Date(d)));
+                        } catch (ex) { }
+                    }
+                }
+                if (x != '') { sections.push({ name: "Mesh Agent", html: x, img: 'meshagent' }); }
+            }
+
+            if (hardware.mobile) {
+                var x = '';
+                if (hardware.mobile.brand && hardware.mobile.model) { x += addDetailItem("Model", EscapeHtml(hardware.mobile.brand + ', ' + hardware.mobile.model), s); }
+                if (hardware.mobile.device) { x += addDetailItem("Device", EscapeHtml(hardware.mobile.device), s); }
+                if (hardware.mobile.bootloader) { x += addDetailItem("Bootloader", EscapeHtml(hardware.mobile.bootloader), s); }
+                if (hardware.mobile.id) { x += addDetailItem("Identifier", EscapeHtml(hardware.mobile.id), s); }
+                if (hardware.mobile.host) { x += addDetailItem("Hostname", EscapeHtml(hardware.mobile.host), s); }
+                if (hardware.mobile.androidapi && hardware.mobile.androidrelease) { x += addDetailItem("Android Version", EscapeHtml(hardware.mobile.androidrelease + ', API Level ' + hardware.mobile.androidapi), s); }
+                if (x != '') { sections.push({ name: "Mobile Device", html: x, img: 'mobile' }); }
+            }
+
+            if (network.netif2 != null) {
+                var x = '';
+                x += '<table style=width:100%>';
+                for (var i in network.netif2) {
+                    var m = network.netif2[i];
+                    if ((Array.isArray(m) == false) || (m.length < 1) || (m[0] == null) || ((typeof m[0].mac == 'string') && (m[0].mac.startsWith('00:00:00:00')))) continue;
+                    x += '<tr><td><div class=style10 style=border-radius:5px;padding:8px>';
+                    x += '<div style=margin-bottom:3px><b>' + EscapeHtml(i + (m[0].fqdn ? (', ' + m[0].fqdn) : '')) + '</b></div>';
+                    if (m.desc) { x += addDetailItem("Description", EscapeHtml(m.desc).split('(R)').join('&reg;')); }
+                    if (typeof m[0].mac == 'string') {
+                        if (m[0].gatewaymac) {
+                            x += addDetailItem("MAC Layer", format("MAC: {0}, Gateway: {1}", EscapeHtml(m[0].mac), EscapeHtml(m[0].gatewaymac)));
+                        } else {
+                            x += addDetailItem("MAC Layer", format("MAC: {0}", EscapeHtml(m[0].mac)));
+                        }
+                    }
+                    if (typeof m[0].speed == 'number' && (m[0].speed != 9223372036854775807 && m[0].speed > 0)) {
+                        x += addDetailItem("Interface Speed", format("{0}", getNetworkSpeed(m[0].speed)));
+                    }
+                    for (var j = 0; j < m.length; j++) {
+                        var iplayer = m[j], items = [];
+                        if (iplayer.address) { items.push(format("IP: {0}", EscapeHtml(iplayer.address))); }
+                        if (iplayer.netmask) { items.push(format("Mask: {0}", EscapeHtml(iplayer.netmask))); }
+                        if (iplayer.gateway) { items.push(format("Gateway: {0}", EscapeHtml(iplayer.gateway))); }
+                        if (items.length > 0) {
+                            if (iplayer.family == 'IPv4') { x += addDetailItem("IPv4 Layer", items.join(", ")); }
+                            if (iplayer.family == 'IPv6') { x += addDetailItem("IPv6 Layer", items.join(", ")); }
+                        }
+                    }
+                    x += '</div></td></tr>';
+                }
+                if (hardware.network && hardware.network.dns) {
+                    x += '<tr><td><div class=style10 style=border-radius:5px;padding:8px>';
+                    x += addDetailItem('<b>' + "DNS Servers" + '</b>', hardware.network.dns.join(", "));
+                    x += '</div></td></tr>';
+                }
+                x += '</table>';
+                if (x != '') { sections.push({ name: "Networking", html: x, img: 'networking' }); }
+            }
+
+            if (node.intelamt != null) {
+                var x = '';
+                x += addDetailItem("Version", (node.intelamt.ver) ? ('v' + EscapeHtml(node.intelamt.ver)) : ('<i>' + "Unknown" + '</i>'), s);
+                x += addDetailItem("Identifier", (node.intelamt.uuid) ? (EscapeHtml(node.intelamt.uuid)) : ('<i>' + "Unknown" + '</i>'), s);
+                var provisioningStates = { 0: nobreak("Not Activated (Pre)"), 1: nobreak("Not Activated (In)"), 2: nobreak("Activated") };
+                var provisioningMode = '';
+                if ((node.intelamt.state == 2) && node.intelamt.flags) { if (node.intelamt.flags & 2) { provisioningMode = (', ' + "Client Control Mode (CCM)"); } else if (node.intelamt.flags & 4) { provisioningMode = (', ' + "Admin Control Mode (ACM)"); } }
+                x += addDetailItem("Provisioning State", ((node.intelamt.state) ? (provisioningStates[node.intelamt.state]) : ('<i>' + "Unknown" + '</i>')) + provisioningMode, s);
+                x += addDetailItem("Security", (node.intelamt.tls == 1) ? "Secured using TLS" : "TLS is not setup", s);
+                x += addDetailItem("Admin Credentials", ((node.intelamt.user) == null || (node.intelamt.user == '') || ((node.intelamt.warn != null) && ((node.intelamt.warn & 9) != 0))) ? "Not Known" : "Known", s);
+                if (x != '') {
+                    if ((typeof node.intelamt.sku == 'number') && ((node.intelamt.sku & 16) != 0)) {
+                        sections.push({ name: "Intel&reg; Standard Manageability (Intel&reg; SM)", html: x, img: 'amt' });
+                    } else {
+                        sections.push({ name: "Intel&reg; Active Management Technology (Intel&reg; AMT)", html: x, img: 'amt' });
+                    }
+                }
+            }
+
+            if (hardware.identifiers) {
+                var x = '', ident = hardware.identifiers;
+                if (ident.bios_vendor) { x += addDetailItem("Vendor", EscapeHtml(ident.bios_vendor), s); }
+                if (ident.bios_version) { x += addDetailItem("Version", EscapeHtml(ident.bios_version), s); }
+                if (ident.bios_serial) { x += addDetailItem("Serial", EscapeHtml(ident.bios_serial), s); }
+                if (ident.bios_mode) { x += addDetailItem("Mode", EscapeHtml(ident.bios_mode), s); }
+                if (x != '') { sections.push({ name: "BIOS", html: x, img: 'chip' }); }
+
+                x = '';
+                if (ident.board_vendor) { x += addDetailItem("Vendor", EscapeHtml(ident.board_vendor), s); }
+                if (ident.board_name) { x += addDetailItem("Name", EscapeHtml(ident.board_name), s); }
+                if (ident.board_serial && (ident.board_serial != '')) { x += addDetailItem("Serial", EscapeHtml(ident.board_serial), s); }
+                if (ident.board_version) { x += addDetailItem("Version", EscapeHtml(ident.board_version), s); }
+                if (ident.product_uuid) { x += addDetailItem("Identifier", EscapeHtml(ident.product_uuid), s); }
+                if (ident.cpu_name) { x += addDetailItem("CPU", EscapeHtml(ident.cpu_name).split('(TM)').join('&trade;').split('(R)').join('&reg;'), s); }
+                if (ident.gpu_name) { for (var i in ident.gpu_name) { x += addDetailItem("GPU", EscapeHtml(ident.gpu_name[i]).split('(TM)').join('&trade;').split('(R)').join('&reg;'), s); } }
+                if (x != '') { sections.push({ name: "Motherboard", html: x, img: 'motherboard' }); }
+            }
+
+            if (hardware.tpm) {
+                var x = '', tpm = hardware.tpm;
+                if (tpm.SpecVersion) { x += addDetailItem("SpecVersion", parseFloat(EscapeHtml(tpm.SpecVersion)).toFixed(1), s); }
+                if (tpm.ManufacturerId) { x += addDetailItem("ManufacturerId", EscapeHtml(tpm.ManufacturerId), s); }
+                if (tpm.ManufacturerVersion) { x += addDetailItem("ManufacturerVersion", EscapeHtml(tpm.ManufacturerVersion), s); }
+                if (tpm.IsActivated != null) { x += addDetailItem("IsActivated", (tpm.IsActivated ? "Yes" : "No"), s); }
+                if (tpm.IsEnabled != null) { x += addDetailItem("IsEnabled", (tpm.IsEnabled ? "Yes" : "No"), s); }
+                if (tpm.IsOwned != null) { x += addDetailItem("IsOwned", (tpm.IsOwned ? "Yes" : "No"), s); }
+                if (x != '') { sections.push({ name: "TPM", html: x, img: 'tpm'}); }
+            }
+
+            if (hardware.windows) {
+                if (hardware.windows.memory && (hardware.windows.memory.length > 0)) {
+                    var x = '';
+                    hardware.windows.memory.sort(function (a, b) { if (a.BankLabel > b.BankLabel) return 1; if (a.BankLabel < b.BankLabel) return -1; return 0; });
+
+                    x += '<table style=width:100%>';
+                    for (var i in hardware.windows.memory) {
+                        var m = hardware.windows.memory[i];
+                        x += '<tr><td><div class=style10 style=border-radius:5px;padding:8px>';
+                        x += '<div style=margin-bottom:3px><b>' + EscapeHtml((m.BankLabel ? m.BankLabel : (m.DeviceLocator ? m.DeviceLocator : 'Unknown'))) + '</b></div>';
+                        if (m.Capacity && m.Speed) { x += addDetailItem("Capacity / Speed", format("{0} Mb, {1} Mhz", (m.Capacity / 1024 / 1024), m.Speed), s); }
+                        else if (m.Capacity) { x += addDetailItem("Capacity", format("{0} Mb", (m.Capacity / 1024 / 1024)), s); }
+                        if (m.PartNumber) { x += addDetailItem("Part Number", EscapeHtml((m.Manufacturer && m.Manufacturer != 'Undefined') ? (m.Manufacturer + ', ') : '') + EscapeHtml(m.PartNumber), s); }
+                        x += '</div>';
+                    }
+                    x += '</table>';
+
+                    if (x != '') { sections.push({ name: "Memory", html: x, img: 'ram' }); }
+                }
+            }
+
+            if (hardware.linux) {
+                if (hardware.linux.memory && (hardware.linux.memory.Memory_Device.length > 0)) {
+                    var x = '';
+                    hardware.linux.memory.Memory_Device.sort(function(a, b) { if (a.Locator > b.Locator) return 1; if (a.Locator < b.Locator) return -1; return 0; });
+
+                    x += '<table style=width:100%>';
+                    for (var i in hardware.linux.memory.Memory_Device) {
+                        var m = hardware.linux.memory.Memory_Device[i];
+                        if(m.Size && (m.Size == 'No Module Installed')) continue;
+                        x += '<tr><td><div class=style10 style=border-radius:5px;padding:8px>';
+                        x += '<div style=margin-bottom:3px><b>' + EscapeHtml((m.Locator ? m.Locator : 'Unknown')) + '</b></div>';
+                        if (m.Size && m.Speed) { x += addDetailItem("Capacity / Speed", format("{0}, {1}", m.Size, m.Speed), s); }
+                        else if (m.Size) { x += addDetailItem("Capacity", format("{0}", (m.Size)), s); }
+                        if (m.PartNumber) { x += addDetailItem("Part Number", EscapeHtml((m.Manufacturer && m.Manufacturer != 'Undefined')?(m.Manufacturer + ', '):'') + EscapeHtml(m.PartNumber), s); }
+                        x += '</div>';
+                    }
+                    x += '</table>';
+
+                    if (x != '') { sections.push({ name: "Memory", html: x, img: 'ram'}); }
+                }
+            }
+
+            if (hardware.darwin) {
+                if (hardware.darwin.memory && (hardware.darwin.memory.length > 0)) {
+                    var x = '';
+                    x += '<table style=width:100%>';
+                    for (var i in hardware.darwin.memory) {
+                        var m = hardware.darwin.memory[i];
+                        if(m.Size && (m.Size == 'No Module Installed')) continue;
+                        x += '<tr><td><div class=style10 style=border-radius:5px;padding:8px>';
+                        x += '<div style=margin-bottom:3px><b>' + EscapeHtml((m.DeviceLocator ? m.DeviceLocator : 'Unknown')) + '</b></div>';
+                        if (m.Size && m.Speed) { x += addDetailItem("Capacity / Speed", format("{0}, {1}", m.Size, m.Speed), s); }
+                        else if (m.Size) { x += addDetailItem("Capacity", format("{0}", (m.Size)), s); }
+                        if (m.PartNumber) { x += addDetailItem("Part Number", EscapeHtml((m.Manufacturer && m.Manufacturer != '')?(m.Manufacturer + ', '):'') + EscapeHtml(m.PartNumber), s); }
+                        x += '</div>';
+                    }
+                    x += '</table>';
+                    if (x != '') { sections.push({ name: "Memory", html: x, img: 'ram'}); }
+                }
+            }
+
+            if (hardware.identifiers && ident.storage_devices) {
+                var x = '';
+                ident.storage_devices.sort(function (a, b) { if (a.Caption > b.Caption) return 1; if (a.Caption < b.Caption) return -1; return 0; });
+
+                x += '<table style=width:100%>';
+                for (var i in ident.storage_devices) {
+                    var m = ident.storage_devices[i];
+                    if (m.Size) {
+                        x += '<tr><td><div class=style10 style=border-radius:5px;padding:8px>';
+                        x += '<div style=margin-bottom:3px><b>' + EscapeHtml(m.Caption) + '</b></div>';
+                        if (m.Model && (m.Model != m.Caption)) { x += addDetailItem("Model", EscapeHtml(m.Model), s); }
+                        if (m.Size) {
+                            if ((typeof m.Size == 'string') && (parseInt(m.Size) == m.Size)) { m.Size = parseInt(m.Size); }
+                            if (typeof m.Size == 'number') { x += addDetailItem("Capacity", format("{0} Mb", Math.floor(m.Size / 1024 / 1024)), s); }
+                            if (typeof m.Size == 'string') { x += addDetailItem("Capacity", EscapeHtml(m.Size), s); }
+                        }
+                        if(hardware.windows && hardware.windows.drives && m.Model){
+                            const foundObject = hardware.windows.drives.find(obj => obj['Model'] === m.Model);
+                            if(foundObject) x += addDetailItem("Status", EscapeHtml(foundObject.Status), s);
+                        }
+                        x += '</div>';
+                    }
+                }
+                x += '</table>';
+
+                if (x != '') { sections.push({ name: "Storage", html: x, img: 'storage' }); }
+            }
+
+            if (hardware.windows && hardware.windows.volumes) {
+                var x = '';
+                for (var i in hardware.windows.volumes) {
+                    var m = hardware.windows.volumes[i];
+                    x += '<tr><td><div class=style10 style=border-radius:5px;padding:8px>';
+                    x += '<div style=margin-bottom:3px><b>' + i + ':' + (((m.name == null) || (m.name == '')) ? '' : (' - ' + EscapeHtml(m.name))) + '</b></div>';
+                    if (m.size) {
+                        var sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB'];
+                        var j = parseInt(Math.floor(Math.log(Math.abs(m.size)) / Math.log(1024)), 10);
+                        var fsize = (j === 0 ? `${m.size} ${sizes[j]}` : `${(m.size / (1024 ** j)).toFixed(2)} ${sizes[j]}`);
+                        x += addDetailItem("Capacity", EscapeHtml(fsize), s);
+                    }
+                    if (m.sizeremaining) {
+                        var sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB'];
+                        var j = parseInt(Math.floor(Math.log(Math.abs(m.sizeremaining)) / Math.log(1024)), 10);
+                        var fsize = (j === 0 ? `${m.sizeremaining} ${sizes[j]}` : `${(m.sizeremaining / (1024 ** j)).toFixed(2)} ${sizes[j]}`);
+                        x += addDetailItem("Capacity Remaining", EscapeHtml(fsize), s);
+                    }
+                    if (m.type) {
+                        var type = (m.removable == true ? "Removable" : (m.cdrom == true ? "CD-ROM" : ''));
+                        x += addDetailItem("File System", (type != '' ? (type + ' / ') : '') + (m.type == 'Unknown' ? "Unknown" : EscapeHtml(m.type)), s);
+                    }
+
+                    if (m.protectionStatus || m.volumeStatus) {
+                        var bitlockerState = [];
+                        if (m.protectionStatus) bitlockerState.push("Enabled");
+                        if (m.volumeStatus && m.volumeStatus == 'FullyDecrypted') bitlockerState.push("Fully Decrypted");
+                        if (m.volumeStatus && m.volumeStatus == 'EncryptionInProgress') bitlockerState.push("Encryption In Progress");
+                        if (m.volumeStatus && m.volumeStatus == 'FullyEncrypted') bitlockerState.push("Fully Encrypted");
+                        bitlockerState = bitlockerState.join(' - ');
+                        if (m.recoveryPassword) { bitlockerState += addKeyLink('', 'deviceDetailsShowBitlockerInfo(\"' + encodeURIComponentEx(i) + '\",\"' + encodeURIComponentEx(m.identifier) + '\",\"' + encodeURIComponentEx(m.recoveryPassword) + '\")'); }
+                        x += addDetailItem("BitLocker", bitlockerState, s);
+                    }
+                    x += '</div>';
+                }
+                if (x != '') { sections.push({ name: "Storage Volumes", html: '<table style=width:100%>' + x + '</table>', img: 'storage'}); }
+            }
+
+            if (hardware.linux && hardware.linux.volumes) {
+                var x = '';
+                for (var i in hardware.linux.volumes) {
+                    var m = hardware.linux.volumes[i];
+                    if(m.mount_point.startsWith('/var/lib/docker/overlay2')) continue;
+                    x += '<tr><td><div class=style10 style=border-radius:5px;padding:8px>';
+                    x += '<div style=margin-bottom:3px><b>' + m.mount_point + '</b></div>';
+                    if (m.size) {
+                        var sizes = ['KB', 'MB', 'GB', 'TB'];
+                        var j = parseInt(Math.floor(Math.log(Math.abs(m.size)) / Math.log(1024)), 10);
+                        var fsize = (j === 0 ? `${m.size} ${sizes[j]}` : `${(m.size / (1024 ** j)).toFixed(2)} ${sizes[j]}`);
+                        x += addDetailItem("Capacity", EscapeHtml(fsize), s);
+                    }
+                    if (m.available) {
+                        if (Math.abs(m.available) == 0) {
+                            var fsize = `0 KB`;
+                        } else {
+                            var sizes = ['KB', 'MB', 'GB', 'TB'];
+                            var j = parseInt(Math.floor(Math.log(Math.abs(m.available)) / Math.log(1024)), 10);
+                            var fsize = (j === 0 ? `${m.available} ${sizes[j]}` : `${(m.available / (1024 ** j)).toFixed(2)} ${sizes[j]}`);
+                        }
+                        x += addDetailItem("Capacity Remaining", EscapeHtml(fsize), s);
+                    }
+                    if (m.type) {
+                        var type = (m.removable == true ? "Removable" : (m.cdrom == true ? "CD-ROM" : ''));
+                        x += addDetailItem("File System", (type != '' ? (type + ' / ') : '') + (m.type == 'Unknown' ? "Unknown" : EscapeHtml(m.type)), s);
+                    }
+                    x += '</div>';
+                }
+                if (x != '') { sections.push({ name: "Storage Volumes", html: '<table style=width:100%>' + x + '</table>', img: 'storage'}); }
+            }
+
+            if (hardware.darwin && hardware.darwin.volumes) {
+                var x = '';
+                for (var i in hardware.darwin.volumes) {
+                    var m = hardware.darwin.volumes[i];
+                    if(m.mount_point.startsWith('/var/lib/docker/overlay2')) continue;
+                    x += '<tr><td><div class=style10 style=border-radius:5px;padding:8px>';
+                    x += '<div style=margin-bottom:3px><b>' + m.mount_point + '</b></div>';
+                    if (m.size) {
+                        x += addDetailItem("Capacity", EscapeHtml(m.size), s);
+                    }
+                    if (m.available) {
+                        x += addDetailItem("Capacity Remaining", EscapeHtml(m.available), s);
+                    }
+                    if (m.type) {
+                        var type = (m.removable == true ? "Removable" : (m.cdrom == true ? "CD-ROM" : ''));
+                        x += addDetailItem("File System", (type != '' ? (type + ' / ') : '') + (m.type == 'Unknown' ? "Unknown" : EscapeHtml(m.type)), s);
+                    }
+                    x += '</div>';
+                }
+                if (x != '') { sections.push({ name: "Storage Volumes", html: '<table style=width:100%>' + x + '</table>', img: 'storage'}); }
+            }
+
+            var x = '';
+            for (var i in sections) {
+                if (sections[i].img == null) {
+                    x += '<div class=DevSt style=margin-bottom:3px;margin-left:4px><b>' + sections[i].name + '</b></div><div style=margin-bottom:10px;margin-left:4px>' + sections[i].html + '</div>';
+                } else {
+                    x += '<table style=width:100%><tr>';
+                    x += '<td style=width:32px;vertical-align:top><img src=images/details/' + sections[i].img + '32.png srcset="images/details/' + sections[i].img + '64.png 2x" border=0 width=32 /></td>';
+                    x += '<td><div class=DevSt style=margin-bottom:3px;margin-left:4px><b>' + sections[i].name + '</b></div><div style=margin-bottom:10px;margin-left:4px>' + sections[i].html + '</div></td>';
+                    x += '</tr></table>';
+                }
+            }
+
+            if (x == '') {
+                QH('p10detailshtml', "No information for this device.");
+            } else {
+                QH('p10detailshtml', x);
+            }
+        }
+
+        function deviceDetailsShowBitlockerInfo(drive, identifier, password) {
+            if (xxdialogMode) return false;
+            var x = '<div><p>' + "Identifier" + '</p><p style=user-select:text;font-weight:bold>' + (identifier ? decodeURIComponent(identifier) : "Unknown") + '</p>';
+            x += '<p>' + "Recovery Password" + '</p><p style=user-select:text;font-weight:bold>' + (password ? decodeURIComponent(password) : "Unknown") + '</p></div>';
+            setDialogMode(2, decodeURIComponent(drive) + ': ' + "BitLocker Information", 1, null, x, '');
+        }
+
+        function insertTextAtCursor(ctrl, val) {
+            if (document.selection) { ctrl.focus(); sel = document.selection.createRange(); sel.text = val; }
+            else if (ctrl.selectionStart || ctrl.selectionStart == '0') {
+                var start = ctrl.selectionStart, end = ctrl.selectionEnd;
+                ctrl.value = ctrl.value.substring(0, start) + val + ctrl.value.substring(end, ctrl.value.length);
+                ctrl.setSelectionRange(end + 1, end + 1);
+            } else { ctrl.value += myValue; }
+        }
+
+        var consoleNode;
+        var consoleServerText = '';
+        function setupConsole() {
+            var samenode = (consoleNode == currentNode);
+            consoleNode = currentNode;
+
+            var mesh = meshes[consoleNode.meshid];
+            var rights = GetNodeRights(currentNode);
+            if ((rights & 16) != 0) {
+                if (consoleNode.consoleText == null) { consoleNode.consoleText = ''; }
+                if (samenode == false) {
+                    QH('p15agentConsoleText', consoleNode.consoleText);
+                    Q('p15agentConsoleText').scrollTop = Q('p15agentConsoleText').scrollHeight;
+                }
+                var online = (((consoleNode.conn & 1) != 0) || ((consoleNode.conn & 16) != 0)) ? true : false;
+                var onlineText = ((consoleNode.conn & 1) != 0) ? "Agent is online" : "Agent is offline"
+                if ((consoleNode.conn & 16) != 0) { onlineText += ", MQTT is online" }
+                QH('p15statetext', onlineText);
+                QE('p15uploadCore', ((consoleNode.conn & 1) != 0));
+                QV('p15outputselecttd', ((consoleNode.conn & 16) != 0) || ((currentNode.pmt == 1) && ((features2 & 2) != 0)));
+                QV('p15outputselect2', ((consoleNode.conn & 16) != 0));
+                QV('p15outputselect3', ((currentNode.pmt == 1) && ((features2 & 2) != 0)));
+
+                var c = Q('p15outputselect').value;
+                if (((consoleNode.conn & 16) == 0) && (c == 2)) { c = 1; Q('p15outputselect').value = 1; }
+                if (((currentNode.pmt != 1) || ((features2 & 2) == 0)) && (c == 3)) { c = 1; Q('p15outputselect').value = 1; }
+
+                var active = false;
+                if (((consoleNode.conn & 1) != 0) && (c == 1)) { active = true; }
+                if (((consoleNode.conn & 16) != 0) && (c == 2)) { active = true; }
+                if (((currentNode.pmt == 1) && ((features2 & 2) != 0)) && (c == 3)) { active = true; }
+                QE('p15consoleText', active);
+            } else {
+                QH('p15statetext', "Access Denied");
+                QE('p15consoleText', false);
+                QE('p15uploadCore', false);
+                QV('p15outputselecttd', false);
+            }
+            QV('devListToolbarViewIcons3', ((consoleNode.conn & 1) != 0));
+        }
+
+        function p15consoleClear() {
+            QH('p15agentConsoleText', '');
+            Q('id_p15consoleClear').blur();
+            consoleNode.consoleText = '';
+        }
+
+        var consoleHistory = [];
+        function p15consoleSend(e) {
+            if (e && e.keyCode != 13) return;
+            var v = Q('p15consoleText').value, t = '<div style=color:green>&gt; ' + EscapeHtml(v) + '<br/></div>';
+
+            if (((consoleNode.conn & 16) != 0) && (Q('p15outputselect').value == 2)) {
+                t = '<div style=color:orange>' + "MQTT" + '&gt; ' + EscapeHtml(v) + '<br/></div>';
+                consoleNode.consoleText += t;
+                meshserver.send({ action: 'sendmqttmsg', topic: 'console', nodeids: [consoleNode._id], msg: v });
+            } else if ((consoleNode.pmt == 1) && (Q('p15outputselect').value == 3) && ((features2 & 2) != 0)) {
+                t = '<div style=color:violet>' + "PUSH" + '&gt; ' + EscapeHtml(v) + '<br/></div>';
+                consoleNode.consoleText += t;
+                meshserver.send({ action: 'pushconsole', nodeid: consoleNode._id, console: v });
+            } else if ((consoleNode.conn & 1) != 0) {
+                consoleNode.consoleText += t;
+                meshserver.send({ action: 'msg', type: 'console', nodeid: consoleNode._id, value: v });
+            }
+
+            Q('p15agentConsoleText').innerHTML += t;
+            Q('p15agentConsoleText').scrollTop = Q('p15agentConsoleText').scrollHeight;
+            Q('p15consoleText').value = '';
+
+            if (v.length > 0) {
+                var j = consoleHistory.indexOf(v);
+                if (j >= 0) { consoleHistory.splice(j, 1); }
+                consoleHistory.unshift(v);
+                consoleHistory.splice(10);
+            }
+        }
+
+        function p15consoleReceive(node, data, source) {
+            if (node === 'serverconsole') {
+                data = '<div>' + EscapeHtml(data) + '</div>'
+                consoleServerText += data;
+                if (consoleNode == 'server') {
+                    Q('p15agentConsoleText').innerHTML += data;
+                    Q('p15agentConsoleText').scrollTop = Q('p15agentConsoleText').scrollHeight;
+                }
+            } else {
+                if (source == 'MQTT') { data = '<div style=color:red>' + "MQTT" + '&gt; ' + EscapeHtml(data) + '<br/></div>'; } else { data = '<div>' + EscapeHtml(data) + '</div>' }
+                if (node.consoleText == null) { node.consoleText = data; } else { node.consoleText += data; }
+                if (consoleNode == node) {
+                    Q('p15agentConsoleText').innerHTML += data;
+                    Q('p15agentConsoleText').scrollTop = Q('p15agentConsoleText').scrollHeight;
+                }
+            }
+        }
+
+        function p15downloadConsoleText() {
+            saveAs(new Blob([Q('p15agentConsoleText').innerText], { type: 'application/octet-stream' }), "console.txt");
+        }
+
+        function p15uploadCore(e) {
+            if (xxdialogMode) return;
+            if (e.shiftKey == true) { meshserver.send({ action: 'uploadagentcore', nodeid: consoleNode._id, type: 'default' }); }
+            else if (e.altKey == true) { meshserver.send({ action: 'uploadagentcore', nodeid: consoleNode._id, type: 'clear' }); }
+            else if (e.ctrlKey == true) { p15uploadCore2(); }
+            else { 
+                var htmlValue = '<select id=d3coreMode style=width:230px>' +
+                    '<option value=1>' + "Upload default server core" + '</option>' +
+                    '<option value=2>' + "Clear the core" + '</option>' +
+                    '<option value=3>' + "Upload a core file" + '</option>' +
+                    '<option value=4>' + "Soft disconnect agent" + '</option>' +
+                    '<option value=5>' + "Hard disconnect agent" + '</option>' +
+                    '<option value=6>' + "Upload recovery core" + '</option>' +
+                    '<option value=7>' + "Upload tiny core" + '</option>' +
+                    '<option value=8>' + "Restart agent service" + '</option>' +
+                    '<option value=9>' + "Force agent update" + '</option></select>';
+                setDialogMode(2, "Perform Agent Action", 3, p15uploadCoreEx, addHtmlValue("Action", htmlValue));
+            }
+        }
+
+        function p15uploadCoreEx() {
+            if (Q('d3coreMode').value == 1) {
+                meshserver.send({ action: 'uploadagentcore', nodeid: consoleNode._id, type: 'default' });
+            } else if (Q('d3coreMode').value == 2) {
+                meshserver.send({ action: 'uploadagentcore', nodeid: consoleNode._id, type: 'clear' });
+            } else if (Q('d3coreMode').value == 3) {
+                p15uploadCore2();
+            } else if (Q('d3coreMode').value == 4) {
+                meshserver.send({ action: 'agentdisconnect', nodeid: consoleNode._id, disconnectMode: 1 });
+            } else if (Q('d3coreMode').value == 5) {
+                meshserver.send({ action: 'agentdisconnect', nodeid: consoleNode._id, disconnectMode: 2 });
+            } else if (Q('d3coreMode').value == 6) {
+                meshserver.send({ action: 'uploadagentcore', nodeid: consoleNode._id, type: 'recovery' });
+            } else if (Q('d3coreMode').value == 7) {
+                meshserver.send({ action: 'uploadagentcore', nodeid: consoleNode._id, type: 'tiny' });
+            } else if (Q('d3coreMode').value == 8) {
+                meshserver.send({ action: 'msg', type: 'console', nodeid: consoleNode._id, value:'service restart' });
+            } else if (Q('d3coreMode').value == 9) {
+                meshserver.send({ action: 'updateAgents', nodeids: [consoleNode._id] });
+            }
+        }
+
+        function p15uploadCore2() {
+            if (xxdialogMode) return;
+            Q('d3localmodeform').action = 'uploadmeshcorefile.ashx';
+            Q('d3auth').value = authCookie;
+            Q('d3attrib').value = currentNode._id;
+            setDialogMode(4, "Upload Mesh Agent Core", 3, p15uploadCoreEx2);
+            d3init();
+        }
+
+        function p15uploadCoreEx2() {
+            var mode = Q('d3uploadMode').value;
+            if (mode == 1) {
+                Q('d3submit').click();
+            } else {
+                var files = d3getFileSel();
+                if (files.length == 1) { meshserver.send({ action: 'uploadagentcore', nodeid: consoleNode._id, type: 'custom', path: d3filetreelocation.join('/') + '/' + files[0] }); }
+            }
+        }
+
+        var currentMesh;
+        function p20updateMesh() {
+            if (currentMesh == null) return;
+            QH('p20meshName', EscapeHtml(currentMesh.name));
+            var meshtype = format("Unknown #{0}", currentMesh.mtype);
+            var meshrights = GetMeshRights(currentMesh);
+            if (currentMesh.mtype == 1) meshtype = "Intel&reg; AMT only, no agent";
+            if (currentMesh.mtype == 2) meshtype = "Managed using a software agent";
+            if (currentMesh.mtype == 3) { if (currentMesh.relayid == null) { meshtype = "Local devices, no agent"; } else { meshtype = "No agent devices relayed thru agent"; } }
+            if (currentMesh.mtype == 4) { if (currentMesh.relayid == null) { meshtype = "IP-KVM device"; } else { meshtype = "IP-KVM device relayed thru agent"; } if (currentMesh.kvm.model == 1) { meshtype += ', ' + 'Raritan KX III'; } }
+
+            var x = '';
+            x += addHtmlValue("Name", addLinkConditional(EscapeHtml(currentMesh.name), 'p20editmesh(1)', (meshrights & 1) != 0));
+            x += addHtmlValue("Description", addLinkConditional(((currentMesh.desc && currentMesh.desc != '') ? EscapeHtml(currentMesh.desc) : ('<i>' + "None" + '</i>')), 'p20editmesh(2)', (meshrights & 1) != 0));
+            x += addHtmlValue("Type", meshtype);
+
+            if (((currentMesh.mtype == 3) || (currentMesh.mtype == 4)) && (currentMesh.relayid != null)) {
+                var relayName = '<i>' + "Unknown" + '</i>';
+                var relayNode = getNodeFromId(currentMesh.relayid);
+                if (relayNode != null) { relayName = EscapeHtml(relayNode.name); }
+                x += addHtmlValue("Relay Device", addLinkConditional(relayName, 'p20editmeshrelay()', (meshrights & 1) != 0));
+            }
+
+            if (currentMesh.mtype == 4) {
+                x += addHtmlValue("Hostname", currentMesh.kvm.host);
+                x += addHtmlValue("Username", currentMesh.kvm.user);
+            }
+
+            x += '<br><input type=button value="' + "Notes" + '" onclick=showNotes(false,"' + encodeURIComponent(currentMesh._id) + '") />';
+
+            x += '<br style=clear:both><br>';
+            var currentMeshLinks = currentMesh.links[userinfo._id];
+            if (currentMeshLinks && ((currentMeshLinks.rights & 2) != 0)) { x += '<button type=button onclick=p20showAddMeshUserDialog() class="p20-add-user-button"><i class="fa fa-plus"></i> ' + "Add User" + '</button>'; }
+
+            if (navigator.userAgent.toLowerCase().indexOf('android') >= 0) {
+                x += '<div style=margin-bottom:6px;float:left;margin-right:10px><a onclick=p20installAndroidDialog() style=cursor:pointer><img src=images/icon-addnew.png border=0 height=12 width=12> ' + "Install on this device" + '</a></div>';
+            }
+
+            x += '<table style="color:black;background-color:#EEE;border-color:#AAA;border-width:1px;border-style:solid;border-collapse:collapse" border=0 cellpadding=2 cellspacing=0 width=100%><tbody><tr style=background-color:#AAAAAA;font-weight:bold><th scope=col style=text-align:left;width:430px>' + "User Authorizations" + '</th></tr>';
+
+            var count = 1, sortedusers = [];
+            for (var i in currentMesh.links) {
+                var uname = i.split('/')[2];
+                if (currentMesh.links[i].name) { uname = currentMesh.links[i].name; }
+                if (i == userinfo._id) { uname = userinfo.name; }
+                if ((usergroups != null) && (usergroups[i] != null)) { uname = usergroups[i].name; }
+                sortedusers.push({ id: i, name: uname, rights: currentMesh.links[i].rights });
+            }
+            sortedusers.sort(function (a, b) { if (a.name > b.name) return 1; if (a.name < b.name) return -1; return 0; });
+
+            for (var i in sortedusers) {
+                var trash = '', rights = "Partial Rights", r = sortedusers[i].rights, icon = 2;
+                if (r == 0xFFFFFFFF) rights = "Full Administrator"; else if (r == 0) rights = "No Rights";
+                if ((i != userinfo._id) && (meshrights == 0xFFFFFFFF || (((meshrights & 2) != 0)))) { trash = '<a onclick=p20deleteUser(event,"' + encodeURIComponent(sortedusers[i].id) + '") style=cursor:pointer><img src=images/trash.png border=0 height=10 width=10></a>'; }
+                if (sortedusers[i].id.startsWith('ugrp/')) { icon = 4; }
+                x += '<tr onclick=p20viewuser("' + encodeURIComponent(sortedusers[i].id) + '") style=height:32px;cursor:pointer' + (((count % 2) == 0) ? ';background-color:#DDD' : '') + '><td>';
+                x += '<div style=float:right>' + trash + '</div><div style=float:right;padding-right:4px>' + rights + '</div><div class=m' + icon + '></div><div>&nbsp;' + EscapeHtml(decodeURIComponent(sortedusers[i].name)) + '<div></div></div>';
+                x += '</td></tr>';
+                ++count;
+            }
+
+            x += '</tbody></table>';
+
+            if (meshrights == 0xFFFFFFFF) { x += '<div style=font-size:small;text-align:right;margin-top:12px><button type=button onclick=p20showDeleteMeshDialog() class="p20-delete-group-button">' + "Delete Group" + '</button></div>'; }
+
+            QH('p20info', x);
+        }
+
+        function p20showDeleteMeshDialog() {
+            if (xxdialogMode) return false;
+            var x = format("Are you sure you want to delete group {0}? Deleting the device group will also delete all information about devices within this group.", EscapeHtml(currentMesh.name)) + '<br /><br />';
+            x += '<label><input id=p20check type=checkbox onchange=p20validateDeleteMeshDialog() />' + "Confirm" + '</label>';
+            setDialogMode(2, "Delete Group", 3, p20showDeleteMeshDialogEx, x);
+            p20validateDeleteMeshDialog();
+            return false;
+        }
+
+        function p20validateDeleteMeshDialog() {
+            QE('idx_dlgOkButton', Q('p20check').checked);
+        }
+
+        function p20showDeleteMeshDialogEx(buttons, tag) {
+            meshserver.send({ action: 'deletemesh', meshid: currentMesh._id, meshname: currentMesh.name });
+        }
+
+        function p20editmeshrelay() {
+            if (xxdialogMode) return;
+
+            var relayDevices = [];
+            if ((features & 2) == 0) { for (var i in nodes) { var node = nodes[i]; if ((node.mtype == 2) && (node.agent != null) && (GetNodeRights(node) == 0xFFFFFFFF)) { relayDevices.push(node); } } }
+            relayDevices.sort(nameSort);
+
+            if (relayDevices.length == 0) {
+                setDialogMode(2, "Edit Device Group", 1, null, "No relay devices available.");
+            } else {
+                var relayDevices2 = [];
+                for (var i in relayDevices) { relayDevices2.push('<option value="' + (relayDevices[i]._id + '"' + ((currentMesh.relayid == relayDevices[i]._id) ? ' selected' : '')) + '>' + EscapeHtml(relayDevices[i].name) + '</option>'); }
+                var x = addHtmlValue("Relay Device", '<div style=width:170px><select id=d2devrelay style=width:100%>' + relayDevices2.join('') + '</select></div>');
+                setDialogMode(2, "Edit Device Group", 3, p20editmeshrelayEx, x);
+            }
+        }
+
+        function p20editmeshrelayEx() {
+            meshserver.send({ action: 'editmesh', meshid: currentMesh._id, relayid: Q('d2devrelay').value });
+        }
+
+        function p20editmesh(focus) {
+            if (xxdialogMode) return;
+            var x = addHtmlValue("Name", '<input id=dp20meshname style=width:170px maxlength=32 onchange=p20editmeshValidate() onkeyup=p20editmeshValidate() />');
+            x += addHtmlValue("Description", '<input id=dp20meshdesc style=width:170px maxlength=1024 onkeyup=p20editmeshValidate() />');
+            setDialogMode(2, "Edit Device Group", 3, p20editmeshEx, x);
+            Q('dp20meshname').value = currentMesh.name;
+            if (currentMesh.desc) Q('dp20meshdesc').value = currentMesh.desc;
+            p20editmeshValidate();
+            if (focus == 2) { Q('dp20meshdesc').focus(); } else { Q('dp20meshname').focus(); }
+        }
+
+        function p20editmeshEx() {
+            meshserver.send({ action: 'editmesh', meshid: currentMesh._id, meshname: Q('dp20meshname').value, desc: Q('dp20meshdesc').value });
+        }
+
+        function p20editmeshValidate() {
+            QE('idx_dlgOkButton', Q('dp20meshname').value.length > 0);
+        }
+
+        function p20installAndroidDialog() {
+            if (xxdialogMode) return;
+            var x = '<div style=text-align:center><p>' + "Install the MeshCentral Agent on your Android device. Once installed, click the pairing link to connect your device to this server." + '</p>';
+            x += '<p><a rel=\"noreferrer noopener\" target=_blank href=\"https://play.google.com/store/apps/details?id=com.meshcentral.agent2\"><img style=cursor:pointer src=\"images/google-play-140.png\" width=140 srcset=\"images/google-play-280.png 2x\" /></a></p>';
+            x += '<p><a rel=\"noreferrer noopener\" target=_blank href=\"https://www.amazon.co.uk/gp/product/B097Z4Q7SK/\"><img style=cursor:pointer src=\"images/amazon-appstore-140.png\"  width=140 srcset=\"images/amazon-appstore-280.png 2x\" /></a></p>';
+            x += '<p><a rel=\"noreferrer noopener\" target=_blank href="meshagents?id=14' + (urlargs.key?('&key=' + urlargs.key):'') + '" title="' + "APK version of the MeshAgent" + '">' + "Android APK" + '</a></p>';
+            x += '<p><a href="' + serverinfo.magenturl + ',' + serverinfo.agentCertHash + ',' + currentMesh._id.split('/')[2] + '"><b>' + "Device Pairing Link" + '</b></a></p></div>';
+            setDialogMode(2, "Android Installation", 1, null, x);
+        }
+
+        function p20showAddMeshUserDialog() {
+            if (xxdialogMode) return;
+            var x = addHtmlValue('User ID', '<input id=dp20username style=width:170px maxlength=256 onchange=p20validateAddMeshUserDialog() onkeyup=p20validateAddMeshUserDialog() />');
+            x += '<div style="border:2px groove gray;background-color:white;max-height:120px;overflow-y:scroll">';
+            x += '<label><input type=checkbox onchange=p20validateAddMeshUserDialog() id=p20fulladmin>' + "Full Administrator" + '</label><br>';
+            x += '<label><input type=checkbox onchange=p20validateAddMeshUserDialog() id=p20editmesh>' + "Edit Device Group" + '</label><br>';
+            x += '<label><input type=checkbox onchange=p20validateAddMeshUserDialog() id=p20manageusers>' + "Manage Device Group Users" + '</label><br>';
+            x += '<label><input type=checkbox onchange=p20validateAddMeshUserDialog() id=p20managecomputers>' + "Manage Device Group Computers" + '</label><br>';
+            x += '<label><input type=checkbox onchange=p20validateAddMeshUserDialog() id=p20remotecontrol>' + "Remote Control" + '</label><br>';
+            x += '<label><input type=checkbox onchange=p20validateAddMeshUserDialog() id=p20remoteview style=margin-left:12px>' + "Remote View Only" + '</label><br>';
+            x += '<label><input type=checkbox onchange=p20validateAddMeshUserDialog() id=p20remotelimitedinput style=margin-left:12px>' + "Limited Input Only" + '</label><br>';
+            x += '<label><input type=checkbox onchange=p20validateAddMeshUserDialog() id=p20noterminal style=margin-left:12px>' + "No Terminal Access" + '</label><br>';
+            x += '<label><input type=checkbox onchange=p20validateAddMeshUserDialog() id=p20nofiles style=margin-left:12px>' + "No File Access" + '</label><br>';
+            x += '<label><input type=checkbox onchange=p20validateAddMeshUserDialog() id=p20noamt style=margin-left:12px>' + "No Intel&reg; AMT" + '</label><br>';
+            x += '<label><input type=checkbox onchange=p20validateAddMeshUserDialog() id=p20meshagentconsole>' + "Mesh Agent Console" + '</label><br>';
+            x += '<label><input type=checkbox onchange=p20validateAddMeshUserDialog() id=p20meshserverfiles>' + "Server Files" + '</label><br>';
+            x += '<label><input type=checkbox onchange=p20validateAddMeshUserDialog() id=p20wakedevices>' + "Wake Devices" + '</label><br>';
+            x += '<label><input type=checkbox onchange=p20validateAddMeshUserDialog() id=p20editnotes>' + "Edit Device Notes" + '</label><br>';
+            x += '<label><input type=checkbox onchange=p20validateAddMeshUserDialog() id=p20limitevents>' + "Show Only Own Events" + '</label><br>';
+            x += '<label><input type=checkbox onchange=p20validateAddMeshUserDialog() id=p20chatnotify>' + "Chat & Notify" + '</label><br>';
+            x += '<label><input type=checkbox onchange=p20validateAddMeshUserDialog() id=p20uninstall>' + "Uninstall Agent" + '</label><br>';
+            x += '<label><input type=checkbox onchange=p20validateAddMeshUserDialog() id=p20commands>' + "Remote Commands" + '</label><br>';
+            x += '<label><input type=checkbox onchange=p20validateAddMeshUserDialog() id=p20resetoff>' + "Reset / Power Off" + '</label><br>';
+            x += '</div>';
+            setDialogMode(2, "Add User to Device Group", 3, p20showAddMeshUserDialogEx, x);
+            p20validateAddMeshUserDialog();
+            Q('dp20username').focus();
+        }
+
+        function p20validateAddMeshUserDialog() {
+            var meshrights = GetMeshRights(currentMesh);
+            var nc = !Q('p20fulladmin').checked;
+            QE('p20fulladmin', meshrights == 0xFFFFFFFF);
+            QE('p20editmesh', nc && (meshrights == 0xFFFFFFFF));
+            QE('p20manageusers', nc);
+            QE('p20managecomputers', nc);
+            QE('p20remotecontrol', nc);
+            QE('p20meshagentconsole', nc);
+            QE('p20meshserverfiles', nc);
+            QE('p20wakedevices', nc);
+            QE('p20editnotes', nc);
+            QE('p20limitevents', nc);
+            QE('p20remoteview', nc && Q('p20remotecontrol').checked);
+            QE('p20remotelimitedinput', nc && Q('p20remotecontrol').checked && !Q('p20remoteview').checked);
+            QE('p20noterminal', nc && Q('p20remotecontrol').checked);
+            QE('p20nofiles', nc && Q('p20remotecontrol').checked);
+            QE('p20noamt', nc && Q('p20remotecontrol').checked);
+            QE('p20chatnotify', nc);
+            QE('p20uninstall', nc);
+            QE('p20commands', nc);
+            QE('p20resetoff', nc);
+        }
+
+        function p20showAddMeshUserDialogEx() {
+            var meshadmin = 0;
+            if (Q('p20fulladmin').checked == true) { meshadmin = 0xFFFFFFFF; } else {
+                if (Q('p20editmesh').checked == true) meshadmin += 1;
+                if (Q('p20manageusers').checked == true) meshadmin += 2;
+                if (Q('p20managecomputers').checked == true) meshadmin += 4;
+                if (Q('p20remotecontrol').checked == true) meshadmin += 8;
+                if (Q('p20meshagentconsole').checked == true) meshadmin += 16;
+                if (Q('p20meshserverfiles').checked == true) meshadmin += 32;
+                if (Q('p20wakedevices').checked == true) meshadmin += 64;
+                if (Q('p20editnotes').checked == true) meshadmin += 128;
+                if (Q('p20remoteview').checked == true) meshadmin += 256;
+                if (Q('p20noterminal').checked == true) meshadmin += 512;
+                if (Q('p20nofiles').checked == true) meshadmin += 1024;
+                if (Q('p20noamt').checked == true) meshadmin += 2048;
+                if (Q('p20remotelimitedinput').checked == true) meshadmin += 4096;
+                if (Q('p20limitevents').checked == true) meshadmin += 8192;
+                if (Q('p20chatnotify').checked == true) meshadmin += 16384;
+                if (Q('p20uninstall').checked == true) meshadmin += 32768;
+                if (Q('p20commands').checked == true) meshadmin += 131072;
+                if (Q('p20resetoff').checked == true) meshadmin += 262144;
+            }
+            var users = Q('dp20username').value.split(','), users2 = [];
+            for (var i in users) { users2.push(users[i].trim()); }
+            meshserver.send({ action: 'addmeshuser', meshid: currentMesh._id, meshname: currentMesh.name, usernames: users2, meshadmin: meshadmin });
+        }
+
+        function p20viewuser(userid) {
+            if (xxdialogMode) return;
+            userid = decodeURIComponent(userid);
+            var r = [], cmeshrights = GetMeshRights(currentMesh), meshrights = GetMeshRights(currentMesh, userid);
+            if (meshrights == 0xFFFFFFFF) r.push("Full Administrator"); else {
+                if ((meshrights & 1) != 0) r.push("Edit Device Group");
+                if ((meshrights & 2) != 0) r.push("Manage Device Group Users");
+                if ((meshrights & 4) != 0) r.push("Manage Device Group Computers");
+                if ((meshrights & 8) != 0) r.push("Remote Control");
+                if ((meshrights & 16) != 0) r.push("Agent Console");
+                if ((meshrights & 32) != 0) r.push("Server Files");
+                if ((meshrights & 64) != 0) r.push("Wake Devices");
+                if ((meshrights & 128) != 0) r.push("Edit Notes");
+                if ((meshrights & 256) != 0) r.push("Remote View Only");
+                if ((meshrights & 512) != 0) r.push("No Terminal");
+                if ((meshrights & 1024) != 0) r.push("No Files");
+                if ((meshrights & 2048) != 0) r.push("No Intel&reg; AMT");
+                if (((meshrights & 8) != 0) && ((meshrights & 4096) != 0) && ((meshrights & 256) == 0)) r.push("Limited Input");
+                if ((meshrights & 8192) != 0) r.push("Self Events Only");
+                if ((meshrights & 16384) != 0) r.push("Chat & Notify");
+                if ((meshrights & 32768) != 0) r.push("Uninstall");
+                if ((meshrights & 131072) != 0) r.push("Commands");
+                if ((meshrights & 262144) != 0) r.push("Reset/Off");
+            }
+            if (r.length == 0) { r.push("No Rights"); }
+            var buttons = 1, uname = userid.split('/')[2];
+            if (currentMesh.links[userid].name) { uname = currentMesh.links[userid].name; }
+            var x = addHtmlValue("User Name", EscapeHtml(uname));
+            if (uname != userid.split('/')[2]) { x += addHtmlValue("User ID", EscapeHtml(userid.split('/')[2])); }
+            x += addHtmlValue("Permissions", r.join(", "));
+            if (((userinfo._id) != userid) && (cmeshrights == 0xFFFFFFFF || (((cmeshrights & 2) != 0) && (meshrights != 0xFFFFFFFF)))) buttons += 4;
+            setDialogMode(2, "Device Group User", buttons, p20viewuserEx, x, userid);
+        }
+
+        function p20viewuserEx(button, userid) {
+            if (button != 2) return;
+            var uname = userid.split('/')[2];
+            if (users && users[userid]) { uname = users[userid].name; }
+            if (usergroups && usergroups[userid]) { uname = usergroups[userid].name; }
+            if (userinfo._id == userid) { uname = userinfo.name; }
+            setDialogMode(2, "Remote Mesh User", 3, p20viewuserEx2, format("Confirm removal of user {0}?", uname), userid);
+        }
+        function p20deleteUser(e, userid) { haltEvent(e); p20viewuserEx(2, decodeURIComponent(userid)); }
+        function p20viewuserEx2(button, userid) { meshserver.send({ action: 'removemeshuser', meshid: currentMesh._id, meshname: currentMesh.name, userid: userid }); }
+
+        var notifications = [];
+
+        function clickNotificationIcon(show) {
+            if (show == true) { QV('notifiyBox', true); } else if (show == false) { QV('notifiyBox', false); } else { QV('notifiyBox', QS('notifiyBox')['display'] == 'none'); }
+            drawNotifications();
+        }
+
+        function setNotificationCount(c) {
+            if (parseInt(Q('notificationCount').innerHTML) == c) return;
+            QH('notificationCount2', c);
+            QV('notificationCount', c > 0);
+        }
+
+        function drawNotifications() {
+            var notifySettings = getstore('notifications', 0);
+            var r = '';
+            if (notifications.length == 0) {
+                r = '<div style=margin:5px>' + "There are currently no notifications" + '</div>';
+            } else {
+                for (var i in notifications) {
+                    var n = notifications[i], t = '', d = new Date(n.time), icon = 0;
+                    if (n.title != null) { t = '<b>' + EscapeHtml(n.title) + '</b>: ' }
+                    if (n.nodeid != null) {
+                        var node = getNodeFromId(n.nodeid);
+                        if (node != null) {
+                            icon = node.icon;
+                            if (notifySettings & 16) { t = '<b>' + EscapeHtml(meshes[node.meshid].name) + ' / ' + EscapeHtml(node.name) + '</b>: '; } else { t = '<b>' + EscapeHtml(node.name) + '</b>: '; }
+                        }
+                    }
+
+                    r += '<div title="' + format("Occured at {0}", printDateTime(d)) + '" id="notifyx' + n.id + '" class=notification style="cursor:pointer;border-top:1px solid ' + ((r == '') ? 'transparent' : 'orange') + '">';
+                    if (icon) { r += '<div class=j' + icon + ' onclick="notificationSelected(' + n.id + ')" style=margin:5px;float:left></div>'; }
+                    r += '<div onclick="notificationDelete(' + n.id + ')" class=unselectable title="' + "Clear this notification" + '" style=margin:5px;float:right;color:orange><b>X</b></div><div onclick="notificationSelected(' + n.id + ')" style=margin:5px>' + t + EscapeHtml(n.text) + '</div><div style=margin-left:5px;margin-bottom:5px;color:gray;font-size:10px>' + printDateTime(d) + '</div></div>';
+                }
+            }
+            var deleteall = '';
+            if (notifications.length > 1) { deleteall = '<div id="notifyRemoveAll" onclick="deleteAllNotifications()" style="cursor:pointer;border-top:1px solid orange;margin:5px;color:orange;text-align:right;padding-right:3px">' + "Clear all" + '</div>'; }
+            QH('notifiyBox', '<div class=customScroll style="max-height:170px;overflow-y:auto;margin:5px">' + r + deleteall + '</div>');
+        }
+
+        function notificationSelected(id, del) {
+            var j = -1;
+            for (var i in notifications) { if (notifications[i].id == id) { j = i; } }
+            if (j != -1) {
+                notificationSelectedEx(notifications[j], id);
+                if (del && notifications[j]) {
+                    if (notifications[j].notification) { notifications[j].notification.close(); delete notifications[j].notification; }
+                    notificationDelete(id);
+                }
+            }
+        }
+
+        function notificationSelectedEx(n, id) {
+            if (n.nodeid != null) {
+                if (n.tag == 'desktop') gotoDevice(n.nodeid, 12);
+                else if (n.tag == 'terminal') gotoDevice(n.nodeid, 11);
+                else if (n.tag == 'files') gotoDevice(n.nodeid, 13);
+                else if (n.tag == 'intelamt') gotoDevice(n.nodeid, 14);
+                else if (n.tag == 'console') gotoDevice(n.nodeid, 15); 
+                else gotoDevice(n.nodeid, 10);
+            } else {
+                if ((n.tag == 'backupcodes') && !xxdialogMode) { account_manageOtp(0); notificationDelete(id); }
+                else if ((n.tag != null) && n.tag.startsWith('meshmessenger/')) {
+                    safeNewWindow('/messenger?id=' + n.tag + '&title=' + encodeURIComponentEx(n.username), n.tag.split('/')[2]);
+                    notificationDelete(id);
+                } else if (n.url != null) {
+                    safeNewWindow(n.url);
+                    notificationDelete(id);
+                }
+            }
+        }
+
+        function notificationDelete(id) {
+            var j = -1, e = Q('notifyx' + id);
+            if (e != null) {
+                for (var i in notifications) { if (notifications[i].id == id) { j = i; } }
+                if (j != -1) {
+                    meshserver.send({ action: 'intersession', subaction: 'removeNotify', id: id });
+                    if (notifications[j].notification) { notifications[j].notification.close(); delete notifications[j].notification; }
+                    notifications.splice(j, 1);
+                    e.parentNode.removeChild(e);
+                    setNotificationCount(notifications.length);
+                    if (notifications.length == 0) { QV('notifiyBox', false); }
+                    if (notifications.length == 1) { QV('notifyRemoveAll', false); }
+                    if ((notifications.length > 0) && (j == 0)) {
+                        var n = notifications[0];
+                        QS('notifyx' + n.id)['border-top'] = '1px solid transparent';
+                    }
+                }
+            }
+        }
+
+        function addNotification(n) {
+            var translatedTitles = [
+                null,
+                "New Account",
+                "Server Limit",
+                "Security Warning",
+                "Account Settings",
+                "Device Group",
+                "Invite Codes"
+            ];
+            var translatedMessages = [
+                null,
+                "Permission denied",
+                "Invalid username",
+                "Invalid password",
+                "Invalid email",
+                "Invalid domain",
+                "Invalid site permissions",
+                "User already exists",
+                "Unable to add user in this mode",
+                "Validation exception",
+                "Account limit reached.",
+                "Chat Request, Click here to accept.",
+                "There has been {0} failed login attempts on this account since the last login.",
+                "Failed to change email address, another account already using: {0}.",
+                "Email sent.",
+                "User {0} not found.",
+                "Users {0} not found.",
+                "Error, unable to change to previously used password.",
+                "Error, unable to change to commonly used password.",
+                "Error, password not changed.",
+                "Password changed.",
+                "Current password not correct.",
+                "Error, invite code \"{0}\" already in use.",
+                "SMS gateway not enabled",
+                "No user management rights",
+                "Invalid SMS message",
+                "No phone number for this user",
+                "SMS succesfuly sent.",
+                "SMS error",
+                "SMS error: {0}",
+                "Email domain \"{0}\" is not allowed. Only ({1}) are allowed"
+            ];
+            if (typeof n.titleid == 'number') { try { n.title = translatedTitles[n.titleid]; } catch (ex) { } }
+            if (typeof n.msgid == 'number') { try { n.text = translatedMessages[n.msgid]; if (Array.isArray(n.args)) { n.text = format(n.text, n.args[0], n.args[1], n.args[2], n.args[3], n.args[4], n.args[5]); } } catch (ex) { } }
+
+            if (n.time == null) { n.time = Date.now(); }
+            if (n.id == null) { n.id = Math.random(); }
+            notifications.unshift(n);
+            setNotificationCount(notifications.length);
+            clickNotificationIcon(true);
+            var notifySettings = getstore('notifications', 0);
+            if (notifySettings & 1) { Q('chimes').play(); }
+
+            var notification = null;
+            if (Notification && (Notification.permission == 'granted')) {
+                var text = n.text.split('&reg;').join('').split('<b>').join('').split('</b>').join('').split('<br />').join('\r\n');
+                if (n.nodeid) {
+                    var node = getNodeFromId(n.nodeid);
+                    if (node) {
+                        if (notifySettings & 16) {
+                            notification = new Notification(decodeURIComponent('{{{extitle}}}') + ' - ' + meshes[node.meshid].name + ' - ' + node.name, { tag: n.tag, body: text, icon: '/images/notify/icons128-' + node.icon + '.png' });
+                        } else {
+                            notification = new Notification(decodeURIComponent('{{{extitle}}}') + ' - ' + node.name, { tag: n.tag, body: text, icon: '/images/notify/icons128-' + node.icon + '.png' });
+                        }
+                    }
+                } else {
+                    if (n.icon == null) { n.icon = 0; }
+                    var title = n.title;
+                    if (title == null) { title = ''; } else { title = ' - ' + n.title; }
+                    notification = new Notification(decodeURIComponent('{{{extitle}}}') + title, { tag: n.tag, body: text, icon: '/images/notify/icons128-' + n.icon + '.png' });
+                }
+                notification.id = n.id;
+                notification.xtag = n.tag;
+                notification.url = n.url;
+                notification.nodeid = n.nodeid;
+                notification.username = n.username;
+                notification.onclick = function (e) { notificationSelected(e.target.id, true); }
+                n.notification = notification;
+            }
+
+            if ((typeof n.maxtime == 'number') && (n.maxtime > 0)) { var trigger = function notifyRemoveTrigger() { notificationDelete(notifyRemoveTrigger.xid); }; trigger.xid = n.id; setTimeout(trigger, n.maxtime * 1000); }
+        }
+
+        function deleteAllNotifications() {
+            notifications = [];
+            setNotificationCount(0);
+            drawNotifications();
+            QV('notifiyBox', false);
+        }
+
+        var xxcurrentView = -1;
+        function go(x) {
+            setSessionActivity();
+            if (xxdialogMode || xxcurrentView == x) return;
+            setDialogMode(0);
+            for (var i = 0; i < 32; i++) { QV('p' + i, i == x); }
+            xxcurrentView = x;
+            updateFooterMenu(null, x);
+            updateCurrentUrl();
+        }
+
+        function updateCurrentUrl() {
+            if (((features & 0x10000000) == 0) && (xxcurrentView > 0)) {
+                var urlviewmode = '';
+                if ((xxcurrentView >= 10) && (xxcurrentView <= 19)) {
+                    if (currentNode != null) { urlviewmode = '?viewmode=' + xxcurrentView + '&gotonode=' + currentNode._id.split('/')[2] + ((currentDevicePanel > 0)?('&panel=' + currentDevicePanel):''); }
+                } else if ((xxcurrentView >= 20) && (xxcurrentView <= 29)) {
+                    if (currentMesh != null) { urlviewmode = '?viewmode=' + xxcurrentView + '&gotomesh=' + currentMesh._id.split('/')[2]; }
+                } else if (xxcurrentView > 1) { urlviewmode = '?viewmode=' + xxcurrentView; }
+                for (var i in urlargs) { urlviewmode += (((urlviewmode == '') ? '?' : '&') + i + '=' + urlargs[i]); }
+                try { window.history.replaceState({}, document.title, window.location.pathname + urlviewmode); } catch (ex) { }
+            }
+        }
+
+        var xxdialogMode;
+        var xxdialogFunc;
+        var xxdialogButtons;
+        var xxdialogTag;
+
+        function setDialogMode(x, y, b, f, c, tag) {
+            setSessionActivity();
+            xxdialogMode = x;
+            xxdialogFunc = f;
+            xxdialogButtons = b;
+            xxdialogTag = tag;
+            QE('idx_dlgOkButton', true);
+            QV('idx_dlgOkButton', b & 1);
+            QV('idx_dlgCancelButton', b & 2);
+            QV('id_dialogclose', (b & 2) || (b & 8));
+            QV('idx_dlgDeleteButton', b & 4);
+            QV('idx_dlgButtonBar', b & 7);
+            if (y) QH('id_dialogtitle', y);
+            for (var i = 1; i < 24; i++) { QV('dialog' + i, i == x); }
+            QV('dialog', x);
+            if (c) { if (x == 2) { QH('id_dialogOptions', c); } else { QH('id_dialogMessage', c); } }
+        }
+
+        function dialogclose(x) {
+            setSessionActivity();
+            var f = xxdialogFunc;
+            var b = xxdialogButtons;
+            var t = xxdialogTag;
+            setDialogMode();
+            if (((b & 8) || x) && f) f(x, t);
+        }
+
+        function removeUserRights(rights, userid) {
+            if ((userid != userinfo._id) || (userinfo.removeRights == null)) return rights;
+            var add = 0, substract = 0;
+            if ((userinfo.removeRights & 0x00000008) != 0) { substract += 0x00000008; }
+            if ((userinfo.removeRights & 0x00010000) != 0) { add += 0x00010000; }
+            if ((userinfo.removeRights & 0x00000100) != 0) { add += 0x00000100; }
+            if ((userinfo.removeRights & 0x00000200) != 0) { add += 0x00000200; }
+            if ((userinfo.removeRights & 0x00000400) != 0) { add += 0x00000400; }
+            if ((userinfo.removeRights & 0x00000010) != 0) { substract += 0x00000010; }
+            if ((userinfo.removeRights & 0x00008000) != 0) { substract += 0x00008000; }
+            if ((userinfo.removeRights & 0x00020000) != 0) { substract += 0x00020000; }
+            if ((userinfo.removeRights & 0x00000040) != 0) { substract += 0x00000040; }
+            if ((userinfo.removeRights & 0x00040000) != 0) { substract += 0x00040000; }
+            if (rights != 0xFFFFFFFF) {
+                rights |= add;
+                rights &= (0xFFFFFFFF - substract);
+            } else {
+                rights = 1 + 2 + 4 + 8 + 32 + 64 + 128 + 16384 + 32768 + 131072 + 262144 + 524288 + 1048576;
+                rights |= add;
+                rights &= (0xFFFFFFFF - substract);
+            }
+            return rights;
+        }
+
+        function GetMeshRights(mesh, userid) {
+            if (mesh == null) { return 0; }
+            if (userid == null) { userid = userinfo._id; }
+            if (typeof mesh == 'string') { mesh = meshes[mesh] }
+            if ((mesh == null) || (mesh.links == null)) { return 0; }
+
+            if (serverinfo.manageAllDeviceGroups && (userid == userinfo._id)) return removeUserRights(0xFFFFFFFF, userid);
+
+            var rights = 0, r = mesh.links[userid];
+            if (r != null) {
+                if (r.rights == 0xFFFFFFFF) { return removeUserRights(0xFFFFFFFF, userid); }
+                rights = r.rights;
+            }
+
+            var user = null;
+            if (userid == userinfo._id) { user = userinfo; } else { if (users != null) { user = users[userid]; } }
+            if (user != null) {
+                for (var i in user.links) {
+                    if (i.startsWith('ugrp/')) {
+                        r = mesh.links[i];
+                        if (r != null) {
+                            if (r.rights == 0xFFFFFFFF) { return removeUserRights(0xFFFFFFFF, userid); }
+                            rights |= r.rights;
+                        }
+                    }
+                }
+            }
+
+            return removeUserRights(rights, userid);
+        }
+
+        function IsMeshViewable(mesh, userid) {
+            if (mesh == null) { return false; }
+            if (userid == null) { userid = userinfo._id; }
+            if (typeof mesh == 'string') { mesh = meshes[mesh] }
+            if ((mesh == null) || (mesh.links == null)) { return false; }
+            if (mesh.links[userid] != null) { return true; }
+
+            if (serverinfo.manageAllDeviceGroups && (userid == userinfo._id)) return true;
+
+            var user = null;
+            if (userid == userinfo._id) { user = userinfo; } else { if (users != null) { user = users[userid]; } }
+            if (user != null) {
+                for (var i in user.links) {
+                    if ((i.startsWith('ugrp/')) && (mesh.links[i] != null)) { return true; }
+                }
+            }
+
+            return false;
+        }
+
+        function GetNodeRights(node, userid) {
+            if (node == null) { return 0; }
+            if (userid == null) { userid = userinfo._id; }
+            if (typeof node == 'string') { node = getNodeFromId(node); if (node == null) { return 0; } }
+            var r = GetMeshRights(node.meshid, userid);
+            if (r == 0xFFFFFFFF) return removeUserRights(r, userid);
+
+            if ((node.links != null) && (node.links[userid] != null)) { r |= node.links[userid].rights; }
+
+            if ((node.links != null) && (userinfo.links != null)) {
+                for (var i in node.links) {
+                    if (i.startsWith('ugrp/') && (userinfo.links[i] != null) && (node.links[i].rights != null)) { r |= node.links[i].rights; }
+                }
+            }
+            return removeUserRights(r, userid);
+        }
+
+        function IsNodeViewable(node, userid) {
+            if (node == null) { return false; }
+            if (userid == null) { userid = userinfo._id; }
+            if (typeof node == 'string') { node = getNodeFromId(node); if (node == null) { return false; } }
+            if (IsMeshViewable(node.meshid, userid)) return true;
+
+            if ((node.links != null) && (node.links[userid] != null)) { return true; }
+
+            if ((node.links != null) && (userinfo.links != null)) {
+                for (var i in node.links) { if (i.startsWith('ugrp/') && (userinfo.links[i] != null) && (node.links[i].rights != null)) { return true; } }
+            }
+
+            return false;
+        }
+
+        function nameSort(a, b) { var aa = a.name.toLowerCase(), bb = b.name.toLowerCase(); return sortCollator.compare(aa, bb); }
+        function getNodeAmtVersion(node) { if ((node == null) || (node.intelamt == null) || (typeof node.intelamt.ver != 'string')) return 0; var verSplit = node.intelamt.ver.split('.'); if (verSplit.length < 2) return 0; return parseInt(verSplit[0]) + (parseInt(verSplit[1]) / 100); }
+        function putstore(name, val) { try { if ((typeof (localStorage) === 'undefined') || (localStorage.getItem(name) == val)) return; if (val == null) { localStorage.removeItem(name); } else { localStorage.setItem(name, val); } } catch (e) { } if (name[0] != '_') { var s = {}; for (var i = 0, len = localStorage.length; i < len; ++i) { var k = localStorage.key(i); if (k[0] != '_') { s[k] = localStorage.getItem(k); } } meshserver.send({ action: 'userWebState', state: JSON.stringify(s) }); } }
+        function getstore(name, val) { try { if (typeof (localStorage) === 'undefined') return val; var v = localStorage.getItem(name); if ((v == null) || (v == null)) return val; return v; } catch (e) { return val; } }
+        function center() { if (xtermfit) xtermfit.fit(); onDevicesScroll(); QS('dialog').left = ((((getDocWidth() - 300) / 2)) + 'px'); deskAdjust(); if (currentNode != null) { drawDeviceTimeline(); } }
+        function messagebox(t, m) { QH('id_dialogMessage', m); setDialogMode(1, t, 1); }
+        function statusbox(t, m) { QH('id_dialogMessage', m); setDialogMode(1, t); }
+        function getDocWidth() { if (window.innerWidth) return window.innerWidth; if (document.documentElement && document.documentElement.clientWidth && document.documentElement.clientWidth != 0) return document.documentElement.clientWidth; return document.getElementsByTagName('body')[0].clientWidth; }
+        function haltEvent(e) { if (e.preventDefault) e.preventDefault(); if (e.stopPropagation) e.stopPropagation(); return false; }
+        function haltReturn(e) { if (e.keyCode == 13) { haltEvent(e); } }
+        function validateEmail(v) { var emailReg = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/; return emailReg.test(v); }
+        function reload() { window.location.href = window.location.href; }
+        function getNodeFromId(id) { for (var i in nodes) { if (nodes[i]._id == id) return nodes[i]; } return null; }
+        function addHtmlValue(t, v) { return '<table><td style=width:120px>' + t + '<td><b>' + v + '</b></table>'; }
+        function addHtmlValue2(t, v) { return '<div><div style=display:inline-block;float:right>' + v + '</div><div style=display:inline-block>' + t + '</div></div>'; }
+        function addHtmlValue4(t, v) { return '<table style=width:100%><td style=width:120px>' + t + '<td style=text-align:right><b>' + v + '</b></table>'; }
+        function addLink(x, f) { return '<a style=cursor:pointer;text-decoration:none onclick=\'' + f + '\'>&diams; ' + x + '</a>'; }
+        function addLinkConditional(x, f, c) { if (c) return addLink(x, f); return x; }
+        function addKeyLink(x, f) { return '<span tabindex=0 style=cursor:pointer;text-decoration:none onclick=' + f + ' onkeypress="if (event.key==\'Enter\') { ' + f + ' } ">' + x + ' <img class=hoverButton src=images/key16.png></span>'; }
+        function addKeyLinkConditional(x, t, c) { if (c) return '<span title=\'' + t + '\'>' + x + ' <img class=hoverButton src=images/key16.png></span>'; return x }
+        function passwordcheck(p) { var re = /(?=.*\d)(?=.*[a-z])(?=.*[A-Z])(?=.*[!@#$%^&*()]).{8,}/; return re.test(p); }
+        function getFileSizeStr(size) { if (typeof size != 'number') { size = 0; } if (size == 1) return "1 byte"; return format('{0} bytes', size); }
+        function focusTextBox(x) { setTimeout(function () { Q(x).selectionStart = Q(x).selectionEnd = 65535; Q(x).focus(); }, 0); }
+        var isFilenameValid = (function () { var x1 = /^[^\\/:\*\?"<>\|]+$/, x2 = /^\./, x3 = /^(nul|prn|con|lpt[0-9]|com[0-9])(\.|$)/i; return function isFilenameValid(fname) { return x1.test(fname) && !x2.test(fname) && !x3.test(fname) && (fname[0] != '.'); } })();
+        function printDate(d) { return d.toLocaleDateString(args.locale); }
+        function printTime(d) { return d.toLocaleTimeString(args.locale); }
+        function printDateTime(d) { return d.toLocaleString(args.locale); }
+        function format(format) { var args = Array.prototype.slice.call(arguments, 1); return format.replace(/{(\d+)}/g, function (match, number) { return typeof args[number] != 'undefined' ? args[number] : match; }); };
+        function nobreak(x) { return x.split(' ').join('&nbsp;'); }
+        function getUserName(userid) { 
+            var useridsplit = userid.split('/'), userid2 = useridsplit[0] + '/' + useridsplit[1] + '/' + useridsplit[2], guestname = '';
+            if ((useridsplit.length == 4) && (useridsplit[3].startsWith('guest:'))) { guestname = ' - ' + decode_utf8(atob(useridsplit[3].substring(6))); }
+            if (users && users[userid2] != null) { if (users[userid2].realname != null) return (users[userid2].realname + guestname); else return (users[userid2].name + guestname); }
+            if (currentNode && currentNode.links && currentNode.links[userid] && currentNode.links[userid].name != null) { return (currentNode.links[userid].name + guestname); }
+            if (userid == userinfo._id) { return (userinfo.name + guestname); }
+            if (nodes) { for (var a in nodes) { if (nodes[a].links) { for (var b in nodes[a].links) { if (nodes[a].links[b].name && b == userid) return (nodes[a].links[b].name + guestname); } } } }
+            if (meshes) { for (var a in meshes) { if (meshes[a].links) { for (var b in meshes[a].links) { if (meshes[a].links[b].name && b == userid) return (meshes[a].links[b].name + guestname); } } } }
+            return (useridsplit[2] + guestname);
+        }
+        function addDetailItem(title, value, state) { return '<table style=width:100%><td>' + nobreak(title) + '<td style=text-align:right>' + value + '</table>'; }
+        function isPrivateIP(a) { return (a.startsWith('10.') || a.startsWith('172.16.') || a.startsWith('192.168.')); }
+        function encodeURIComponentEx(txt) { return encodeURIComponent(txt).replace(/'/g, '%27'); };
+        function safeNewWindow(url, target) { var newWindow = window.open(url, target, 'noopener,noreferrer'); if (newWindow) { newWindow.opener = null; } }
+
+    </script>
+</body>
+</html>


### PR DESCRIPTION
Introduces a new stylesheet for mobile bootstrap styling and a new Handlebars template for the mobile default view. This enhances mobile UI support and layout customization.

For testing, Just place both in 

meshcentral-web/views - rename default3-mobile.handlebars > default-mobile.handlebars
meshcentral-web/public/styles - Insert style-mobile-bootstrap.css

Then use Classic UI and check it on Mobile. 

