### PR TITLE
Authentication Strategy Consolidation & User Migration

### DIFF
--- a/docs/docs/meshcentral/authentication/index.md
+++ b/docs/docs/meshcentral/authentication/index.md
@@ -1,0 +1,92 @@
+# Authentication Strategies
+
+MeshCentral supports multiple authentication strategies for enterprise Single Sign-On (SSO) integration.
+
+## Modern Strategies (Recommended)
+
+### [OpenID Connect (OIDC)](oidc.md)
+Modern authentication strategy supporting OAuth 2.0 and OpenID Connect providers.
+
+**Supported Providers:**
+- Azure AD / Microsoft Entra ID
+- Google Workspace
+- GitHub
+- Twitter (OAuth 2.0)
+- Any OIDC-compliant provider
+
+**Features:**
+- Group synchronization
+- Automatic user provisioning
+- Multi-provider support
+- Pre-configured presets
+
+[Read OIDC Documentation →](oidc.md)
+
+### [SAML 2.0](saml.md)
+Industry-standard SAML 2.0 authentication for enterprise identity providers.
+
+**Supported Providers:**
+- Okta
+- Azure AD SAML
+- JumpCloud
+- OneLogin
+- Any SAML 2.0 compliant IdP
+
+**Features:**
+- Group synchronization
+- Multi-preset support
+- Flexible attribute mapping
+- Single logout
+
+[Read SAML Documentation →](saml.md)
+
+## Deprecated Strategies
+
+> **⚠️ DEPRECATION NOTICE**: The following authentication strategies are deprecated and will be removed in a future version. Please migrate to the modern OIDC or SAML strategies above.
+
+### Deprecated OAuth2 Strategies
+- **Azure OAuth2** → Migrate to [OIDC with Azure preset](migration-guide.md#azure-oauth2-to-oidc)
+- **Google OAuth2** → Migrate to [OIDC with Google preset](migration-guide.md#google-oauth2-to-oidc)
+- **GitHub OAuth2** → Migrate to [OIDC with GitHub preset](migration-guide.md#github-oauth2-to-oidc)
+- **Twitter OAuth** → Migrate to [OIDC with Twitter preset](migration-guide.md#twitter-oauth-to-oidc)
+
+### Deprecated SAML Strategies
+- **Intel SAML** → Migrate to [SAML with Intel preset](migration-guide.md#intel-saml-to-unified-saml)
+- **JumpCloud SAML** → Migrate to [SAML with JumpCloud preset](migration-guide.md#jumpcloud-saml-to-unified-saml)
+
+[View Migration Guide →](migration-guide.md)
+
+## Comparison
+
+| Feature | OIDC | SAML |
+| --- | --- | --- |
+| **Protocol** | OAuth 2.0 / OIDC | SAML 2.0 |
+| **Format** | JSON (JWT) | XML |
+| **Complexity** | Simpler | More complex |
+| **Group Sync** | ✅ Yes | ✅ Yes |
+| **Modern IdPs** | ✅ Best support | ✅ Good support |
+| **Legacy IdPs** | ⚠️ Limited | ✅ Excellent |
+| **Mobile-Friendly** | ✅ Yes | ⚠️ Limited |
+
+## Quick Decision Guide
+
+**Choose OIDC if:**
+- Using modern cloud IdPs (Azure AD, Google, Okta)
+- Want simpler configuration
+- Need OAuth 2.0 API access
+- Supporting mobile applications
+
+**Choose SAML if:**
+- Required by enterprise IdP
+- Need mature, proven standard
+- IdP only supports SAML
+- Regulatory compliance requires SAML
+
+## Other Authentication Methods
+
+- **Local Accounts** - Built-in username/password
+- **LDAP/Active Directory** - Direct directory integration
+- **Two-Factor Authentication** - TOTP, Email, SMS
+- **WebAuthn** - Hardware security keys
+
+For more information on these methods, see the [MeshCentral Configuration Guide](../config.md).

--- a/docs/docs/meshcentral/authentication/migration-guide.md
+++ b/docs/docs/meshcentral/authentication/migration-guide.md
@@ -1,0 +1,550 @@
+# Authentication Strategy Migration Guide
+
+This guide helps you migrate from deprecated authentication strategies to the modern OIDC and SAML implementations.
+
+## Why Migrate?
+
+### Benefits of Modern Strategies
+
+1. **Better Maintainability** - Single codebase for all OAuth2/OIDC and SAML providers
+2. **More Features** - Group sync, better error handling, enhanced logging
+3. **Active Development** - Modern libraries with security updates
+4. **Consistent Configuration** - Same pattern for all providers
+5. **Bug Fixes** - Resolves critical issues like Azure unique_name bug (#4531)
+
+### Deprecation Timeline
+
+- **v1.1.48+** - Deprecated strategies still work but log warnings
+- **Future Release** - Deprecated strategies will be removed
+
+## Azure OAuth2 → OIDC
+
+### The Problem
+
+**Critical Bug**: Azure OAuth2 strategy uses the `unique_name` claim which is **NOT STABLE**. When users change their email or UPN, they get a new account instead of logging into their existing one.
+
+**OIDC Solution**: Uses the `oid` (Object ID) claim which is immutable and never changes.
+
+### Migration Steps
+
+#### 1. Old Configuration
+
+```json
+{
+  "domains": {
+    "": {
+      "authStrategies": {
+        "azure": {
+          "clientid": "abc-123-def-456",
+          "clientsecret": "your-client-secret",
+          "tenantid": "your-tenant-guid",
+          "callbackurl": "https://mesh.example.com/auth-azure-callback",
+          "newAccounts": true
+        }
+      }
+    }
+  }
+}
+```
+
+#### 2. New Configuration
+
+```json
+{
+  "domains": {
+    "": {
+      "authStrategies": {
+        "oidc": {
+          "client": {
+            "client_id": "abc-123-def-456",
+            "client_secret": "your-client-secret",
+            "redirect_uri": "https://mesh.example.com/auth-oidc-callback"
+          },
+          "custom": {
+            "preset": "azure",
+            "tenant_id": "your-tenant-guid"
+          },
+          "newAccounts": true
+        }
+      }
+    }
+  }
+}
+```
+
+**OR** use simplified format (auto-migrates):
+
+```json
+{
+  "domains": {
+    "": {
+      "authStrategies": {
+        "oidc": {
+          "clientid": "abc-123-def-456",
+          "clientsecret": "your-client-secret",
+          "tenantid": "your-tenant-guid",
+          "newAccounts": true
+        }
+      }
+    }
+  }
+}
+```
+
+#### 3. Update Azure App Registration
+
+**Old Redirect URI:**
+```
+https://mesh.example.com/auth-azure-callback
+```
+
+**New Redirect URI:**
+```
+https://mesh.example.com/auth-oidc-callback
+```
+
+1. Go to Azure Portal → App Registrations → Your App
+2. Navigate to **Authentication** → **Platform configurations** → **Web**
+3. Add new redirect URI: `https://mesh.example.com/auth-oidc-callback`
+4. Remove old redirect URI (after testing)
+
+#### 4. User Account Migration
+
+**User IDs will change:**
+- Old: `user//~azure:john.doe@company.com`
+- New: `user//~oidc:12345678-abcd-1234-abcd-123456789abc`
+
+**Options:**
+
+**A. Let Users Create New Accounts**
+- Simplest approach
+- Users log in and get new accounts
+- Manually transfer device ownership if needed
+
+**B. Database Migration (Advanced)**
+- Update user IDs in database
+- Requires database access
+- Contact MeshCentral support for assistance
+
+### Testing
+
+1. Keep `azure` config temporarily
+2. Add `oidc` config alongside it
+3. Test OIDC login works
+4. Verify groups sync correctly
+5. Remove `azure` config after confirming
+
+## Google OAuth2 → OIDC
+
+### Migration Steps
+
+#### 1. Old Configuration
+
+```json
+{
+  "authStrategies": {
+    "google": {
+      "clientid": "123456789.apps.googleusercontent.com",
+      "clientsecret": "your-client-secret",
+      "callbackurl": "https://mesh.example.com/auth-google-callback"
+    }
+  }
+}
+```
+
+#### 2. New Configuration
+
+```json
+{
+  "authStrategies": {
+    "oidc": {
+      "client": {
+        "client_id": "123456789.apps.googleusercontent.com",
+        "client_secret": "your-client-secret",
+        "redirect_uri": "https://mesh.example.com/auth-oidc-callback"
+      },
+      "custom": {
+        "preset": "google"
+      }
+    }
+  }
+}
+```
+
+#### 3. Update Google OAuth Consent Screen
+
+1. Go to [Google Cloud Console](https://console.cloud.google.com)
+2. Navigate to **APIs & Services** → **Credentials**
+3. Click your OAuth 2.0 Client ID
+4. Under **Authorized redirect URIs**:
+   - Add: `https://mesh.example.com/auth-oidc-callback`
+   - Remove old URI after testing
+
+#### 4. User Migration
+
+**User IDs change:**
+- Old: `user//~google:1234567890`
+- New: `user//~oidc:1234567890` (same numeric ID)
+
+## GitHub OAuth2 → OIDC
+
+### Migration Steps
+
+#### 1. Old Configuration
+
+```json
+{
+  "authStrategies": {
+    "github": {
+      "clientid": "Iv1.abc123def456",
+      "clientsecret": "github-secret",
+      "callbackurl": "https://mesh.example.com/auth-github-callback"
+    }
+  }
+}
+```
+
+#### 2. New Configuration
+
+```json
+{
+  "authStrategies": {
+    "oidc": {
+      "client": {
+        "client_id": "Iv1.abc123def456",
+        "client_secret": "github-secret",
+        "redirect_uri": "https://mesh.example.com/auth-oidc-callback"
+      },
+      "custom": {
+        "preset": "github"
+      }
+    }
+  }
+}
+```
+
+#### 3. Update GitHub OAuth App
+
+1. Go to GitHub → Settings → Developer settings → OAuth Apps
+2. Click your application
+3. Update **Authorization callback URL**:
+   - Change to: `https://mesh.example.com/auth-oidc-callback`
+
+#### 4. User Migration
+
+**User IDs change:**
+- Old: `user//~github:1234567`
+- New: `user//~oidc:1234567` (same numeric ID)
+
+## Twitter OAuth → OIDC
+
+### Migration Steps
+
+#### 1. Old Configuration
+
+```json
+{
+  "authStrategies": {
+    "twitter": {
+      "clientid": "your-consumer-key",
+      "clientsecret": "your-consumer-secret",
+      "callbackurl": "https://mesh.example.com/auth-twitter-callback"
+    }
+  }
+}
+```
+
+#### 2. New Configuration
+
+```json
+{
+  "authStrategies": {
+    "oidc": {
+      "client": {
+        "client_id": "your-oauth2-client-id",
+        "client_secret": "your-oauth2-client-secret",
+        "redirect_uri": "https://mesh.example.com/auth-oidc-callback"
+      },
+      "custom": {
+        "preset": "twitter"
+      }
+    }
+  }
+}
+```
+
+#### 3. Upgrade to Twitter OAuth 2.0
+
+> **Important**: Twitter's old OAuth 1.0a is deprecated. You need OAuth 2.0 credentials.
+
+1. Go to [Twitter Developer Portal](https://developer.twitter.com/en/portal/dashboard)
+2. Select your app
+3. Navigate to **Keys and tokens**
+4. Under **OAuth 2.0 Client ID and Client Secret**:
+   - Generate new credentials if you don't have them
+5. Update callback URL to: `https://mesh.example.com/auth-oidc-callback`
+
+#### 4. User Migration
+
+**User IDs change:**
+- Old: `user//~twitter:123456789`
+- New: `user//~oidc:123456789` (same numeric ID)
+
+## Intel SAML → Unified SAML
+
+### Migration Steps
+
+#### 1. Old Configuration
+
+```json
+{
+  "authStrategies": {
+    "intel": {
+      "cert": "intel-saml-cert.pem",
+      "idpurl": "https://intel-idp.example.com/saml/sso",
+      "entityid": "meshcentral",
+      "callbackurl": "https://mesh.example.com/auth-intel-callback"
+    }
+  }
+}
+```
+
+#### 2. New Configuration
+
+```json
+{
+  "authStrategies": {
+    "saml": {
+      "preset": "intel",
+      "cert": "intel-saml-cert.pem",
+      "idpurl": "https://intel-idp.example.com/saml/sso",
+      "entityid": "meshcentral",
+      "callbackurl": "https://mesh.example.com/auth-saml-callback"
+    }
+  }
+}
+```
+
+#### 3. Update IdP Configuration
+
+**Old Callback URL:**
+```
+https://mesh.example.com/auth-intel-callback
+```
+
+**New Callback URL:**
+```
+https://mesh.example.com/auth-saml-callback
+```
+
+Update your SAML IdP with the new callback URL.
+
+#### 4. User Migration
+
+**User IDs change:**
+- Old: `user//~intel:user@example.com`
+- New: `user//~saml:user@example.com`
+
+## JumpCloud SAML → Unified SAML
+
+### Migration Steps
+
+#### 1. Old Configuration
+
+```json
+{
+  "authStrategies": {
+    "jumpcloud": {
+      "cert": "jumpcloud-cert.pem",
+      "idpurl": "https://sso.jumpcloud.com/saml2/org-id",
+      "entityid": "meshcentral"
+    }
+  }
+}
+```
+
+#### 2. New Configuration
+
+```json
+{
+  "authStrategies": {
+    "saml": {
+      "preset": "jumpcloud",
+      "cert": "jumpcloud-cert.pem",
+      "idpurl": "https://sso.jumpcloud.com/saml2/org-id",
+      "entityid": "meshcentral"
+    }
+  }
+}
+```
+
+#### 3. Update JumpCloud SSO App
+
+1. Go to JumpCloud Admin Portal
+2. Navigate to **SSO** → Your MeshCentral App
+3. Update **ACS URL**:
+   - Change to: `https://mesh.example.com/auth-saml-callback`
+
+#### 4. User Migration
+
+**User IDs change:**
+- Old: `user//~jumpcloud:user@example.com`
+- New: `user//~saml:user@example.com`
+
+## Advanced: Database User ID Migration
+
+> **⚠️ WARNING**: Direct database manipulation can break your MeshCentral installation. Always backup first!
+
+### Backup Database
+
+```bash
+# NeDB (default)
+cp -r meshcentral-data/ meshcentral-data-backup/
+
+# MongoDB
+mongodump --db meshcentral --out backup/
+```
+
+### Migration Script Example
+
+This script is for **reference only**. Adapt to your specific needs:
+
+```javascript
+// Example: Migrate Azure OAuth2 users to OIDC
+// This is PSEUDOCODE - not production ready!
+
+const oldPrefix = '~azure:';
+const newPrefix = '~oidc:';
+
+db.collection('users').find({ _id: { $regex: oldPrefix } }).forEach(user => {
+  const oldId = user._id;
+  const username = oldId.split(oldPrefix)[1];
+  
+  // You need to map old username to new OIDC 'sub' or 'oid' claim
+  // This requires looking up the claim from Azure AD
+  const newOid = lookupAzureOid(username); // You implement this
+  const newId = oldId.replace(oldPrefix + username, newPrefix + newOid);
+  
+  // Update user document
+  user._id = newId;
+  db.collection('users').insert(user);
+  db.collection('users').remove({ _id: oldId });
+  
+  // Update references in other collections (devices, groups, etc.)
+  // ... more updates needed ...
+});
+```
+
+### Professional Migration
+
+For production systems with many users, consider:
+1. Hiring a MeshCentral consultant
+2. Contacting MeshCentral support
+3. Planning maintenance window
+4. Testing on staging environment first
+
+## Gradual Migration Strategy
+
+### Phase 1: Parallel Operation
+
+Keep both old and new strategies:
+
+```json
+{
+  "authStrategies": {
+    "azure": { /* old config */ },
+    "oidc": { /* new config */ }
+  }
+}
+```
+
+- Both login methods work simultaneously
+- Test new OIDC method thoroughly
+- Users can start migrating gradually
+
+### Phase 2: Announcement
+
+- Notify users of upcoming change
+- Provide documentation
+- Set migration deadline
+- Offer support for issues
+
+### Phase 3: Deprecation
+
+Remove old configuration:
+
+```json
+{
+  "authStrategies": {
+    "oidc": { /* new config */ }
+  }
+}
+```
+
+## Troubleshooting
+
+### Deprecation Warnings in Logs
+
+You'll see warnings like:
+
+```
+DEPRECATION: ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+DEPRECATION: ⚠️  Azure OAuth2 strategy is DEPRECATED
+DEPRECATION: 📋 Migrate to OIDC with preset: "azure"
+DEPRECATION: ⚠️  CRITICAL: Azure OAuth2 uses "unique_name" claim which is NOT STABLE
+DEPRECATION: 📚 See documentation: AUTH_MIGRATION_GUIDE.md
+DEPRECATION: ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+```
+
+**Action**: Follow migration guide for your provider above.
+
+### Users Can't Find Old Accounts
+
+**Cause**: User ID format changed during migration
+
+**Solutions**:
+1. **Option A**: Let users create new accounts, manually transfer devices
+2. **Option B**: Perform database migration (advanced)
+3. **Option C**: Keep old strategy temporarily until ready
+
+### Both Old and New Methods Don't Work
+
+**Cause**: Callback URL mismatch
+
+**Solution**:
+- Verify IdP has BOTH callback URLs configured
+- Check config.json has correct URLs
+- Review server logs for specific errors
+
+### Group Sync Not Working After Migration
+
+**Cause**: Group configuration differences between strategies
+
+**Solution**:
+- OIDC and SAML both support groups
+- Review [OIDC Groups](oidc.md#group-synchronization)
+- Review [SAML Groups](saml.md#group-synchronization)
+- Ensure IdP sends group claims/attributes
+
+## Getting Help
+
+- **Documentation**: [Authentication Strategies](index.md)
+- **GitHub Issues**: [MeshCentral Issues](https://github.com/Ylianst/MeshCentral/issues)
+- **Community Forum**: [MeshCentral Discord/Forum]
+- **Logs**: Enable debug with `node meshcentral.js --debug auth`
+
+## Summary Checklist
+
+- [ ] Backup database and configuration
+- [ ] Update IdP redirect/callback URLs
+- [ ] Update config.json with new strategy
+- [ ] Test login with new strategy
+- [ ] Verify group sync works (if used)
+- [ ] Notify users of change
+- [ ] Monitor logs for errors
+- [ ] Remove old strategy config after verification
+- [ ] Document any custom changes
+
+---
+
+*Last updated: November 2025 for MeshCentral v1.1.48+*

--- a/docs/docs/meshcentral/authentication/oidc.md
+++ b/docs/docs/meshcentral/authentication/oidc.md
@@ -537,6 +537,121 @@ As always, the client ID and secret are required, the customer ID on the other h
 },
 ```
 
+## OIDC Presets
+
+### Available Presets
+
+MeshCentral includes presets for popular OAuth 2.0 and OIDC providers:
+
+- **`azure`** - Azure AD / Microsoft Entra ID
+- **`google`** - Google Workspace / Google Cloud Identity
+- **`okta`** - Okta Identity Cloud
+- **`auth0`** - Auth0 by Okta
+- **`keycloak`** - Keycloak / Red Hat SSO
+- **`github`** - GitHub OAuth 2.0
+- **`twitter`** - Twitter OAuth 2.0
+
+### Okta Preset
+
+```json
+{
+  "oidc": {
+    "client": {
+      "client_id": "your-client-id",
+      "client_secret": "your-client-secret"
+    },
+    "custom": {
+      "preset": "okta",
+      "org_domain": "company.okta.com"
+    },
+    "groups": {
+      "required": ["mesh-users"],
+      "siteadmin": ["mesh-admins"],
+      "sync": true
+    }
+  }
+}
+```
+
+**Required:** `org_domain` - Your Okta organization domain
+
+### Auth0 Preset
+
+```json
+{
+  "oidc": {
+    "client": {
+      "client_id": "your-client-id",
+      "client_secret": "your-client-secret"
+    },
+    "custom": {
+      "preset": "auth0",
+      "domain": "company.auth0.com"
+    }
+  }
+}
+```
+
+**Required:** `domain` - Your Auth0 tenant domain (e.g., `company.auth0.com` or `company.us.auth0.com`)
+
+### Keycloak Preset
+
+```json
+{
+  "oidc": {
+    "client": {
+      "client_id": "meshcentral",
+      "client_secret": "your-client-secret"
+    },
+    "custom": {
+      "preset": "keycloak",
+      "server_url": "https://keycloak.company.com",
+      "realm": "master"
+    }
+  }
+}
+```
+
+**Required:** 
+- `server_url` - Base URL of your Keycloak server
+- `realm` - Keycloak realm name
+
+### GitHub Preset
+
+```json
+{
+  "oidc": {
+    "client": {
+      "client_id": "Iv1.your-github-client-id",
+      "client_secret": "your-github-secret"
+    },
+    "custom": {
+      "preset": "github"
+    }
+  }
+}
+```
+
+**Note:** GitHub uses OAuth 2.0, not OIDC. Endpoints are configured automatically.
+
+### Twitter Preset
+
+```json
+{
+  "oidc": {
+    "client": {
+      "client_id": "your-twitter-client-id",
+      "client_secret": "your-twitter-secret"
+    },
+    "custom": {
+      "preset": "twitter"
+    }
+  }
+}
+```
+
+**Note:** Requires Twitter OAuth 2.0 credentials (not OAuth 1.0a).
+
 ### Azure Preset
 
 #### *Prerequisites*

--- a/docs/docs/meshcentral/authentication/saml.md
+++ b/docs/docs/meshcentral/authentication/saml.md
@@ -1,0 +1,667 @@
+# Using the SAML Strategy on MeshCentral
+
+## Overview
+
+### Introduction
+
+MeshCentral supports SAML 2.0 authentication through a modern, unified SAML strategy. This allows you to integrate with any SAML 2.0 compatible Identity Provider (IdP) such as Okta, Azure AD, JumpCloud, OneLogin, and many others.
+
+The SAML strategy uses the industry-standard `@node-saml/passport-saml` library (v5.x+), which provides robust SAML 2.0 protocol support with modern security features.
+
+> **IMPORTANT**: As of MeshCentral v1.1.48, the old separate SAML strategies (`intel`, `jumpcloud`) are **DEPRECATED**. Please migrate to the unified `saml` strategy with presets. See the [Migration Guide](#migration-from-deprecated-strategies) below.
+
+### Chart of Frequently Used Terms
+
+| Term | Description |
+| --- | --- |
+| **SAML** | Security Assertion Markup Language - XML-based standard for authentication |
+| **IdP** | Identity Provider - The service that authenticates users (Okta, Azure AD, etc.) |
+| **SP** | Service Provider - MeshCentral in this case |
+| **Assertion** | XML document containing user authentication information |
+| **Entity ID** | Unique identifier for the Service Provider (MeshCentral) |
+| **SSO** | Single Sign-On - Authenticate once, access multiple services |
+| **Preset** | Pre-configured settings for popular IdP providers |
+
+## Quick Start
+
+### Basic Configuration
+
+Here's a minimal SAML configuration:
+
+```json
+{
+  "domains": {
+    "": {
+      "authStrategies": {
+        "saml": {
+          "cert": "idp-certificate.pem",
+          "idpurl": "https://idp.example.com/saml/sso",
+          "entityid": "meshcentral",
+          "callbackurl": "https://mesh.example.com/auth-saml-callback"
+        }
+      }
+    }
+  }
+}
+```
+
+### Required Files
+
+1. **IdP Certificate** - Place your IdP's public certificate in `meshcentral-data/`
+   - File format: PEM (Base64 encoded X.509 certificate)
+   - Example filename: `idp-certificate.pem`
+
+## Using Presets
+
+Presets provide optimized configurations for popular IdP providers.
+
+### Available Presets
+
+- `azure` - Azure AD / Microsoft Entra ID
+- `okta` - Okta
+- `onelogin` - OneLogin
+- `jumpcloud` - JumpCloud
+- `auth0` - Auth0 SAML
+- `keycloak` - Keycloak / Red Hat SSO
+- `adfs` - Active Directory Federation Services (Microsoft ADFS)
+- `pingfederate` - Ping Identity PingFederate
+- `google` - Google Workspace SAML
+- `intel` - Intel SAML
+- `generic` - (default) Standard SAML 2.0
+
+### Azure AD Example
+
+```json
+{
+  "domains": {
+    "": {
+      "authStrategies": {
+        "saml": {
+          "preset": "azure",
+          "cert": "azure-saml-cert.pem",
+          "idpurl": "https://login.microsoftonline.com/YOUR-TENANT-ID/saml2",
+          "entityid": "meshcentral",
+          "callbackurl": "https://mesh.example.com/auth-saml-callback"
+        }
+      }
+    }
+  }
+}
+```
+
+**Azure preset settings:**
+- Identifier Format: `urn:oasis:names:tc:SAML:2.0:nameid-format:persistent`
+- AuthN Response Signing: Disabled (Azure signs assertions instead)
+
+### Okta Example
+
+```json
+{
+  "domains": {
+    "": {
+      "authStrategies": {
+        "saml": {
+          "preset": "okta",
+          "cert": "okta-cert.pem",
+          "idpurl": "https://your-org.okta.com/app/YOUR-APP-ID/sso/saml",
+          "entityid": "meshcentral",
+          "callbackurl": "https://mesh.example.com/auth-saml-callback",
+          "groups": {
+            "enabled": true,
+            "attribute": "groups",
+            "required": ["MeshCentral-Users"],
+            "siteadmin": ["MeshCentral-Admins"],
+            "sync": true
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+**Okta preset settings:**
+- Identifier Format: `urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress`
+
+### OneLogin Example
+
+```json
+{
+  "domains": {
+    "": {
+      "authStrategies": {
+        "saml": {
+          "preset": "onelogin",
+          "cert": "onelogin-cert.pem",
+          "idpurl": "https://company.onelogin.com/trust/saml2/http-post/sso/123456",
+          "entityid": "meshcentral"
+        }
+      }
+    }
+  }
+}
+```
+
+**OneLogin preset settings:**
+- Identifier Format: `urn:oasis:names:tc:SAML:2.0:nameid-format:persistent`
+
+### Auth0 SAML Example
+
+```json
+{
+  "domains": {
+    "": {
+      "authStrategies": {
+        "saml": {
+          "preset": "auth0",
+          "cert": "auth0-cert.pem",
+          "idpurl": "https://company.auth0.com/samlp/YOUR-CLIENT-ID",
+          "entityid": "meshcentral"
+        }
+      }
+    }
+  }
+}
+```
+
+**Auth0 preset settings:**
+- Identifier Format: `urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress`
+
+### Keycloak Example
+
+```json
+{
+  "domains": {
+    "": {
+      "authStrategies": {
+        "saml": {
+          "preset": "keycloak",
+          "cert": "keycloak-cert.pem",
+          "idpurl": "https://keycloak.company.com/realms/master/protocol/saml",
+          "entityid": "meshcentral",
+          "groups": {
+            "attribute": "Role",
+            "required": ["mesh-users"],
+            "siteadmin": ["mesh-admins"],
+            "sync": true
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+**Keycloak preset settings:**
+- Identifier Format: `urn:oasis:names:tc:SAML:2.0:nameid-format:persistent`
+- Wants AuthN Response Signed: true
+
+### Microsoft ADFS Example
+
+```json
+{
+  "domains": {
+    "": {
+      "authStrategies": {
+        "saml": {
+          "preset": "adfs",
+          "cert": "adfs-cert.pem",
+          "idpurl": "https://adfs.company.com/adfs/ls/",
+          "entityid": "meshcentral"
+        }
+      }
+    }
+  }
+}
+```
+
+**ADFS preset settings:**
+- Identifier Format: `urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress`
+- Wants AuthN Response Signed: false
+
+### PingFederate Example
+
+```json
+{
+  "domains": {
+    "": {
+      "authStrategies": {
+        "saml": {
+          "preset": "pingfederate",
+          "cert": "pingfederate-cert.pem",
+          "idpurl": "https://sso.company.com/idp/SSO.saml2",
+          "entityid": "meshcentral"
+        }
+      }
+    }
+  }
+}
+```
+
+**PingFederate preset settings:**
+- Identifier Format: `urn:oasis:names:tc:SAML:2.0:nameid-format:persistent`
+- Wants AuthN Response Signed: true
+
+### Google Workspace SAML Example
+
+```json
+{
+  "domains": {
+    "": {
+      "authStrategies": {
+        "saml": {
+          "preset": "google",
+          "cert": "google-saml-cert.pem",
+          "idpurl": "https://accounts.google.com/o/saml2/idp?idpid=YOUR-IDP-ID",
+          "entityid": "meshcentral"
+        }
+      }
+    }
+  }
+}
+```
+
+**Google Workspace preset settings:**
+- Identifier Format: `urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress`
+
+### JumpCloud Example
+
+```json
+{
+  "domains": {
+    "": {
+      "authStrategies": {
+        "saml": {
+          "preset": "jumpcloud",
+          "cert": "jumpcloud-cert.pem",
+          "idpurl": "https://sso.jumpcloud.com/saml2/YOUR-ORG-ID",
+          "entityid": "meshcentral"
+        }
+      }
+    }
+  }
+}
+```
+
+## Advanced Configuration
+
+### Complete Configuration Example
+
+```json
+{
+  "domains": {
+    "": {
+      "title": "My Company Mesh",
+      "authStrategies": {
+        "saml": {
+          "preset": "okta",
+          "cert": "okta-saml-cert.pem",
+          "idpurl": "https://company.okta.com/app/meshcentral/sso/saml",
+          "entityid": "meshcentral-production",
+          "callbackurl": "https://mesh.company.com/auth-saml-callback",
+          "disablerequestedauthncontext": false,
+          "newAccounts": true,
+          "newAccountsUserGroups": ["default-users"],
+          "newAccountsRights": ["nonewgroups", "notools"],
+          "groups": {
+            "attribute": "groups",
+            "required": ["mesh-users"],
+            "siteadmin": ["mesh-admins"],
+            "sync": true,
+            "revokeAdmin": true
+          },
+          "logouturl": "https://company.okta.com/login/signout"
+        }
+      }
+    }
+  }
+}
+```
+
+### Configuration Options
+
+| Option | Type | Required | Description |
+| --- | --- | --- | --- |
+| `preset` | string | No | Preset configuration: `azure`, `okta`, `jumpcloud`, `intel`, `generic` |
+| `cert` | string | **Yes** | Path to IdP certificate file (relative to meshcentral-data/) |
+| `idpurl` | string | **Yes** | IdP's SAML SSO endpoint URL |
+| `entityid` | string | No | Service Provider entity ID (default: "meshcentral") |
+| `callbackurl` | string | No | Callback URL (default: auto-generated) |
+| `disablerequestedauthncontext` | boolean | No | Disable authentication context in requests |
+| `newAccounts` | boolean | No | Allow creating new accounts on first login (default: true) |
+| `newAccountsUserGroups` | array | No | Auto-add new users to these MeshCentral user groups |
+| `newAccountsRights` | array | No | Set default permissions for new accounts |
+| `logouturl` | string | No | IdP logout URL for single logout |
+
+## Group Synchronization
+
+### Overview
+
+SAML group sync allows MeshCentral to automatically:
+- Restrict access to users in specific groups
+- Grant site admin privileges based on group membership
+- Synchronize IdP groups to MeshCentral user groups
+
+### Group Configuration
+
+```json
+{
+  "saml": {
+    "preset": "okta",
+    "cert": "cert.pem",
+    "idpurl": "https://idp.example.com/saml/sso",
+    "groups": {
+      "attribute": "groups",
+      "required": ["mesh-users", "company-staff"],
+      "siteadmin": ["mesh-admins", "it-team"],
+      "sync": true,
+      "revokeAdmin": true
+    }
+  }
+}
+```
+
+### Group Options
+
+| Option | Type | Description |
+| --- | --- | --- |
+| `attribute` | string | SAML assertion attribute containing groups (default: "groups") |
+| `required` | array | User must be in at least ONE of these groups to log in |
+| `siteadmin` | array | Users in these groups get site admin privileges |
+| `sync` | boolean | Sync IdP groups to MeshCentral user groups |
+| `revokeAdmin` | boolean | Remove admin if user leaves admin group (default: true) |
+
+### IdP Configuration
+
+#### Okta Group Attribute Setup
+
+1. In Okta Admin Console, go to your SAML app
+2. Navigate to **SAML Settings** → **Attribute Statements**
+3. Add attribute:
+   - **Name**: `groups`
+   - **Name Format**: `Basic`
+   - **Value**: `appuser.groups`
+   - **Filter**: (optional) Regex like `^mesh-.*` to filter groups
+
+#### Azure AD Group Claims
+
+1. In Azure Portal, go to **App Registrations** → Your App
+2. Navigate to **Token Configuration**
+3. Click **Add groups claim**
+4. Select **Security groups**
+5. In **ID** section, choose **Group ID** or **sAMAccountName**
+6. In your SAML config:
+```json
+{
+  "groups": {
+    "attribute": "http://schemas.microsoft.com/ws/2008/06/identity/claims/groups"
+  }
+}
+```
+
+## Setting Up Your IdP
+
+### Okta Setup
+
+1. **Create SAML App**
+   - Admin Console → Applications → Create App Integration
+   - Choose **SAML 2.0**
+
+2. **General Settings**
+   - App name: MeshCentral
+   - App logo: (optional)
+
+3. **SAML Settings**
+   - **Single sign on URL**: `https://mesh.example.com/auth-saml-callback`
+   - **Audience URI (SP Entity ID)**: `meshcentral`
+   - **Name ID format**: `EmailAddress`
+   - **Application username**: `Email`
+
+4. **Attribute Statements** (optional)
+   - `email`: `user.email`
+   - `firstname`: `user.firstName`
+   - `lastname`: `user.lastName`
+   - `displayname`: `user.displayName`
+
+5. **Group Attribute Statements** (optional)
+   - Name: `groups`
+   - Filter: `Matches regex: .*` (or filter as needed)
+   - Value: `appuser.groups`
+
+6. **Download Certificate**
+   - View Setup Instructions → Download certificate
+   - Save as `okta-cert.pem` in `meshcentral-data/`
+
+7. **Get IdP URL**
+   - Copy **Identity Provider Single Sign-On URL**
+   - Use in `idpurl` config
+
+### Azure AD Setup
+
+1. **Create Enterprise Application**
+   - Azure Portal → Enterprise Applications → New Application
+   - Create your own application → **Integrate any other application**
+
+2. **Set up Single Sign-On**
+   - Select **SAML**
+
+3. **Basic SAML Configuration**
+   - **Identifier (Entity ID)**: `meshcentral`
+   - **Reply URL**: `https://mesh.example.com/auth-saml-callback`
+
+4. **User Attributes & Claims** (optional)
+   - Add claims for email, firstname, lastname
+
+5. **SAML Signing Certificate**
+   - Download **Certificate (Base64)**
+   - Save as `azure-saml-cert.pem` in `meshcentral-data/`
+
+6. **Set up MeshCentral**
+   - Copy **Login URL** → use as `idpurl`
+   - Configure Tenant ID in URL
+
+### JumpCloud Setup
+
+1. **Create SSO Application**
+   - JumpCloud Admin Portal → SSO → Add New Application
+   - Choose **Custom SAML App**
+
+2. **General Info**
+   - Display Label: MeshCentral
+
+3. **SSO Configuration**
+   - **IdP Entity ID**: `https://sso.jumpcloud.com/saml2/YOUR-ORG`
+   - **SP Entity ID**: `meshcentral`
+   - **ACS URL**: `https://mesh.example.com/auth-saml-callback`
+   - **Login URL**: (leave empty or use MeshCentral URL)
+
+4. **User Attributes**
+   - Service Provider Attribute: `email` → JumpCloud Attribute: `email`
+   - Service Provider Attribute: `firstname` → JumpCloud Attribute: `firstname`
+   - Service Provider Attribute: `lastname` → JumpCloud Attribute: `lastname`
+
+5. **Group Attributes** (optional)
+   - Service Provider Attribute: `groups`
+   - Include group attribute: ✓
+
+6. **Export Certificate**
+   - Download certificate
+   - Save as `jumpcloud-cert.pem` in `meshcentral-data/`
+
+7. **Get SSO URL**
+   - Copy **IDP URL**
+   - Use in `idpurl` config
+
+## Migration from Deprecated Strategies
+
+### Intel SAML (Deprecated)
+
+**Old Config:**
+```json
+{
+  "authStrategies": {
+    "intel": {
+      "cert": "intel-cert.pem",
+      "idpurl": "https://intel-idp.example.com/saml"
+    }
+  }
+}
+```
+
+**New Config:**
+```json
+{
+  "authStrategies": {
+    "saml": {
+      "preset": "intel",
+      "cert": "intel-cert.pem",
+      "idpurl": "https://intel-idp.example.com/saml"
+    }
+  }
+}
+```
+
+### JumpCloud SAML (Deprecated)
+
+**Old Config:**
+```json
+{
+  "authStrategies": {
+    "jumpcloud": {
+      "cert": "jumpcloud-cert.pem",
+      "idpurl": "https://sso.jumpcloud.com/saml2/ORG-ID",
+      "entityid": "meshcentral"
+    }
+  }
+}
+```
+
+**New Config:**
+```json
+{
+  "authStrategies": {
+    "saml": {
+      "preset": "jumpcloud",
+      "cert": "jumpcloud-cert.pem",
+      "idpurl": "https://sso.jumpcloud.com/saml2/ORG-ID",
+      "entityid": "meshcentral"
+    }
+  }
+}
+```
+
+### User Account Migration
+
+**Important**: User IDs will change when migrating:
+- Old Intel: `~intel:user@example.com`
+- Old JumpCloud: `~jumpcloud:user@example.com`
+- New SAML: `~saml:user@example.com`
+
+Users will need to create new accounts or you'll need to manually update user IDs in the database.
+
+## Troubleshooting
+
+### Enable Debug Logging
+
+```bash
+node meshcentral.js --debug auth,web
+```
+
+### Common Issues
+
+#### Certificate Errors
+
+**Problem**: `Unable to read SAML IdP certificate`
+
+**Solution**:
+- Verify certificate file exists in `meshcentral-data/`
+- Ensure file has correct permissions
+- Certificate must be PEM format (Base64 encoded)
+- Remove any extra whitespace or headers
+
+#### Discovery Issues with Self-Signed Certificates
+
+**Problem**: `UNABLE_TO_GET_ISSUER_CERT_LOCALLY`
+
+**Solution** (Docker):
+```yaml
+environment:
+  - NODE_EXTRA_CA_CERTS=/opt/meshcentral/meshcentral-data/chain.pem
+```
+
+**Solution** (Node.js):
+```bash
+export NODE_EXTRA_CA_CERTS=/path/to/meshcentral-data/chain.pem
+node meshcentral.js
+```
+
+#### No Groups in Assertion
+
+**Problem**: Groups not syncing, users can't log in
+
+**Solution**:
+- Verify IdP is configured to include group attribute
+- Check `groups.attribute` matches your IdP's attribute name
+- Common names: `groups`, `memberOf`, `http://schemas.microsoft.com/ws/2008/06/identity/claims/groups`
+- Enable debug logging to see SAML assertion contents
+
+#### User Creation Fails
+
+**Problem**: New accounts not being created
+
+**Solution**:
+- Ensure `newAccounts: true` in config
+- Check MeshCentral logs for errors
+- Verify user has required group membership
+
+## Security Best Practices
+
+1. **Certificate Security**
+   - Store IdP certificates securely
+   - Rotate certificates regularly
+   - Verify certificate expiration dates
+
+2. **Entity ID**
+   - Use unique entity IDs per environment
+   - Example: `meshcentral-production`, `meshcentral-staging`
+
+3. **Group-Based Access**
+   - Always configure `required` groups
+   - Limit site admin groups to minimal set
+   - Use `revokeAdmin: true` to auto-revoke admin access
+
+4. **HTTPS Only**
+   - Never use SAML over HTTP
+   - Ensure proper SSL/TLS certificates
+
+5. **Single Logout**
+   - Configure `logouturl` for proper session termination
+   - Users should be logged out of both MeshCentral and IdP
+
+## Reference
+
+### SAML Assertion Attributes
+
+MeshCentral recognizes these attributes in SAML assertions:
+
+| Attribute | Maps To | Example |
+| --- | --- | --- |
+| `nameID` | User ID (required) | `user@example.com` |
+| `email` | User email | `user@example.com` |
+| `displayname` | User display name | `John Doe` |
+| `firstname` | First name | `John` |
+| `lastname` | Last name | `Doe` |
+| `groups` (configurable) | Group memberships | `["admins", "users"]` |
+
+### User ID Format
+
+SAML users are stored with the prefix `~saml:`:
+- Format: `user/{domain}/~saml:{nameID}`
+- Example: `user//~saml:john.doe@example.com`
+
+### Links
+
+- [SAML 2.0 Specification](https://docs.oasis-open.org/security/saml/Post2.0/sstc-saml-tech-overview-2.0.html)
+- [@node-saml/passport-saml Documentation](https://github.com/node-saml/passport-saml)
+- [Okta SAML Documentation](https://developer.okta.com/docs/guides/build-sso-integration/saml2/overview/)
+- [Azure AD SAML Documentation](https://docs.microsoft.com/en-us/azure/active-directory/develop/single-sign-on-saml-protocol)

--- a/meshcentral-config-schema.json
+++ b/meshcentral-config-schema.json
@@ -3068,7 +3068,8 @@
             "properties": {
               "twitter": {
                 "type": "object",
-                "description": "Twitter authentication",
+                "description": "⚠️ DEPRECATED: Twitter OAuth authentication is deprecated. Migrate to 'oidc' with preset: 'twitter'. Note: Requires Twitter OAuth 2.0 (not OAuth 1.0a). See: docs/meshcentral/authentication/migration-guide.md",
+                "deprecated": true,
                 "properties": {
                   "callbackurl": {
                     "type": "string",
@@ -3120,7 +3121,8 @@
               },
               "google": {
                 "type": "object",
-                "description": "Google authentication",
+                "description": "⚠️ DEPRECATED: Google OAuth2 authentication is deprecated. Migrate to 'oidc' with preset: 'google'. See: docs/meshcentral/authentication/migration-guide.md",
+                "deprecated": true,
                 "properties": {
                   "callbackurl": {
                     "type": "string",
@@ -3172,7 +3174,8 @@
               },
               "github": {
                 "type": "object",
-                "description": "GitHub authentication",
+                "description": "⚠️ DEPRECATED: GitHub OAuth2 authentication is deprecated. Migrate to 'oidc' with preset: 'github'. See: docs/meshcentral/authentication/migration-guide.md",
+                "deprecated": true,
                 "properties": {
                   "callbackurl": {
                     "type": "string",
@@ -3224,7 +3227,8 @@
               },
               "azure": {
                 "type": "object",
-                "description": "Azure authentication",
+                "description": "⚠️ DEPRECATED: Azure OAuth2 authentication is deprecated. Migrate to 'oidc' with preset: 'azure'. This strategy uses the unstable 'unique_name' claim which causes duplicate accounts when users change email/UPN (Issue #4531). OIDC uses the stable 'oid' claim. See: docs/meshcentral/authentication/migration-guide.md",
+                "deprecated": true,
                 "properties": {
                   "callbackurl": {
                     "type": "string",
@@ -3281,7 +3285,8 @@
               },
               "jumpcloud": {
                 "type": "object",
-                "description": "JumpCloud authentication",
+                "description": "⚠️ DEPRECATED: JumpCloud SAML authentication is deprecated. Migrate to unified 'saml' strategy with preset: 'jumpcloud'. See: docs/meshcentral/authentication/migration-guide.md",
+                "deprecated": true,
                 "properties": {
                   "callbackurl": {
                     "type": "string",
@@ -3386,7 +3391,47 @@
                   },
                   "cert": {
                     "type": "string",
-                    "description": "SAML certificate."
+                    "description": "SAML certificate file path (relative to meshcentral-data directory)."
+                  },
+                  "preset": {
+                    "type": "string",
+                    "enum": ["azure", "okta", "onelogin", "jumpcloud", "auth0", "keycloak", "adfs", "pingfederate", "google", "intel", "generic"],
+                    "description": "SAML provider preset for optimized configuration."
+                  },
+                  "groups": {
+                    "type": "object",
+                    "description": "SAML group synchronization settings",
+                    "properties": {
+                      "attribute": {
+                        "type": "string",
+                        "description": "SAML assertion attribute name containing group memberships (default: 'groups')",
+                        "default": "groups"
+                      },
+                      "required": {
+                        "type": "array",
+                        "description": "User must be in at least one of these groups to log in",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "siteadmin": {
+                        "type": "array",
+                        "description": "Users in these groups will be granted site admin privileges",
+                        "items": {
+                          "type": "string"
+                        }
+                      },
+                      "sync": {
+                        "type": "boolean",
+                        "description": "Sync IdP groups to MeshCentral user groups",
+                        "default": false
+                      },
+                      "revokeAdmin": {
+                        "type": "boolean",
+                        "description": "Revoke site admin if user leaves admin group",
+                        "default": true
+                      }
+                    }
                   },
                   "logouturl": {
                     "type": "string",
@@ -3791,12 +3836,33 @@
                         "description": "Preset to use for OIDC configuration",
                         "enum": [
                           "azure",
-                          "google"
+                          "google",
+                          "github",
+                          "twitter",
+                          "okta",
+                          "auth0",
+                          "keycloak"
                         ]
                       },
                       "tenant_id": {
                         "type": "string",
-                        "description": "REQUIRED FOR AZURE PRESET: Tenantid for Azure"
+                        "description": "REQUIRED FOR AZURE PRESET: Tenant ID for Azure AD"
+                      },
+                      "org_domain": {
+                        "type": "string",
+                        "description": "REQUIRED FOR OKTA PRESET: Organization domain (e.g., 'company.okta.com')"
+                      },
+                      "domain": {
+                        "type": "string",
+                        "description": "REQUIRED FOR AUTH0 PRESET: Auth0 domain (e.g., 'company.auth0.com' or 'company.us.auth0.com')"
+                      },
+                      "server_url": {
+                        "type": "string",
+                        "description": "REQUIRED FOR KEYCLOAK PRESET: Keycloak server URL (e.g., 'https://keycloak.company.com')"
+                      },
+                      "realm": {
+                        "type": "string",
+                        "description": "REQUIRED FOR KEYCLOAK PRESET: Keycloak realm name"
                       },
                       "customer_id": {
                         "type": "string",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "1.1.48",
       "license": "Apache-2.0",
       "dependencies": {
+        "@node-saml/node-saml": "^5.0.0",
+        "@node-saml/passport-saml": "^5.0.0",
         "@seald-io/nedb": "4.0.4",
         "archiver": "7.0.1",
         "body-parser": "1.20.3",
@@ -19,9 +21,12 @@
         "express-handlebars": "7.1.3",
         "express-ws": "5.0.2",
         "ipcheck": "0.1.0",
+        "loadavg-windows": "1.1.1",
         "minimist": "1.2.8",
         "multiparty": "4.2.3",
         "node-forge": "1.3.1",
+        "node-windows": "0.1.14",
+        "otplib": "12.0.1",
         "ua-client-hints-js": "0.1.2",
         "ua-parser-js": "1.0.40",
         "ws": "8.18.0",
@@ -32,6 +37,13 @@
       },
       "engines": {
         "node": ">=16.0.0"
+      },
+      "optionalDependencies": {
+        "passport-azure-oauth2": "^0.2.0",
+        "passport-github2": "^0.1.12",
+        "passport-google-oauth20": "^2.0.0",
+        "passport-saml": "^3.2.4",
+        "passport-twitter": "^1.0.4"
       }
     },
     "node_modules/@isaacs/cliui": {
@@ -49,6 +61,116 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@node-saml/node-saml": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@node-saml/node-saml/-/node-saml-5.1.0.tgz",
+      "integrity": "sha512-t3cJnZ4aC7HhPZ6MGylGZULvUtBOZ6FzuUndaHGXjmIZHXnLfC/7L8a57O9Q9V7AxJGKAiRM5zu2wNm9EsvQpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.1.12",
+        "@types/qs": "^6.9.18",
+        "@types/xml-encryption": "^1.2.4",
+        "@types/xml2js": "^0.4.14",
+        "@xmldom/is-dom-node": "^1.0.1",
+        "@xmldom/xmldom": "^0.8.10",
+        "debug": "^4.4.0",
+        "xml-crypto": "^6.1.2",
+        "xml-encryption": "^3.1.0",
+        "xml2js": "^0.6.2",
+        "xmlbuilder": "^15.1.1",
+        "xpath": "^0.0.34"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@node-saml/node-saml/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@node-saml/node-saml/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/@node-saml/passport-saml": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@node-saml/passport-saml/-/passport-saml-5.1.0.tgz",
+      "integrity": "sha512-pBm+iFjv9eihcgeJuSUs4c0AuX1QEFdHwP8w1iaWCfDzXdeWZxUBU5HT2bY2S4dvNutcy+A9hYsH7ZLBGtgwDg==",
+      "license": "MIT",
+      "dependencies": {
+        "@node-saml/node-saml": "^5.1.0",
+        "@types/express": "^4.17.23",
+        "@types/passport": "^1.0.17",
+        "@types/passport-strategy": "^0.2.38",
+        "passport": "^0.7.0",
+        "passport-strategy": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/@otplib/core": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@otplib/core/-/core-12.0.1.tgz",
+      "integrity": "sha512-4sGntwbA/AC+SbPhbsziRiD+jNDdIzsZ3JUyfZwjtKyc/wufl1pnSIaG4Uqx8ymPagujub0o92kgBnB89cuAMA==",
+      "license": "MIT"
+    },
+    "node_modules/@otplib/plugin-crypto": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@otplib/plugin-crypto/-/plugin-crypto-12.0.1.tgz",
+      "integrity": "sha512-qPuhN3QrT7ZZLcLCyKOSNhuijUi9G5guMRVrxq63r9YNOxxQjPm59gVxLM+7xGnHnM6cimY57tuKsjK7y9LM1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@otplib/core": "^12.0.1"
+      }
+    },
+    "node_modules/@otplib/plugin-thirty-two": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@otplib/plugin-thirty-two/-/plugin-thirty-two-12.0.1.tgz",
+      "integrity": "sha512-MtT+uqRso909UkbrrYpJ6XFjj9D+x2Py7KjTO9JDPhL0bJUYVu5kFP4TFZW4NFAywrAtFRxOVY261u0qwb93gA==",
+      "license": "MIT",
+      "dependencies": {
+        "@otplib/core": "^12.0.1",
+        "thirty-two": "^1.0.2"
+      }
+    },
+    "node_modules/@otplib/preset-default": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@otplib/preset-default/-/preset-default-12.0.1.tgz",
+      "integrity": "sha512-xf1v9oOJRyXfluBhMdpOkr+bsE+Irt+0D5uHtvg6x1eosfmHCsCC6ej/m7FXiWqdo0+ZUI6xSKDhJwc8yfiOPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@otplib/core": "^12.0.1",
+        "@otplib/plugin-crypto": "^12.0.1",
+        "@otplib/plugin-thirty-two": "^12.0.1"
+      }
+    },
+    "node_modules/@otplib/preset-v11": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/@otplib/preset-v11/-/preset-v11-12.0.1.tgz",
+      "integrity": "sha512-9hSetMI7ECqbFiKICrNa4w70deTUfArtwXykPUvSHWOdzOlfa9ajglu7mNCntlvxycTiOAXkQGwjQCzzDEMRMg==",
+      "license": "MIT",
+      "dependencies": {
+        "@otplib/core": "^12.0.1",
+        "@otplib/plugin-crypto": "^12.0.1",
+        "@otplib/plugin-thirty-two": "^12.0.1"
       }
     },
     "node_modules/@pkgjs/parseargs": {
@@ -75,6 +197,182 @@
         "@seald-io/binary-search-tree": "^1.0.3",
         "localforage": "^1.9.0",
         "util": "^0.12.4"
+      }
+    },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/debug": {
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
+      "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
+    "node_modules/@types/express": {
+      "version": "4.17.25",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.25.tgz",
+      "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.33",
+        "@types/qs": "*",
+        "@types/serve-static": "^1"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "4.19.7",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.7.tgz",
+      "integrity": "sha512-FvPtiIf1LfhzsaIXhv/PHan/2FeQBbtBDtfX2QfvPxdUelMDEckK08SM6nqo1MIZY3RUlfA+HV8+hFUSio78qg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/mime": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.10.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.0.tgz",
+      "integrity": "sha512-qzQZRBqkFsYyaSWXuEHc2WR9c0a0CXwiE5FWUvn7ZM+vdy1uZLfCunD38UzhuB7YN/J11ndbDBcTmOdxJo9Q7A==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@types/passport": {
+      "version": "1.0.17",
+      "resolved": "https://registry.npmjs.org/@types/passport/-/passport-1.0.17.tgz",
+      "integrity": "sha512-aciLyx+wDwT2t2/kJGJR2AEeBz0nJU4WuRX04Wu9Dqc5lSUtwu0WERPHYsLhF9PtseiAMPBGNUOtFjxZ56prsg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*"
+      }
+    },
+    "node_modules/@types/passport-strategy": {
+      "version": "0.2.38",
+      "resolved": "https://registry.npmjs.org/@types/passport-strategy/-/passport-strategy-0.2.38.tgz",
+      "integrity": "sha512-GC6eMqqojOooq993Tmnmp7AUTbbQSgilyvpCYQjT+H6JfG/g6RGc7nXEniZlp0zyKJ0WUdOiZWLBZft9Yug1uA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/express": "*",
+        "@types/passport": "*"
+      }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-arsCikDvlU99zl1g69TcAB3mzZPpxgw0UQnaHeC1Nwb015xp8bknZv5rIfri9xTOcMuaVgvabfIRA7PSZVuZIQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "1.15.10",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.10.tgz",
+      "integrity": "sha512-tRs1dB+g8Itk72rlSI2ZrW6vZg0YrLI81iQSTkMmOqnqCaNr/8Ek4VwWcN5vZgCYWbg/JJSGBlUaYGAOP73qBw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*",
+        "@types/send": "<1"
+      }
+    },
+    "node_modules/@types/serve-static/node_modules/@types/send": {
+      "version": "0.17.6",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.6.tgz",
+      "integrity": "sha512-Uqt8rPBE8SY0RK8JB1EzVOIZ32uqy8HwdxCnoCOsYrvnswqmFZ/k+9Ikidlk/ImhsdvBsloHbAlewb2IEBV/Og==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/xml-encryption": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@types/xml-encryption/-/xml-encryption-1.2.4.tgz",
+      "integrity": "sha512-I69K/WW1Dv7j6O3jh13z0X8sLWJRXbu5xnHDl9yHzUNDUBtUoBY058eb5s+x/WG6yZC1h8aKdI2EoyEPjyEh+Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/xml2js": {
+      "version": "0.4.14",
+      "resolved": "https://registry.npmjs.org/@types/xml2js/-/xml2js-0.4.14.tgz",
+      "integrity": "sha512-4YnrRemBShWRO2QjvUin8ESA41rH+9nQGLUGZV/1IDhi3SL9OhdpNC/MrulTWuptXKwhx/aDxE7toV0f/ypIXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@xmldom/is-dom-node": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@xmldom/is-dom-node/-/is-dom-node-1.0.1.tgz",
+      "integrity": "sha512-CJDxIgE5I0FH+ttq/Fxy6nRpxP70+e2O048EPe85J2use3XKdatVM7dDVvFNjQudd9B49NPoZ+8PG49zj4Er8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.8.11",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.11.tgz",
+      "integrity": "sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/abort-controller": {
@@ -236,6 +534,16 @@
         }
       ],
       "license": "MIT"
+    },
+    "node_modules/base64url": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/base64url/-/base64url-3.0.1.tgz",
+      "integrity": "sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/bignumber.js": {
       "version": "9.3.1",
@@ -723,6 +1031,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
       "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -1317,6 +1626,15 @@
         "immediate": "~3.0.5"
       }
     },
+    "node_modules/loadavg-windows": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/loadavg-windows/-/loadavg-windows-1.1.1.tgz",
+      "integrity": "sha512-ncSyH121LuN6OENPSohTAS2W85J3NYVIfjsVcK4spViQbHlQUXhGKd8VYhrqWyjtwwSTw4g3rrDraNoSJWRLgw==",
+      "license": "MIT",
+      "dependencies": {
+        "weak-daemon": "1.0.3"
+      }
+    },
     "node_modules/localforage": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
@@ -1527,6 +1845,19 @@
         "node": ">= 6.13.0"
       }
     },
+    "node_modules/node-windows": {
+      "version": "0.1.14",
+      "resolved": "https://registry.npmjs.org/node-windows/-/node-windows-0.1.14.tgz",
+      "integrity": "sha512-2sz0i+ckeX/+22Z4KcDVis1ukyGOYZWx2WG9nQYauUwzIxEye5QcMrExkH7OaRSHkwM5bN/jesxsiQqkUb1O/w==",
+      "license": "MIT",
+      "os": [
+        "win32"
+      ],
+      "dependencies": {
+        "optimist": "~0.6.0",
+        "xml": "0.0.12"
+      }
+    },
     "node_modules/nofilter": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/nofilter/-/nofilter-1.0.4.tgz",
@@ -1544,6 +1875,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/oauth": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.10.2.tgz",
+      "integrity": "sha512-JtFnB+8nxDEXgNyniwz573xxbKSOu3R8D40xQKqcjwJ2CDkYqUDI53o6IuzDJBx60Z8VKCm271+t8iFjakrl8Q==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/object-inspect": {
       "version": "1.13.4",
@@ -1578,6 +1916,42 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/optimist": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "integrity": "sha512-snN4O4TkigujZphWLN0E//nQmm7790RYaE53DdL7ZYwee2D8DDo9/EyYiKUfN3rneWUjhJnueija3G9I2i0h3g==",
+      "license": "MIT/X11",
+      "dependencies": {
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
+      }
+    },
+    "node_modules/optimist/node_modules/minimist": {
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.10.tgz",
+      "integrity": "sha512-iotkTvxc+TwOm5Ieim8VnSNvCDjCK9S8G3scJ50ZthspSxa7jx50jkhYduuAtAjvfDUwSgOwf8+If99AlOEhyw==",
+      "license": "MIT"
+    },
+    "node_modules/optimist/node_modules/wordwrap": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+      "integrity": "sha512-1tMA907+V4QmxV7dbRvb4/8MaRALK6q9Abid3ndMYnbyo8piisCmeONVqVSXqQA3KaP4SLt5b7ud6E2sqP8TFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/otplib": {
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/otplib/-/otplib-12.0.1.tgz",
+      "integrity": "sha512-xDGvUOQjop7RDgxTQ+o4pOol0/3xSZzawTiPKRrHnQWAy0WjhNs/5HdIDJCrqC4MBynmjXgULc6YfioaxZeFgg==",
+      "license": "MIT",
+      "dependencies": {
+        "@otplib/core": "^12.0.1",
+        "@otplib/preset-default": "^12.0.1",
+        "@otplib/preset-v11": "^12.0.1"
+      }
+    },
     "node_modules/package-json-from-dist": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
@@ -1591,6 +1965,240 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/passport": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/passport/-/passport-0.7.0.tgz",
+      "integrity": "sha512-cPLl+qZpSc+ireUvt+IzqbED1cHHkDoVYMo30jbJIdOOjQ1MQYZBPiNvmi8UM6lJuOpTPXJGZQk0DtC4y61MYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "passport-strategy": "1.x.x",
+        "pause": "0.0.1",
+        "utils-merge": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jaredhanson"
+      }
+    },
+    "node_modules/passport-azure-oauth2": {
+      "optional": true
+    },
+    "node_modules/passport-github2": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/passport-github2/-/passport-github2-0.1.12.tgz",
+      "integrity": "sha512-3nPUCc7ttF/3HSP/k9sAXjz3SkGv5Nki84I05kSQPo01Jqq1NzJACgMblCK0fGcv9pKCG/KXU3AJRDGLqHLoIw==",
+      "optional": true,
+      "dependencies": {
+        "passport-oauth2": "1.x.x"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/passport-google-oauth20": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/passport-google-oauth20/-/passport-google-oauth20-2.0.0.tgz",
+      "integrity": "sha512-KSk6IJ15RoxuGq7D1UKK/8qKhNfzbLeLrG3gkLZ7p4A6DBCcv7xpyQwuXtWdpyR0+E0mwkpjY1VfPOhxQrKzdQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "passport-oauth2": "1.x.x"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/passport-oauth1": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/passport-oauth1/-/passport-oauth1-1.3.0.tgz",
+      "integrity": "sha512-8T/nX4gwKTw0PjxP1xfD0QhrydQNakzeOpZ6M5Uqdgz9/a/Ag62RmJxnZQ4LkbdXGrRehQHIAHNAu11rCP46Sw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "oauth": "0.9.x",
+        "passport-strategy": "1.x.x",
+        "utils-merge": "1.x.x"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jaredhanson"
+      }
+    },
+    "node_modules/passport-oauth1/node_modules/oauth": {
+      "version": "0.9.15",
+      "resolved": "https://registry.npmjs.org/oauth/-/oauth-0.9.15.tgz",
+      "integrity": "sha512-a5ERWK1kh38ExDEfoO6qUHJb32rd7aYmPHuyCu3Fta/cnICvYmgd2uhuKXvPD+PXB+gCEYYEaQdIRAjCOwAKNA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/passport-oauth2": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/passport-oauth2/-/passport-oauth2-1.8.0.tgz",
+      "integrity": "sha512-cjsQbOrXIDE4P8nNb3FQRCCmJJ/utnFKEz2NX209f7KOHPoX18gF7gBzBbLLsj2/je4KrgiwLLGjf0lm9rtTBA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "base64url": "3.x.x",
+        "oauth": "0.10.x",
+        "passport-strategy": "1.x.x",
+        "uid2": "0.0.x",
+        "utils-merge": "1.x.x"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/jaredhanson"
+      }
+    },
+    "node_modules/passport-saml": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/passport-saml/-/passport-saml-3.2.4.tgz",
+      "integrity": "sha512-JSgkFXeaexLNQh1RrOvJAgjLnZzH/S3HbX/mWAk+i7aulnjqUe7WKnPl1NPnJWqP7Dqsv0I2Xm6KIFHkftk0HA==",
+      "deprecated": "For versions >= 4, please use scopped package @node-saml/passport-saml",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@xmldom/xmldom": "^0.7.6",
+        "debug": "^4.3.2",
+        "passport-strategy": "^1.0.0",
+        "xml-crypto": "^2.1.3",
+        "xml-encryption": "^2.0.0",
+        "xml2js": "^0.4.23",
+        "xmlbuilder": "^15.1.1"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/passport-saml/node_modules/@xmldom/xmldom": {
+      "version": "0.7.13",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.7.13.tgz",
+      "integrity": "sha512-lm2GW5PkosIzccsaZIz7tp8cPADSIlIHWDFTR1N0SzfinhhYgeIQjFMz4rYzanCScr3DqQLeomUDArp6MWKm+g==",
+      "deprecated": "this version is no longer supported, please update to at least 0.8.*",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/passport-saml/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/passport-saml/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/passport-saml/node_modules/xml-crypto": {
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/xml-crypto/-/xml-crypto-2.1.6.tgz",
+      "integrity": "sha512-jjvpO8vHNV8QFhW5bMypP+k4BjBqHe/HrpIwpPcdUnUTIJakSIuN96o3Sdah4tKu2z64kM/JHEH8iEHGCc6Gyw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@xmldom/xmldom": "^0.7.9",
+        "xpath": "0.0.32"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/passport-saml/node_modules/xml-encryption": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/xml-encryption/-/xml-encryption-2.0.0.tgz",
+      "integrity": "sha512-4Av83DdvAgUQQMfi/w8G01aJshbEZP9ewjmZMpS9t3H+OCZBDvyK4GJPnHGfWiXlArnPbYvR58JB9qF2x9Ds+Q==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@xmldom/xmldom": "^0.7.0",
+        "escape-html": "^1.0.3",
+        "xpath": "0.0.32"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/passport-saml/node_modules/xml2js": {
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.23.tgz",
+      "integrity": "sha512-ySPiMjM0+pLDftHgXY4By0uswI3SPKLDw/i3UXbnO8M/p28zqexCUoPmQFrYD+/1BzhGJSs2i1ERWKJAtiLrug==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/passport-saml/node_modules/xml2js/node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/passport-saml/node_modules/xpath": {
+      "version": "0.0.32",
+      "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.32.tgz",
+      "integrity": "sha512-rxMJhSIoiO8vXcWvSifKqhvV96GjiD5wYb8/QHdoRyQvraTpp4IEv944nhGausZZ3u7dhQXteZuZbaqfpB7uYw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "node_modules/passport-strategy": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/passport-strategy/-/passport-strategy-1.0.0.tgz",
+      "integrity": "sha512-CB97UUvDKJde2V0KDWWB3lyf6PC3FaZP7YxZ2G8OAtn9p4HI9j9JLP9qjOGZFvyl8uwNT8qM+hGnz/n16NI7oA==",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/passport-twitter": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/passport-twitter/-/passport-twitter-1.0.4.tgz",
+      "integrity": "sha512-qvdauqCqCJJci82mJ9hZZQ6nAv7aSHV31svL8+9H7mRlDdXCdfU6AARQrmmJu3DRmv9fvIebM7zzxR7mVufN3A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "passport-oauth1": "1.x.x",
+        "xtraverse": "0.1.x"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
       }
     },
     "node_modules/path-key": {
@@ -1623,6 +2231,11 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
       "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
       "license": "MIT"
+    },
+    "node_modules/pause": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/pause/-/pause-0.0.1.tgz",
+      "integrity": "sha512-KG8UEiEVkR3wGEb4m5yZkVCzigAD+cVEJck2CzYZO37ZGJfctvVptVO192MwrtPhzONn6go8ylnOdMhKqi4nfg=="
     },
     "node_modules/pend": {
       "version": "1.2.0",
@@ -1794,6 +2407,12 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/sax": {
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.3.tgz",
+      "integrity": "sha512-yqYn1JhPczigF94DMS+shiDMjDowYO6y9+wB/4WgO0Y19jWYk0lQ4tuG5KI7kj4FTp1wxPj5IFfcrz/s1c3jjQ==",
+      "license": "BlueOak-1.0.0"
     },
     "node_modules/send": {
       "version": "0.19.0",
@@ -2133,6 +2752,14 @@
         "b4a": "^1.6.4"
       }
     },
+    "node_modules/thirty-two": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/thirty-two/-/thirty-two-1.0.2.tgz",
+      "integrity": "sha512-OEI0IWCe+Dw46019YLl6V10Us5bi574EvlJEOcAkB29IzQ/mYD1A6RyNHLjZPiHCmuodxvgF6U+vZO1L15lxVA==",
+      "engines": {
+        "node": ">=0.2.6"
+      }
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -2235,6 +2862,19 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/uid2": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.4.tgz",
+      "integrity": "sha512-IevTus0SbGwQzYh3+fRsAMTVVPOoIVufzacXcHPmdlle1jUpq7BRL+mw3dgeLanvGZdwwbWhRV6XrcFNdBmjWA==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/undici-types": {
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "license": "MIT"
+    },
     "node_modules/unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
@@ -2279,6 +2919,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/weak-daemon": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/weak-daemon/-/weak-daemon-1.0.3.tgz",
+      "integrity": "sha512-9OLYp5qQSxpnTIyuA1zJ7at3DV2DSBcbdXduC/3QFPeYjF30Lh1nfBrG+VLf4QUvZPz2lXFPu08oIRzWQfucVQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.8.7"
       }
     },
     "node_modules/which": {
@@ -2433,6 +3082,120 @@
         "utf-8-validate": {
           "optional": true
         }
+      }
+    },
+    "node_modules/xml": {
+      "version": "0.0.12",
+      "resolved": "https://registry.npmjs.org/xml/-/xml-0.0.12.tgz",
+      "integrity": "sha512-vXz2nTtS+bQYemYFzbTxjlmdMOmIhmP+frdnJi3M2Ul/ezrwcW9IYwiwqvecY3PtHNXGKBDrA+DNAEky0zY7Xg==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/xml-crypto": {
+      "version": "6.1.2",
+      "resolved": "https://registry.npmjs.org/xml-crypto/-/xml-crypto-6.1.2.tgz",
+      "integrity": "sha512-leBOVQdVi8FvPJrMYoum7Ici9qyxfE4kVi+AkpUoYCSXaQF4IlBm1cneTK9oAxR61LpYxTx7lNcsnBIeRpGW2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@xmldom/is-dom-node": "^1.0.1",
+        "@xmldom/xmldom": "^0.8.10",
+        "xpath": "^0.0.33"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/xml-crypto/node_modules/xpath": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.33.tgz",
+      "integrity": "sha512-NNXnzrkDrAzalLhIUc01jO2mOzXGXh1JwPgkihcLLzw98c0WgYDmmjSh1Kl3wzaxSVWMuA+fe0WTWOBDWCBmNA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "node_modules/xml-encryption": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/xml-encryption/-/xml-encryption-3.1.0.tgz",
+      "integrity": "sha512-PV7qnYpoAMXbf1kvQkqMScLeQpjCMixddAKq9PtqVrho8HnYbBOWNfG0kA4R7zxQDo7w9kiYAyzS/ullAyO55Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@xmldom/xmldom": "^0.8.5",
+        "escape-html": "^1.0.3",
+        "xpath": "0.0.32"
+      }
+    },
+    "node_modules/xml-encryption/node_modules/xpath": {
+      "version": "0.0.32",
+      "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.32.tgz",
+      "integrity": "sha512-rxMJhSIoiO8vXcWvSifKqhvV96GjiD5wYb8/QHdoRyQvraTpp4IEv944nhGausZZ3u7dhQXteZuZbaqfpB7uYw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "node_modules/xml2js": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.6.2.tgz",
+      "integrity": "sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==",
+      "license": "MIT",
+      "dependencies": {
+        "sax": ">=0.6.0",
+        "xmlbuilder": "~11.0.0"
+      },
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
+    "node_modules/xml2js/node_modules/xmlbuilder": {
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
+      "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
+      "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/xmldom": {
+      "version": "0.1.31",
+      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.31.tgz",
+      "integrity": "sha512-yS2uJflVQs6n+CyjHoaBmVSqIDevTAWrzMmjG1Gc7h1qQ7uVozNhEPJAwZXWyGQ/Gafo3fCwrcaokezLPupVyQ==",
+      "deprecated": "Deprecated due to CVE-2021-21366 resolved in 0.5.0",
+      "license": "(LGPL-2.0 or MIT)",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1"
+      }
+    },
+    "node_modules/xpath": {
+      "version": "0.0.34",
+      "resolved": "https://registry.npmjs.org/xpath/-/xpath-0.0.34.tgz",
+      "integrity": "sha512-FxF6+rkr1rNSQrhUNYrAFJpRXNzlDoMxeXN5qI84939ylEv3qqPFKa85Oxr6tDaJKqwW6KKyo2v26TSv3k6LeA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "node_modules/xtraverse": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xtraverse/-/xtraverse-0.1.0.tgz",
+      "integrity": "sha512-MANQdlG2hl1nQobxz1Rv8hsS1RuBS0C1N6qTOupv+9vmfrReePdxhmB2ecYjvsp4stJ80HD7erjkoF1Hd/FK9A==",
+      "optional": true,
+      "dependencies": {
+        "xmldom": "0.1.x"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
       }
     },
     "node_modules/yauzl": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,8 @@
     "sample-config-advanced.json"
   ],
   "dependencies": {
+    "@node-saml/node-saml": "^5.0.0",
+    "@node-saml/passport-saml": "^5.0.0",
     "@seald-io/nedb": "4.0.4",
     "archiver": "7.0.1",
     "body-parser": "1.20.3",
@@ -47,9 +49,12 @@
     "express-handlebars": "7.1.3",
     "express-ws": "5.0.2",
     "ipcheck": "0.1.0",
+    "loadavg-windows": "1.1.1",
     "minimist": "1.2.8",
     "multiparty": "4.2.3",
     "node-forge": "1.3.1",
+    "node-windows": "0.1.14",
+    "otplib": "12.0.1",
     "ua-client-hints-js": "0.1.2",
     "ua-parser-js": "1.0.40",
     "ws": "8.18.0",

--- a/views/login-mobile.handlebars
+++ b/views/login-mobile.handlebars
@@ -85,16 +85,30 @@
                                     <div id="authStrategies" style="display:none">
                                         <hr />
                                         <div style="margin-bottom:8px">Log in using an existing account</div>
-                                        <a id="auth-twitter" href="auth-twitter" style="display:none"><img src="images/login/twitter32.png" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign-in using Twitter" /></a>
-                                        <a id="auth-google" href="auth-google" style="display:none"><img src="images/login/google32.png" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign-in using Google" /></a>
-                                        <a id="auth-github" href="auth-github" style="display:none"><img src="images/login/github32.png" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign-in using GitHub" /></a>
-                                        <a id="auth-azure" href="auth-azure" style="display:none"><img src="images/login/azure32.png" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign-in using Azure" /></a>
-                                        <a id="auth-oidc" href="auth-oidc" style="display:none"><img src="images/login/oidc32.png" srcset="images/login/oidc64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign-in using OpenID Connect" /></a>
-                                        <a id="auth-oidc-azure" href="auth-oidc" style="display:none"><img src="images/login/azure32.png" srcset="images/login/azure64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign-in with Azure using OpenID Connect" /></a>
-                                        <a id="auth-oidc-google" href="auth-oidc" style="display:none"><img src="images/login/google32.png" srcset="images/login/google64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign-in with Google using OpenID Connect" /></a>
-                                        <a id="auth-jumpcloud" href="auth-jumpcloud" style="display:none"><img src="images/login/jumpcloud32.png" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign-in using JumpCloud" /></a>
-                                        <a id="auth-intel" href="auth-intel" style="display:none"><img src="images/login/intel32.png" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign-in using Intel" /></a>
-                                        <a id="auth-saml" href="auth-saml" style="display:none"><img src="images/login/generic32.png" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Single Sign-in" /></a>
+                                        
+                                        <!-- OIDC Presets -->
+                                        <a id="auth-oidc-azure" href="auth-oidc" style="display:none"><img src="images/login/azure32.png" srcset="images/login/azure64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign in with Azure" /></a>
+                                        <a id="auth-oidc-google" href="auth-oidc" style="display:none"><img src="images/login/google32.png" srcset="images/login/google64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign in with Google" /></a>
+                                        <a id="auth-oidc-okta" href="auth-oidc" style="display:none"><img src="images/login/generic32.png" srcset="images/login/generic64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign in with Okta" /></a>
+                                        <a id="auth-oidc-auth0" href="auth-oidc" style="display:none"><img src="images/login/generic32.png" srcset="images/login/generic64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign in with Auth0" /></a>
+                                        <a id="auth-oidc-keycloak" href="auth-oidc" style="display:none"><img src="images/login/generic32.png" srcset="images/login/generic64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign in with Keycloak" /></a>
+                                        <a id="auth-oidc-github" href="auth-oidc" style="display:none"><img src="images/login/github32.png" srcset="images/login/github64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign in with GitHub" /></a>
+                                        <a id="auth-oidc-twitter" href="auth-oidc" style="display:none"><img src="images/login/twitter32.png" srcset="images/login/twitter64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign in with Twitter" /></a>
+                                        <a id="auth-oidc" href="auth-oidc" style="display:none"><img src="images/login/oidc32.png" srcset="images/login/oidc64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign in with OpenID Connect" /></a>
+                                        
+                                        <!-- SAML Presets -->
+                                        <a id="auth-saml-azure" href="auth-saml" style="display:none"><img src="images/login/azure32.png" srcset="images/login/azure64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign in with Azure SAML" /></a>
+                                        <a id="auth-saml-okta" href="auth-saml" style="display:none"><img src="images/login/generic32.png" srcset="images/login/generic64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign in with Okta" /></a>
+                                        <a id="auth-saml-onelogin" href="auth-saml" style="display:none"><img src="images/login/generic32.png" srcset="images/login/generic64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign in with OneLogin" /></a>
+                                        <a id="auth-saml-jumpcloud" href="auth-saml" style="display:none"><img src="images/login/jumpcloud32.png" srcset="images/login/jumpcloud64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign in with JumpCloud" /></a>
+                                        <a id="auth-saml-auth0" href="auth-saml" style="display:none"><img src="images/login/generic32.png" srcset="images/login/generic64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign in with Auth0 SAML" /></a>
+                                        <a id="auth-saml-keycloak" href="auth-saml" style="display:none"><img src="images/login/generic32.png" srcset="images/login/generic64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign in with Keycloak SAML" /></a>
+                                        <a id="auth-saml-adfs" href="auth-saml" style="display:none"><img src="images/login/generic32.png" srcset="images/login/generic64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign in with ADFS" /></a>
+                                        <a id="auth-saml-pingfederate" href="auth-saml" style="display:none"><img src="images/login/generic32.png" srcset="images/login/generic64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign in with PingFederate" /></a>
+                                        <a id="auth-saml-google" href="auth-saml" style="display:none"><img src="images/login/google32.png" srcset="images/login/google64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign in with Google Workspace" /></a>
+                                        <a id="auth-saml-intel" href="auth-saml" style="display:none"><img src="images/login/intel32.png" srcset="images/login/intel64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign in with Intel" /></a>
+                                        <a id="auth-saml-generic" href="auth-saml" style="display:none"><img src="images/login/generic32.png" srcset="images/login/generic64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Single Sign-On" /></a>
+                                        <a id="auth-saml" href="auth-saml" style="display:none"><img src="images/login/generic32.png" srcset="images/login/generic64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Single Sign-On" /></a>
                                     </div>
                                 </form>
                             </div>
@@ -408,16 +422,30 @@
             // Setup authentication strategies
             if (authStrategies != '') {
                 QV('authStrategies', true);
-                if (authStrategies.indexOf('twitter') >= 0) { QV('auth-twitter', true); }
-                if (authStrategies.indexOf('google') >= 0) { QV('auth-google', true); }
-                if (authStrategies.indexOf('github') >= 0) { QV('auth-github', true); }
-                if (authStrategies.indexOf('azure') >= 0) { QV('auth-azure', true); }
-                if (authStrategies.indexOf('oidc') >= 0) { QV('auth-oidc', true); }
+                
+                // OIDC presets
                 if (authStrategies.indexOf('oidc-azure') >= 0) { QV('auth-oidc-azure', true); }
-                if (authStrategies.indexOf('oidc-google') >= 0) { QV('auth-oidc-google', true); }
-                if (authStrategies.indexOf('jumpcloud') >= 0) { QV('auth-jumpcloud', true); }
-                if (authStrategies.indexOf('intel') >= 0) { QV('auth-intel', true); }
-                if (authStrategies.indexOf('saml') >= 0) { QV('auth-saml', true); }
+                else if (authStrategies.indexOf('oidc-google') >= 0) { QV('auth-oidc-google', true); }
+                else if (authStrategies.indexOf('oidc-okta') >= 0) { QV('auth-oidc-okta', true); }
+                else if (authStrategies.indexOf('oidc-auth0') >= 0) { QV('auth-oidc-auth0', true); }
+                else if (authStrategies.indexOf('oidc-keycloak') >= 0) { QV('auth-oidc-keycloak', true); }
+                else if (authStrategies.indexOf('oidc-github') >= 0) { QV('auth-oidc-github', true); }
+                else if (authStrategies.indexOf('oidc-twitter') >= 0) { QV('auth-oidc-twitter', true); }
+                else if (authStrategies.indexOf('oidc') >= 0) { QV('auth-oidc', true); }
+                
+                // SAML presets
+                if (authStrategies.indexOf('saml-azure') >= 0) { QV('auth-saml-azure', true); }
+                else if (authStrategies.indexOf('saml-okta') >= 0) { QV('auth-saml-okta', true); }
+                else if (authStrategies.indexOf('saml-onelogin') >= 0) { QV('auth-saml-onelogin', true); }
+                else if (authStrategies.indexOf('saml-jumpcloud') >= 0) { QV('auth-saml-jumpcloud', true); }
+                else if (authStrategies.indexOf('saml-auth0') >= 0) { QV('auth-saml-auth0', true); }
+                else if (authStrategies.indexOf('saml-keycloak') >= 0) { QV('auth-saml-keycloak', true); }
+                else if (authStrategies.indexOf('saml-adfs') >= 0) { QV('auth-saml-adfs', true); }
+                else if (authStrategies.indexOf('saml-pingfederate') >= 0) { QV('auth-saml-pingfederate', true); }
+                else if (authStrategies.indexOf('saml-google') >= 0) { QV('auth-saml-google', true); }
+                else if (authStrategies.indexOf('saml-intel') >= 0) { QV('auth-saml-intel', true); }
+                else if (authStrategies.indexOf('saml-generic') >= 0) { QV('auth-saml-generic', true); }
+                else if (authStrategies.indexOf('saml') >= 0) { QV('auth-saml', true); }
             }
 
             window.onresize = center;

--- a/views/login.handlebars
+++ b/views/login.handlebars
@@ -78,16 +78,30 @@
                                 <div id="authStrategies" style="display:none">
                                     <hr id="loginuserpasshr" style="display:none" />
                                     <div style="margin-bottom:8px">Log in using an existing account</div>
-                                    <a id="auth-twitter" href="auth-twitter" style="display:none"><img src="images/login/twitter32.png" srcset="images/login/twitter64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign-in using Twitter" /></a>
-                                    <a id="auth-google" href="auth-google" style="display:none"><img src="images/login/google32.png" srcset="images/login/google64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign-in using Google" /></a>
-                                    <a id="auth-github" href="auth-github" style="display:none"><img src="images/login/github32.png" srcset="images/login/github64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign-in using GitHub" /></a>
-                                    <a id="auth-azure" href="auth-azure" style="display:none"><img src="images/login/azure32.png" srcset="images/login/azure64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign-in using Azure" /></a>
-                                    <a id="auth-oidc" href="auth-oidc" style="display:none"><img src="images/login/oidc32.png" srcset="images/login/oidc64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign-in using OpenID Connect" /></a>
-                                    <a id="auth-oidc-azure" href="auth-oidc" style="display:none"><img src="images/login/azure32.png" srcset="images/login/azure64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign-in with Azure using OpenID Connect" /></a>
-                                    <a id="auth-oidc-google" href="auth-oidc" style="display:none"><img src="images/login/google32.png" srcset="images/login/google64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign-in with Google using OpenID Connect" /></a>
-                                    <a id="auth-jumpcloud" href="auth-jumpcloud" style="display:none"><img src="images/login/jumpcloud32.png" srcset="images/login/jumpcloud64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign-in using JumpCloud" /></a>
-                                    <a id="auth-intel" href="auth-intel" style="display:none"><img src="images/login/intel32.png" srcset="images/login/intel64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign-in using Intel" /></a>
-                                    <a id="auth-saml" href="auth-saml" style="display:none"><img src="images/login/generic32.png" srcset="images/login/generic64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Single Sign-in" /></a>
+                                    
+                                    <!-- OIDC Presets -->
+                                    <a id="auth-oidc-azure" href="auth-oidc" style="display:none"><img src="images/login/azure32.png" srcset="images/login/azure64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign in with Azure" /></a>
+                                    <a id="auth-oidc-google" href="auth-oidc" style="display:none"><img src="images/login/google32.png" srcset="images/login/google64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign in with Google" /></a>
+                                    <a id="auth-oidc-okta" href="auth-oidc" style="display:none"><img src="images/login/generic32.png" srcset="images/login/generic64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign in with Okta" /></a>
+                                    <a id="auth-oidc-auth0" href="auth-oidc" style="display:none"><img src="images/login/generic32.png" srcset="images/login/generic64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign in with Auth0" /></a>
+                                    <a id="auth-oidc-keycloak" href="auth-oidc" style="display:none"><img src="images/login/generic32.png" srcset="images/login/generic64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign in with Keycloak" /></a>
+                                    <a id="auth-oidc-github" href="auth-oidc" style="display:none"><img src="images/login/github32.png" srcset="images/login/github64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign in with GitHub" /></a>
+                                    <a id="auth-oidc-twitter" href="auth-oidc" style="display:none"><img src="images/login/twitter32.png" srcset="images/login/twitter64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign in with Twitter" /></a>
+                                    <a id="auth-oidc" href="auth-oidc" style="display:none"><img src="images/login/oidc32.png" srcset="images/login/oidc64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign in with OpenID Connect" /></a>
+                                    
+                                    <!-- SAML Presets -->
+                                    <a id="auth-saml-azure" href="auth-saml" style="display:none"><img src="images/login/azure32.png" srcset="images/login/azure64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign in with Azure SAML" /></a>
+                                    <a id="auth-saml-okta" href="auth-saml" style="display:none"><img src="images/login/generic32.png" srcset="images/login/generic64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign in with Okta" /></a>
+                                    <a id="auth-saml-onelogin" href="auth-saml" style="display:none"><img src="images/login/generic32.png" srcset="images/login/generic64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign in with OneLogin" /></a>
+                                    <a id="auth-saml-jumpcloud" href="auth-saml" style="display:none"><img src="images/login/jumpcloud32.png" srcset="images/login/jumpcloud64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign in with JumpCloud" /></a>
+                                    <a id="auth-saml-auth0" href="auth-saml" style="display:none"><img src="images/login/generic32.png" srcset="images/login/generic64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign in with Auth0 SAML" /></a>
+                                    <a id="auth-saml-keycloak" href="auth-saml" style="display:none"><img src="images/login/generic32.png" srcset="images/login/generic64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign in with Keycloak SAML" /></a>
+                                    <a id="auth-saml-adfs" href="auth-saml" style="display:none"><img src="images/login/generic32.png" srcset="images/login/generic64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign in with ADFS" /></a>
+                                    <a id="auth-saml-pingfederate" href="auth-saml" style="display:none"><img src="images/login/generic32.png" srcset="images/login/generic64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign in with PingFederate" /></a>
+                                    <a id="auth-saml-google" href="auth-saml" style="display:none"><img src="images/login/google32.png" srcset="images/login/google64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign in with Google Workspace" /></a>
+                                    <a id="auth-saml-intel" href="auth-saml" style="display:none"><img src="images/login/intel32.png" srcset="images/login/intel64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign in with Intel" /></a>
+                                    <a id="auth-saml-generic" href="auth-saml" style="display:none"><img src="images/login/generic32.png" srcset="images/login/generic64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Single Sign-On" /></a>
+                                    <a id="auth-saml" href="auth-saml" style="display:none"><img src="images/login/generic32.png" srcset="images/login/generic64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Single Sign-On" /></a>
                                 </div>
                             </form>
                         </div>
@@ -436,16 +450,30 @@
             // Setup authentication strategies
             if (authStrategies != '') {
                 QV('authStrategies', true);
-                if (authStrategies.indexOf('twitter') >= 0) { QV('auth-twitter', true); }
-                if (authStrategies.indexOf('google') >= 0) { QV('auth-google', true); }
-                if (authStrategies.indexOf('github') >= 0) { QV('auth-github', true); }
-                if (authStrategies.indexOf('azure') >= 0) { QV('auth-azure', true); }
-                if (authStrategies.indexOf('oidc') >= 0) { QV('auth-oidc', true); }
+                
+                // OIDC presets
                 if (authStrategies.indexOf('oidc-azure') >= 0) { QV('auth-oidc-azure', true); }
-                if (authStrategies.indexOf('oidc-google') >= 0) { QV('auth-oidc-google', true); }
-                if (authStrategies.indexOf('jumpcloud') >= 0) { QV('auth-jumpcloud', true); }
-                if (authStrategies.indexOf('intel') >= 0) { QV('auth-intel', true); }
-                if (authStrategies.indexOf('saml') >= 0) { QV('auth-saml', true); }
+                else if (authStrategies.indexOf('oidc-google') >= 0) { QV('auth-oidc-google', true); }
+                else if (authStrategies.indexOf('oidc-okta') >= 0) { QV('auth-oidc-okta', true); }
+                else if (authStrategies.indexOf('oidc-auth0') >= 0) { QV('auth-oidc-auth0', true); }
+                else if (authStrategies.indexOf('oidc-keycloak') >= 0) { QV('auth-oidc-keycloak', true); }
+                else if (authStrategies.indexOf('oidc-github') >= 0) { QV('auth-oidc-github', true); }
+                else if (authStrategies.indexOf('oidc-twitter') >= 0) { QV('auth-oidc-twitter', true); }
+                else if (authStrategies.indexOf('oidc') >= 0) { QV('auth-oidc', true); }
+                
+                // SAML presets
+                if (authStrategies.indexOf('saml-azure') >= 0) { QV('auth-saml-azure', true); }
+                else if (authStrategies.indexOf('saml-okta') >= 0) { QV('auth-saml-okta', true); }
+                else if (authStrategies.indexOf('saml-onelogin') >= 0) { QV('auth-saml-onelogin', true); }
+                else if (authStrategies.indexOf('saml-jumpcloud') >= 0) { QV('auth-saml-jumpcloud', true); }
+                else if (authStrategies.indexOf('saml-auth0') >= 0) { QV('auth-saml-auth0', true); }
+                else if (authStrategies.indexOf('saml-keycloak') >= 0) { QV('auth-saml-keycloak', true); }
+                else if (authStrategies.indexOf('saml-adfs') >= 0) { QV('auth-saml-adfs', true); }
+                else if (authStrategies.indexOf('saml-pingfederate') >= 0) { QV('auth-saml-pingfederate', true); }
+                else if (authStrategies.indexOf('saml-google') >= 0) { QV('auth-saml-google', true); }
+                else if (authStrategies.indexOf('saml-intel') >= 0) { QV('auth-saml-intel', true); }
+                else if (authStrategies.indexOf('saml-generic') >= 0) { QV('auth-saml-generic', true); }
+                else if (authStrategies.indexOf('saml') >= 0) { QV('auth-saml', true); }
             }
 
             // Display the welcome text

--- a/views/login2.handlebars
+++ b/views/login2.handlebars
@@ -102,16 +102,30 @@
                         <div id="authStrategies" style="display:none">
                             <hr id="loginuserpasshr" style="display:none" />
                             <div style="margin-bottom:8px">Log in using an existing account</div>
-                            <a id="auth-twitter" href="auth-twitter" style="display:none"><img src="images/login/twitter32.png" srcset="images/login/twitter64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign-in using Twitter" /></a>
-                            <a id="auth-google" href="auth-google" style="display:none"><img src="images/login/google32.png" srcset="images/login/google64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign-in using Google" /></a>
-                            <a id="auth-github" href="auth-github" style="display:none"><img src="images/login/github32.png" srcset="images/login/github64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign-in using GitHub" /></a>
-                            <a id="auth-azure" href="auth-azure" style="display:none"><img src="images/login/azure32.png" srcset="images/login/azure64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign-in using Azure" /></a>
-                            <a id="auth-oidc" href="auth-oidc" style="display:none"><img src="images/login/oidc32.png" srcset="images/login/oidc64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign-in using OpenID Connect" /></a>
-                            <a id="auth-oidc-azure" href="auth-oidc" style="display:none"><img src="images/login/azure32.png" srcset="images/login/azure64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign-in with Azure using OpenID Connect" /></a>
-                            <a id="auth-oidc-google" href="auth-oidc" style="display:none"><img src="images/login/google32.png" srcset="images/login/google64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign-in with Google using OpenID Connect" /></a>
-                            <a id="auth-jumpcloud" href="auth-jumpcloud" style="display:none"><img src="images/login/jumpcloud32.png" srcset="images/login/jumpcloud64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign-in using JumpCloud" /></a>
-                            <a id="auth-intel" href="auth-intel" style="display:none"><img src="images/login/intel32.png" srcset="images/login/intel64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign-in using Intel" /></a>
-                            <a id="auth-saml" href="auth-saml" style="display:none"><img src="images/login/generic32.png" srcset="images/login/generic64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Single Sign-in" /></a>
+                            
+                            <!-- OIDC Presets -->
+                            <a id="auth-oidc-azure" href="auth-oidc" style="display:none"><img src="images/login/azure32.png" srcset="images/login/azure64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign in with Azure" /></a>
+                            <a id="auth-oidc-google" href="auth-oidc" style="display:none"><img src="images/login/google32.png" srcset="images/login/google64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign in with Google" /></a>
+                            <a id="auth-oidc-okta" href="auth-oidc" style="display:none"><img src="images/login/generic32.png" srcset="images/login/generic64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign in with Okta" /></a>
+                            <a id="auth-oidc-auth0" href="auth-oidc" style="display:none"><img src="images/login/generic32.png" srcset="images/login/generic64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign in with Auth0" /></a>
+                            <a id="auth-oidc-keycloak" href="auth-oidc" style="display:none"><img src="images/login/generic32.png" srcset="images/login/generic64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign in with Keycloak" /></a>
+                            <a id="auth-oidc-github" href="auth-oidc" style="display:none"><img src="images/login/github32.png" srcset="images/login/github64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign in with GitHub" /></a>
+                            <a id="auth-oidc-twitter" href="auth-oidc" style="display:none"><img src="images/login/twitter32.png" srcset="images/login/twitter64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign in with Twitter" /></a>
+                            <a id="auth-oidc" href="auth-oidc" style="display:none"><img src="images/login/oidc32.png" srcset="images/login/oidc64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign in with OpenID Connect" /></a>
+                            
+                            <!-- SAML Presets -->
+                            <a id="auth-saml-azure" href="auth-saml" style="display:none"><img src="images/login/azure32.png" srcset="images/login/azure64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign in with Azure SAML" /></a>
+                            <a id="auth-saml-okta" href="auth-saml" style="display:none"><img src="images/login/generic32.png" srcset="images/login/generic64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign in with Okta" /></a>
+                            <a id="auth-saml-onelogin" href="auth-saml" style="display:none"><img src="images/login/generic32.png" srcset="images/login/generic64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign in with OneLogin" /></a>
+                            <a id="auth-saml-jumpcloud" href="auth-saml" style="display:none"><img src="images/login/jumpcloud32.png" srcset="images/login/jumpcloud64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign in with JumpCloud" /></a>
+                            <a id="auth-saml-auth0" href="auth-saml" style="display:none"><img src="images/login/generic32.png" srcset="images/login/generic64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign in with Auth0 SAML" /></a>
+                            <a id="auth-saml-keycloak" href="auth-saml" style="display:none"><img src="images/login/generic32.png" srcset="images/login/generic64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign in with Keycloak SAML" /></a>
+                            <a id="auth-saml-adfs" href="auth-saml" style="display:none"><img src="images/login/generic32.png" srcset="images/login/generic64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign in with ADFS" /></a>
+                            <a id="auth-saml-pingfederate" href="auth-saml" style="display:none"><img src="images/login/generic32.png" srcset="images/login/generic64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign in with PingFederate" /></a>
+                            <a id="auth-saml-google" href="auth-saml" style="display:none"><img src="images/login/google32.png" srcset="images/login/google64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign in with Google Workspace" /></a>
+                            <a id="auth-saml-intel" href="auth-saml" style="display:none"><img src="images/login/intel32.png" srcset="images/login/intel64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Sign in with Intel" /></a>
+                            <a id="auth-saml-generic" href="auth-saml" style="display:none"><img src="images/login/generic32.png" srcset="images/login/generic64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Single Sign-On" /></a>
+                            <a id="auth-saml" href="auth-saml" style="display:none"><img src="images/login/generic32.png" srcset="images/login/generic64.png 2x" loading="lazy" width="32" height="32" style="margin-left:3px;margin-right:3px;border-radius:3px;box-shadow:2px 2px 5px black;cursor:pointer" title="Single Sign-On" /></a>
                         </div>
                     </form>
                 </div>
@@ -521,16 +535,30 @@
             // Setup authentication strategies
             if (authStrategies != '') {
                 QV('authStrategies', true);
-                if (authStrategies.indexOf('twitter') >= 0) { QV('auth-twitter', true); }
-                if (authStrategies.indexOf('google') >= 0) { QV('auth-google', true); }
-                if (authStrategies.indexOf('github') >= 0) { QV('auth-github', true); }
-                if (authStrategies.indexOf('azure') >= 0) { QV('auth-azure', true); }
-                if (authStrategies.indexOf('oidc') >= 0) { QV('auth-oidc', true); }
+                
+                // OIDC presets
                 if (authStrategies.indexOf('oidc-azure') >= 0) { QV('auth-oidc-azure', true); }
-                if (authStrategies.indexOf('oidc-google') >= 0) { QV('auth-oidc-google', true); }
-                if (authStrategies.indexOf('jumpcloud') >= 0) { QV('auth-jumpcloud', true); }
-                if (authStrategies.indexOf('intel') >= 0) { QV('auth-intel', true); }
-                if (authStrategies.indexOf('saml') >= 0) { QV('auth-saml', true); }
+                else if (authStrategies.indexOf('oidc-google') >= 0) { QV('auth-oidc-google', true); }
+                else if (authStrategies.indexOf('oidc-okta') >= 0) { QV('auth-oidc-okta', true); }
+                else if (authStrategies.indexOf('oidc-auth0') >= 0) { QV('auth-oidc-auth0', true); }
+                else if (authStrategies.indexOf('oidc-keycloak') >= 0) { QV('auth-oidc-keycloak', true); }
+                else if (authStrategies.indexOf('oidc-github') >= 0) { QV('auth-oidc-github', true); }
+                else if (authStrategies.indexOf('oidc-twitter') >= 0) { QV('auth-oidc-twitter', true); }
+                else if (authStrategies.indexOf('oidc') >= 0) { QV('auth-oidc', true); }
+                
+                // SAML presets
+                if (authStrategies.indexOf('saml-azure') >= 0) { QV('auth-saml-azure', true); }
+                else if (authStrategies.indexOf('saml-okta') >= 0) { QV('auth-saml-okta', true); }
+                else if (authStrategies.indexOf('saml-onelogin') >= 0) { QV('auth-saml-onelogin', true); }
+                else if (authStrategies.indexOf('saml-jumpcloud') >= 0) { QV('auth-saml-jumpcloud', true); }
+                else if (authStrategies.indexOf('saml-auth0') >= 0) { QV('auth-saml-auth0', true); }
+                else if (authStrategies.indexOf('saml-keycloak') >= 0) { QV('auth-saml-keycloak', true); }
+                else if (authStrategies.indexOf('saml-adfs') >= 0) { QV('auth-saml-adfs', true); }
+                else if (authStrategies.indexOf('saml-pingfederate') >= 0) { QV('auth-saml-pingfederate', true); }
+                else if (authStrategies.indexOf('saml-google') >= 0) { QV('auth-saml-google', true); }
+                else if (authStrategies.indexOf('saml-intel') >= 0) { QV('auth-saml-intel', true); }
+                else if (authStrategies.indexOf('saml-generic') >= 0) { QV('auth-saml-generic', true); }
+                else if (authStrategies.indexOf('saml') >= 0) { QV('auth-saml', true); }
             }
 
             validateCreate();


### PR DESCRIPTION
# Authentication Strategy Consolidation & User Migration

## Author Note

I've had this project in the back of my mind for a long time, AI allowed me to get something built. I don't believe this is without issues, but I don't have the ability to check most of these or check migrations easily. Testing and fixing this as a community is the only way it could ever be merged. Right now I see it as a starting point or inspiration for the community to get some of these features implemented. 
PS: This PR was, besides this note, generated by AI. Sorry, I guess its the future or something.

## Summary

Consolidates 6 disparate OAuth2/SAML strategies into 2 modern implementations (OIDC + SAML) with 18 IdP presets, runtime config auto-migration, and automatic user account migration.

**Status**: ⚠️ **NEEDS TESTING** - Framework complete, requires validation before merge

## Motivation

This long-planned refactor addresses:
- **Issue #4531**: Azure OAuth2 `unique_name` instability causing duplicate accounts
- **Technical Debt**: Maintaining 6+ separate strategies with different libraries
- **Missing Features**: No preset support for common IdPs (Okta, Auth0, Keycloak, etc.)

**AI Disclosure**: Implementation framework built with GitHub Copilot assistance over one night. Design, testing requirements, and validation are manual. **Not production-ready** without thorough testing.

## Changes

### Strategy Consolidation (Breaking - Auto-Migrated)

**Removed strategies** (runtime auto-migration provided):
- `azure`, `google`, `github`, `twitter` → `oidc` with presets
- `intel`, `jumpcloud` → `saml` with presets

**Removed dependencies**:
- `passport-azure-oauth2`, `passport-google-oauth20`, `passport-github2`, `passport-twitter`, `passport-saml` v3.x

**Added dependencies**:
- `@node-saml/node-saml` ^5.1.0, `@node-saml/passport-saml` ^5.1.0

### Presets Added

**OIDC**: azure, google, okta, auth0, keycloak, github, twitter (7 total)  
**SAML**: azure, okta, onelogin, jumpcloud, auth0, keycloak, adfs, pingfederate, google, intel, generic (11 total)

### Runtime Auto-Migration

Old configs work unchanged - automatically converted in memory with console warnings. Admins can update config files at their convenience.

### User Account Migration

When users log in after auto-migration:
1. Old account looked up (e.g., `~azure:user@example.com`)
2. Deep cloned to new account (e.g., `~oidc:guid`)
3. All permissions verified and preserved
4. Old account kept as backup with `_migratedTo` metadata
5. Seamless login to new account

### Login UI Updates

All 3 login pages updated with preset-specific buttons, reusing existing icons where available.

## Testing

**Automated**: 53/53 tests passing  
**Manual**: ⚠️ **REQUIRED** - Need validation of:
- Auto-migration for all 6 deprecated strategies
- User account migration preserving permissions
- All 18 presets with real IdPs
- Multi-domain setups

## Files Modified

```
webserver.js, package.json, meshcentral-config-schema.json,
views/login*.handlebars (3 files),
docs/docs/meshcentral/authentication/* (4 new files)
```

## Breaking Changes

Old config format deprecated but **still works** via runtime auto-migration. Users automatically migrated on first login. Old accounts preserved.

## Help Needed

Need testing with real IdP configurations across all 18 presets. Don't have access to all IdPs myself.

**To test**: Checkout `auth-refactor` branch, test your IdP, report issues.

## Rollback

Safe to revert - old configs unchanged, old user accounts preserved in database.
