### PR TITLE
Added showModal support for PluginsDownload (ModernUI)

### DIFF
--- a/pluginHandler.js
+++ b/pluginHandler.js
@@ -115,8 +115,15 @@ module.exports.pluginHandler = function (parent) {
             meshserver.send({ action: 'addplugin', url: Q('pluginurlinput').value});
         };
         obj.addPluginDlg = function() {
-            setDialogMode(2, "Plugin Download URL", 3, obj.addPluginEx, '<p><b>WARNING:</b> Downloading plugins may compromise server security. Only download from trusted sources.</p><input type=text id=pluginurlinput style=width:100% placeholder="https://" />'); 
-            focusTextBox('pluginurlinput');
+            if (typeof showModal === 'function') {
+                setDialogMode(2, "Plugin Download URL", 3, obj.addPluginEx, '<p><b>WARNING:</b> Downloading plugins may compromise server security. Only download from trusted sources.</p><input type=text id=pluginurlinput style=width:100% placeholder="https://" />');
+                showModal('xxAddAgentModal', 'idx_dlgOkButton', obj.addPluginEx);
+                focusTextBox('pluginurlinput');
+            } else {
+                // Fallback to setDialogMode for default.handlebars
+                setDialogMode(2, "Plugin Download URL", 3, obj.addPluginEx, '<p><b>WARNING:</b> Downloading plugins may compromise server security. Only download from trusted sources.</p><input type=text id=pluginurlinput style=width:100% placeholder="https://" />'); 
+                focusTextBox('pluginurlinput');
+            }
         };
         obj.refreshPluginHandler = function() {
             let st = document.createElement('script');


### PR DESCRIPTION
Enhanced the addPluginDlg function to use showModal when available, ensuring compatibility with newer UI templates that rely on modal dialogs. When showModal is not present (e.g., in legacy default.handlebars environments), the function gracefully falls back to the original setDialogMode behavior.