### PR TITLE
Fix deviceViewPanel to properly initialize panel entries

### DIFF
--- a/pluginHandler.js
+++ b/pluginHandler.js
@@ -200,10 +200,12 @@ module.exports.pluginHandler = function (parent) {
     obj.deviceViewPanel = function () {
         var panel = {};
         for (var p in obj.plugins) {
-            if (typeof obj.plugins[p][hookName] == 'function') {
+            if (typeof obj.plugins[p].on_device_header === "function" && typeof obj.plugins[p].on_device_page === "function") {
                 try {
-                    panel[p].header = obj.plugins[p].on_device_header();
-                    panel[p].content = obj.plugins[p].on_device_page();
+                    panel[p] = {
+                        header: obj.plugins[p].on_device_header(),
+                        content: obj.plugins[p].on_device_page()
+                    };
                 } catch (e) {
                     console.log("Error occurred while getting plugin views " + p + ':' + ' (' + e + ')');
                 }


### PR DESCRIPTION
Corrects the logic in deviceViewPanel to ensure that each plugin's panel entry is initialized as an object with header and content properties, and checks for the existence of both on_device_header and on_device_page functions before invoking them.