### PR TITLE
Fix stray character typo in GrabKeyInput key handler

### DIFF
--- a/public/scripts/agent-desktop-0.0.2.js
+++ b/public/scripts/agent-desktop-0.0.2.js
@@ -824,7 +824,7 @@ var CreateAgentRemoteDesktop = function (canvasid, scrolldiv) {
         if (obj.xxKeyInputGrab == true) return;
         document.onkeyup = obj.xxKeyUp;
         document.onkeydown = obj.xxKeyDown;
-        document.onkeypress = obj.xxKeyPress;c
+        document.onkeypress = obj.xxKeyPress;
         obj.xxKeyInputGrab = true;
     }
 


### PR DESCRIPTION
This PR fixes a small typo in the GrabKeyInput function where an extra stray character (c) was present after the onkeypress assignment.
