### PR TITLE
Add Theme Pack Support for Custom UI Themes (Modern UI ONLY) 

### DIFF
--- a/agents/modules_meshcore/computer-identifiers.js
+++ b/agents/modules_meshcore/computer-identifiers.js
@@ -426,7 +426,8 @@ function linux_identifiers()
                     "Discharging": isDischarging,
                     "RemainingCapacity": toMilli(thedata.energy_now),
                     "Voltage": toMilli(thedata.voltage_now),
-                    "Health": (thedata.energy_now && thedata.energy_full_design ? Math.floor((thedata.energy_now / thedata.energy_full_design) * 100) : 0)
+                    "Health": (thedata.energy_full && thedata.energy_full_design ? Math.floor((thedata.energy_full / thedata.energy_full_design) * 100) : 0),
+                    "BatteryCharge": (thedata.energy_now && thedata.energy_full ? Math.floor((thedata.energy_now / thedata.energy_full) * 100) : 0)
                 };
                 values.battery.push(batteryJson);
             }
@@ -615,24 +616,42 @@ function windows_identifiers()
         }
         var values5 = require('win-wmi').query('ROOT\\WMI', "SELECT * FROM BatteryStatus",['InstanceName','ChargeRate','Charging','DischargeRate','Discharging','RemainingCapacity','Voltage']);
         var values6 = [];
-        if (values4.length > 0 && values5.length > 0) {
-            for (i = 0; i < values5.length; ++i) {
+        if (values2.length > 0 && values4.length > 0) {
+            for (i = 0; i < values2.length; ++i) {
                 for (var j = 0; j < values4.length; ++j) {
-                    if (values5[i].InstanceName == values4[j].InstanceName) {
-                        if (values4[j].DesignedCapacity && values4[j].DesignedCapacity > 0) {
+                    if (values2[i].InstanceName == values4[j].InstanceName) {
+                        if ((values4[j].DesignedCapacity && values4[j].DesignedCapacity > 0) && (values2[i].FullChargedCapacity && values2[i].FullChargedCapacity > 0)) {
                             values6[i] = { 
-                                Health: Math.floor((values5[i].RemainingCapacity / values4[j].DesignedCapacity) * 100),
-                                InstanceName: values5[i].InstanceName
+                                Health: Math.floor((values2[i].FullChargedCapacity / values4[j].DesignedCapacity) * 100),
+                                InstanceName: values2[i].InstanceName
                             };
                         } else {
-                            values6[i] = { Health: 0, InstanceName: values5[i].InstanceName };
+                            values6[i] = { Health: 0, InstanceName: values2[i].InstanceName };
                         }
                         break;
                     }
                 }
             }
         }
-        ret.battery = mergeJSONArrays(values, values2, values3, values4, values5, values6);
+        var values7 = [];
+        if (values2.length > 0 && values5.length > 0) {
+            for (i = 0; i < values2.length; ++i) {
+                for (var j = 0; j < values5.length; ++j) {
+                    if (values2[i].InstanceName == values5[j].InstanceName) {
+                        if ((values2[i].FullChargedCapacity && values2[i].FullChargedCapacity > 0) && (values5[j].RemainingCapacity && values5[j].RemainingCapacity > 0)) {
+                            values7[i] = { 
+                                BatteryCharge: Math.floor((values5[j].RemainingCapacity / values2[i].FullChargedCapacity) * 100),
+                                InstanceName: values2[i].InstanceName
+                            };
+                        } else {
+                            values7[i] = { BatteryCharge: 0, InstanceName: values2[i].InstanceName };
+                        }
+                        break;
+                    }
+                }
+            }
+        }
+        ret.battery = mergeJSONArrays(values, values2, values3, values4, values5, values6, values7);
     } catch (ex) { }
 
     return (ret);

--- a/views/default-mobile.handlebars
+++ b/views/default-mobile.handlebars
@@ -6548,7 +6548,8 @@
                     if (battery.Discharging != null) { x += addDetailItem("Discharging", (battery.Discharging ? "Yes" : "No"), s); }
                     if (battery.RemainingCapacity) { x += addDetailItem("Remaining Capacity", format("{0} mWh", battery.RemainingCapacity), s); }
                     if (battery.Voltage) { x += addDetailItem("Voltage", format("{0} V", (battery.Voltage / 1000)), s); }
-                    if (battery.Health) { x += addDetailItem("Health", format("{0} %", battery.Health), s); }   
+                    if (battery.Health) { x += addDetailItem("Health", format("{0} %", battery.Health), s); }
+                    if (battery.BatteryCharge) { x += addDetailItem("Battery Charge", format("{0} %", battery.BatteryCharge), s); }   
                     x += '</div>';
                 }
                 x += '</table>';

--- a/views/default.handlebars
+++ b/views/default.handlebars
@@ -12429,7 +12429,8 @@
                     if (battery.Discharging != null) { x += addDetailItem("Discharging", (battery.Discharging ? "Yes" : "No"), s); }
                     if (battery.RemainingCapacity) { x += addDetailItem("Remaining Capacity", format("{0} mWh", battery.RemainingCapacity), s); }
                     if (battery.Voltage) { x += addDetailItem("Voltage", format("{0} V", (battery.Voltage / 1000)), s); }
-                    if (battery.Health) { x += addDetailItem("Health", format("{0} %", battery.Health), s); }   
+                    if (battery.Health) { x += addDetailItem("Health", format("{0} %", battery.Health), s); }
+                    if (battery.BatteryCharge) { x += addDetailItem("Battery Charge", format("{0} %", battery.BatteryCharge), s); }   
                     x += '</div>';
                 }
                 x += '</table>';

--- a/views/default3.handlebars
+++ b/views/default3.handlebars
@@ -13469,7 +13469,8 @@
                     if (battery.Discharging != null) { x += addDetailItem("Discharging", (battery.Discharging ? "Yes" : "No"), s); }
                     if (battery.RemainingCapacity) { x += addDetailItem("Remaining Capacity", format("{0} mWh", battery.RemainingCapacity), s); }
                     if (battery.Voltage) { x += addDetailItem("Voltage", format("{0} V", (battery.Voltage / 1000)), s); }
-                    if (battery.Health) { x += addDetailItem("Health", format("{0} %", battery.Health), s); }   
+                    if (battery.Health) { x += addDetailItem("Health", format("{0} %", battery.Health), s); }
+                    if (battery.BatteryCharge) { x += addDetailItem("Battery Charge", format("{0} %", battery.BatteryCharge), s); }   
                     x += '</div>';
                 }
                 x += '</table>';


### PR DESCRIPTION
## Feature Overview
Adds comprehensive theme pack support to MeshCentral, allowing administrators to deploy custom UI themes through a structured theme-pack directory system.

## What This Adds

### New Configuration Option
```json
{
  "domains": {
    "": {
      "themePack": "Stylish-UI",
    }
  }
}
```

### Theme Pack Structure
Theme packs are loaded from `meshcentral-data/theme-pack/{ThemePackName}/public/`:
```
meshcentral-data/
└── theme-pack/
    └── {ThemePackName}/
        └── public/
            ├── styles/
            │   └── theme.css
            ├── scripts/
            │   └── theme.js
            └── images/
                ├── logo.png
                ├── background.jpg
                └── (any custom images)
```

## Implementation Details

### User Preference Support
Theme packs load based on both domain settings and individual user preferences:
- Loads when domain admin forces `sitestyle: 3`
- Loads when users manually switch to modern UI (sitestyle 3)
- Loads with URL parameter `?sitestyle=3`

## Use Cases

### 1. Custom Branding
Organizations can deploy custom themes matching their brand guidelines without modifying core MeshCentral files.

### 2. Per-Domain Themes
Different domains can use different theme packs for multi-tenant deployments.


## Configuration Example

```json
{
  "$schema": "http://raw.githubusercontent.com/Ylianst/MeshCentral/master/meshcentral-config-schema.json",
  "domains": {
    "": {
      "themePack": "Stylish-UI",
    },
    "corporate": {
      "themePack": "Corporate-Theme",
      "sitestyle": 3
    }
  }
}
```

## Backward Compatibility

✅ Fully backward compatible - no breaking changes
- Theme pack feature is opt-in
- Default behavior unchanged when no theme pack is configured
