### PR TITLE
OIDC - select_account

### DIFF
--- a/webserver.js
+++ b/webserver.js
@@ -8020,6 +8020,11 @@ module.exports.CreateWebServer = function (parent, db, args, certificates, doneF
             strategy.options = Object.assign(strategy.options, { 'client': client, sessionKey: 'oidc-' + domain.id });
             strategy.client = client.metadata
             strategy.obj.client = client
+			
+			if (preset == 'azure') {
+				strategy.options.params = strategy.options.params || {}
+				strategy.options.params.prompt = 'select_account';
+			}
 
             // Setup strategy and save configs for later
             passport.use('oidc-' + domain.id, new strategy.obj.openidClient.Strategy(strategy.options, oidcCallback));


### PR DESCRIPTION
Currently there is an issue that when using Azure OIDC authentication and you are logged in to a different tenant, no user prompt comes up, but instead this error:

`https://my-meshcentral-server/auth-oidc-azure-callback?error=invalid_request&error_description=AADSTS50178%3a+User+account+%27%7bEUII+Hidden%7d%27+from+identity+provider+%27https%3a%2f%2fsts.windows.net%2fe56d3ed2-014e-4fe5-90d0-cf16c3de957a%2f%27+does+not+exist+in+tenant+%27MyTenant+%27+and+cannot+access+the+application+.+The+account+needs+to+be+added+as+an+external+user+in+the+tenant+first.+Sign+out+and+sign+in+again+with+a+different+Azure+Active+Directory+user+account.+Trace+ID%3a+ae0e3fcf-e263-431e-81b5-51f4c4c3c500+Correlation+ID%3a+f716beb6-5b9f-4ee0-9d0f-43202c6b5934+Timestamp%3a+2026-01-06+07%3a20%3a34Z&error_uri=https%3a%2f%2flogin.microsoftonline.com%2ferror%3fcode%3d50178&state=e20OM8doEjHwtLRk0XdkH1uKyy5rWiJzhkOhYJU5JL4#`

Adding a Select_Account brings up the user select window in the browser.