### PR TITLE
Authentication Strategy - support auth with github enterprise instances

### DIFF
--- a/meshcentral-config-schema.json
+++ b/meshcentral-config-schema.json
@@ -3314,6 +3314,26 @@
                     "type": "string",
                     "description": "GitHub client secret."
                   },
+                  "authorizationurl": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "The URL used to obtain an authorization grant from the user."
+                  },
+                  "tokenurl": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "The URL used to exchange a code for an access token."
+                  },
+                  "userprofileurl": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "The URL used to obtain user profile information."
+                  },
+                  "useremailurl": {
+                    "type": "string",
+                    "format": "uri",
+                    "description": "The URL used to obtain user email information."
+                  },
                   "logouturl": {
                     "type": "string",
                     "format": "uri",

--- a/sample-config-advanced.json
+++ b/sample-config-advanced.json
@@ -525,7 +525,11 @@
           "_newAccountsUserGroups": [ "ugrp//xxxxxxxxxxxxxxxxx" ],
           "_newAccountsRights": [ "nonewgroups", "notools" ],
           "clientid": "xxxxxxxxxxxxxxxxxxxxxxx",
-          "clientsecret": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+          "clientsecret": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+          "_authorizationurl": "https://hostname/login/oauth/authorize",
+          "_tokenurl": "https://hostname/login/oauth/access_token",
+          "_userprofileurl": "https://hostname/user",
+          "_useremailurl": "https://hostname/user/emails"
         },
         "azure": {
           "_callbackurl": "https://server/auth-azure-callback",

--- a/webserver.js
+++ b/webserver.js
@@ -7800,6 +7800,11 @@ module.exports.CreateWebServer = function (parent, db, args, certificates, doneF
             const GitHubStrategy = require('passport-github2');
             let options = { clientID: domain.authstrategies.github.clientid, clientSecret: domain.authstrategies.github.clientsecret };
             if (typeof domain.authstrategies.github.callbackurl == 'string') { options.callbackURL = domain.authstrategies.github.callbackurl; } else { options.callbackURL = url + 'auth-github-callback'; }
+            //override passport-github2 defaults that point to github.com with urls specified by user
+            if (typeof domain.authstrategies.github.authorizationurl == 'string') { options.authorizationURL = domain.authstrategies.github.authorizationurl; }
+            if (typeof domain.authstrategies.github.tokenurl == 'string') { options.tokenURL = domain.authstrategies.github.tokenurl; }
+            if (typeof domain.authstrategies.github.userprofileurl == 'string') { options.userProfileURL = domain.authstrategies.github.userprofileurl; }
+            if (typeof domain.authstrategies.github.useremailurl == 'string') { options.userEmailURL = domain.authstrategies.github.useremailurl; }
             parent.authLog('setupDomainAuthStrategy', 'Adding Github SSO with options: ' + JSON.stringify(options));
             passport.use('github-' + domain.id, new GitHubStrategy(options,
                 function (token, tokenSecret, profile, cb) {


### PR DESCRIPTION
As documented here: 

https://github.com/cfsghost/passport-github/pull/17/commits/5283b9c1a4a7d0efaa74ba3809d19218ef0d7e85

passport-github2 allows to specify custom urls. 

I have sucessfully tested the change with my github enterprise instance.