### PR TITLE
Add allowedFramingOrigins config for CSP frame-ancestors whitelist

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -53,6 +53,7 @@
         "allevents",
         "allowaccountreset",
         "allowframing",
+        "allowedframingorigins",
         "allowfullscreen",
         "allowhighqualitydesktop",
         "allowsavingdevicecredentials",

--- a/meshcentral-config-schema.json
+++ b/meshcentral-config-schema.json
@@ -454,6 +454,17 @@
           "default": false,
           "description": "When enabled, the MeshCentral web site can be embedded within another website's iframe."
         },
+        "allowedFramingOrigins": {
+          "type": [
+            "array",
+            "string"
+          ],
+          "items": {
+            "type": "string"
+          },
+          "default": null,
+          "description": "List of origins allowed to embed MeshCentral in an iframe. Uses Content-Security-Policy frame-ancestors. 'self' is always included. Example: [\"https://rmm.example.com\"]. Comma-separated string also supported."
+        },
         "cookieIpCheck": {
           "type": [
             "string",
@@ -2922,6 +2933,17 @@
               "id",
               "secret"
             ]
+          },
+          "allowedFramingOrigins": {
+            "type": [
+              "array",
+              "string"
+            ],
+            "items": {
+              "type": "string"
+            },
+            "default": null,
+            "description": "Per-domain override. List of origins allowed to embed this domain in an iframe. Uses Content-Security-Policy frame-ancestors. Overrides settings.allowedFramingOrigins when set."
           },
           "httpHeaders": {
             "type": "object",

--- a/sample-config-advanced.json
+++ b/sample-config-advanced.json
@@ -50,6 +50,7 @@
     "_allowLoginToken": true,
     "_StrictTransportSecurity": true,
     "_allowFraming": true,
+    "_allowedFramingOrigins": ["https://rmm.example.com"],
     "_cookieIpCheck": false,
     "_cookieEncoding": "hex",
     "_webRTC": false,

--- a/webserver.js
+++ b/webserver.js
@@ -842,6 +842,19 @@ module.exports.CreateWebServer = function (parent, db, args, certificates, doneF
         return parent.config.domains[''];
     }
 
+    function parseAllowedFramingOrigins(val) {
+        if (val == null) return [];
+        var arr = [];
+        if (Array.isArray(val)) { arr = val.slice(); } else if (typeof val == 'string') { arr = val.split(',').map(function (s) { return s.trim(); }).filter(function (s) { return s.length > 0; }); } else { return []; }
+        var out = [];
+        for (var i = 0; i < arr.length; i++) {
+            var o = arr[i].trim().replace(/\/+$/, '');
+            if (o.length === 0) continue;
+            if (o.indexOf('https://') === 0 || o.indexOf('http://') === 0) { out.push(o); }
+        }
+        return out;
+    }
+
     function handleLogoutRequest(req, res) {
         const domain = checkUserIpAddress(req, res);
         if (domain == null) { return; }
@@ -3330,7 +3343,7 @@ module.exports.CreateWebServer = function (parent, db, args, certificates, doneF
         if (obj.args.nousers == true) { features += 0x00000004; } // Single user mode
         if (domain.userQuota == -1) { features += 0x00000008; } // No server files mode
         if (obj.args.mpstlsoffload) { features += 0x00000010; } // No mutual-auth CIRA
-        if ((parent.config.settings.allowframing != null) || (domain.allowframing != null)) { features += 0x00000020; } // Allow site within iframe
+        if ((parent.config.settings.allowframing != null) || (domain.allowframing != null) || (parent.config.settings.allowedframingorigins != null) || (domain.allowedframingorigins != null)) { features += 0x00000020; } // Allow site within iframe
         if ((domain.mailserver != null) && (obj.parent.certificates.CommonName != null) && (obj.parent.certificates.CommonName.indexOf('.') != -1) && (obj.args.lanonly != true)) { features += 0x00000040; } // Email invites
         if (obj.args.webrtc == true) { features += 0x00000080; } // Enable WebRTC (Default false for now)
         // 0x00000100 --> This feature flag is free for future use.
@@ -3405,7 +3418,7 @@ module.exports.CreateWebServer = function (parent, db, args, certificates, doneF
     function handleRootRequestLogin(req, res, domain, hardwareKeyChallenge, passRequirements) {
         parent.debug('web', 'handleRootRequestLogin()');
         var features = 0;
-        if ((parent.config != null) && (parent.config.settings != null) && ((parent.config.settings.allowframing == true) || (typeof parent.config.settings.allowframing == 'string'))) { features += 32; } // Allow site within iframe
+        if ((parent.config != null) && (parent.config.settings != null) && ((parent.config.settings.allowframing == true) || (typeof parent.config.settings.allowframing == 'string') || (parent.config.settings.allowedframingorigins != null) || (domain != null && domain.allowedframingorigins != null))) { features += 32; } // Allow site within iframe
         if (domain.usernameisemail) { features += 0x00200000; } // Username is email address
         var httpsPort = ((obj.args.aliasport == null) ? obj.args.port : obj.args.aliasport); // Use HTTPS alias port is specified
         var loginmode = 0;
@@ -6858,15 +6871,30 @@ module.exports.CreateWebServer = function (parent, db, args, certificates, doneF
                 }
             }
 
+            // allowedFramingOrigins: domain override, else settings
+            var allowedFramingOriginsVal = (domain != null && domain.allowedframingorigins != null) ? domain.allowedframingorigins : parent.config.settings.allowedframingorigins;
+            var framingOrigins = parseAllowedFramingOrigins(allowedFramingOriginsVal);
+            var hasAllowedFramingOrigins = (domain != null && domain.allowedframingorigins != null) || (parent.config.settings.allowedframingorigins != null);
+
+
             // Finish setup security headers
+            var cspBase = "default-src 'none'; font-src 'self' fonts.gstatic.com data:; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' " + extraScriptSrc + "; connect-src 'self'" + geourl + selfurl + "; img-src 'self' blob: data:" + geourl + extraImgSrc + " data:; style-src 'self' 'unsafe-inline' fonts.googleapis.com; frame-src 'self' blob: mcrouter:" + extraFrameSrc + "; media-src 'self'; form-action 'self' " + duoSrc + "; manifest-src 'self'";
+            if (hasAllowedFramingOrigins) {
+                var frameAncestors = "'self'" + (framingOrigins.length > 0 ? ' ' + framingOrigins.join(' ') : '');
+                cspBase += "; frame-ancestors " + frameAncestors;
+            }
             const headers = {
                 'Referrer-Policy': 'no-referrer',
                 'X-XSS-Protection': '1; mode=block',
                 'X-Content-Type-Options': 'nosniff',
-                'Content-Security-Policy': "default-src 'none'; font-src 'self' fonts.gstatic.com data:; script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' " + extraScriptSrc + "; connect-src 'self'" + geourl + selfurl + "; img-src 'self' blob: data:" + geourl + extraImgSrc + " data:; style-src 'self' 'unsafe-inline' fonts.googleapis.com; frame-src 'self' blob: mcrouter:" + extraFrameSrc + "; media-src 'self'; form-action 'self' " + duoSrc + "; manifest-src 'self'"
+                'Content-Security-Policy': cspBase
             };
             if (req.headers['user-agent'] && (req.headers['user-agent'].indexOf('Chrome') >= 0)) { headers['Permissions-Policy'] = 'interest-cohort=()'; } // Remove Google's FLoC Network, only send this if Chrome browser
-            if ((parent.config.settings.allowframing !== true) && (typeof parent.config.settings.allowframing !== 'string')) { headers['X-Frame-Options'] = 'sameorigin'; }
+            if (hasAllowedFramingOrigins) {
+                if (framingOrigins.length === 0) { headers['X-Frame-Options'] = 'sameorigin'; }
+            } else if ((parent.config.settings.allowframing !== true) && (typeof parent.config.settings.allowframing !== 'string')) {
+                headers['X-Frame-Options'] = 'sameorigin';
+            }
             if ((parent.config.settings.stricttransportsecurity === true) || ((parent.config.settings.stricttransportsecurity !== false) && (obj.isTrustedCert(domain)))) { if (typeof parent.config.settings.stricttransportsecurity == 'string') { headers['Strict-Transport-Security'] = parent.config.settings.stricttransportsecurity; } else { headers['Strict-Transport-Security'] = 'max-age=63072000'; } }
 
             // If this domain has configured headers, add them. If a header is set to null, remove it.
@@ -8093,7 +8121,7 @@ module.exports.CreateWebServer = function (parent, db, args, certificates, doneF
             strategy.options = Object.assign(strategy.options, { 'client': client, sessionKey: 'oidc-' + domain.id });
             strategy.client = client.metadata
             strategy.obj.client = client
-
+            
             // Validate OIDC Icon Url once and null it if it fails validation
             if (obj.common.validateObject(strategy.custom) && obj.common.validateString(strategy.custom.buttoniconurl)) {
                 if (obj.common.validateUrl(strategy.custom.buttoniconurl)){


### PR DESCRIPTION
- Add settings.allowedFramingOrigins and domain-level override
- Implement Content-Security-Policy frame-ancestors with domain whitelist, always includes self if set
- Adjust X-Frame-Options when external origins are allowed
- Enable iframe feature flag when allowedFramingOrigins is set
- Support array or comma-separated string config

Enables more secure embedding in parent portals (e.g. TacticalRMM) while blocking clickjacking from arbitrary sites. Use of parameter disables X-Frame-Options and uses CSP frame-ancestors when only specific origins should frame the site.

