### PR TITLE
Fix: apply nowrap to tab title to avoid line break

### DIFF
--- a/public/styles/style-bootstrap.css
+++ b/public/styles/style-bootstrap.css
@@ -399,6 +399,7 @@ body {
     width: 100px;
     height: 24px;
     cursor: pointer;
+    white-space: nowrap;
 }
 
 .nonenglish .topbar_td {

--- a/public/styles/style.css
+++ b/public/styles/style.css
@@ -240,6 +240,7 @@ body {
     width: 100px;
     height: 24px;
     cursor: pointer;
+    white-space: nowrap;
 }
 
 .nonenglish .topbar_td {


### PR DESCRIPTION
Long tab titles wrap, causing other tabs to be cut off:
1. Modern UI;  Chinese (`zh-chs` or `zh-cht`). Click any Intel® AMT device:
<img width="600" height="300" alt="{5E7852BA-A67E-468F-BA5C-73F07B616458}" src="https://github.com/user-attachments/assets/037735d8-5135-4013-b470-ab0367641a35" />

2. Modern UI; Top Bar interface; Japanese(`ja`). Go to home page:
<img width="600" height="300" alt="{FBC7C75E-7FAA-482B-94FE-730FB109C0D0}" src="https://github.com/user-attachments/assets/dd0b7aa0-1311-4718-a0ff-d7c79a7ab5f4" />

---
Expected:
<img width="600" height="300" alt="{A8B2AEF9-4D8B-491C-9E01-68871443682B}" src="https://github.com/user-attachments/assets/b599bf5d-8ced-4a20-a4b4-8a421b45cd83" />
<img width="600" height="300" alt="{C09AAEB6-DB5B-4A42-8E0E-07709FBA3932}" src="https://github.com/user-attachments/assets/0e83a24f-fcd6-4a30-b0f3-7d4d0571e9fc" />

---
Currently this issue only occurs in Modern UI mode, but I modified both (Modern and Classic) just in case long titles appear in Classic UI in the future.