### PR TITLE
UPN / loggedOnUser - domain clients

### DIFF
--- a/agents/meshcore.js
+++ b/agents/meshcore.js
@@ -138,7 +138,6 @@ function getDomainInfo() {
 }
 
 function getLoggedOnUserBySessionId(sessionId) {
-
     try {
         const result = require('win-registry').QueryKey(require('win-registry').HKEY.LocalMachine,
             ("SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Authentication\\LogonUI\\SessionData\\" + sessionId), 'LoggedOnUser'
@@ -151,7 +150,6 @@ function getLoggedOnUserBySessionId(sessionId) {
         return null;
 
     } catch (err) {
-        //console.error("Registry read failed:", err.message);
         return null;
     }
 }


### PR DESCRIPTION
The UPN was not correct when the domain name and the DNS name are not the same, Same for user logon name and SAM name.  Unfortunately, there seems not be a good way to extract the information from WMI or registry. The only way seems to be dsregcmd /status

With this approach the information is still incorrect when logging in with the SAM, but when using the UPN the result looks better.