### PR TITLE
Proxy for Plugins fix

### DIFF
--- a/pluginHandler.js
+++ b/pluginHandler.js
@@ -256,12 +256,10 @@ module.exports.pluginHandler = function (parent) {
                 options.agent = new (require('https-proxy-agent').HttpsProxyAgent)(require('url').parse(parent.config.settings.plugins.proxy) || process.env['HTTP_PROXY'] || process.env['HTTPS_PROXY'] || process.env['http_proxy'] || process.env['https_proxy']);
             }
             http.get(options, function (res) {
-
                 var configStr = '';
                 res.on('data', function (chunk) {
                     configStr += chunk;
                 });
-
                 res.on('end', function () {
                     if (configStr[0] == '{') { // Let's be sure we're JSON
                         try {
@@ -277,7 +275,6 @@ module.exports.pluginHandler = function (parent) {
                         reject("Error getting plugin config. Check that you have valid JSON.");
                     }
                 });
-
             }).on('error', function (e) {
                 reject("Error getting plugin config: " + e.message);
             });


### PR DESCRIPTION
Before I got the error:
`HttpsProxyAgent is not a constructor`

Config:
```
"plugins": {
      "enabled": true,
      "proxy": "http://contoso:9090/"
    },
```

Later on I had some more error:
```
node:events:497
      throw er; // Unhandled 'error' event
      ^

Error: socket hang up
    at TLSSocket.socketOnEnd (node:_http_client:598:25)
    at TLSSocket.emit (node:events:531:35)
    at endReadableNT (node:internal/streams/readable:1698:12)
    at process.processTicksAndRejections (node:internal/process/task_queues:90:21)
Emitted 'error' event on ClientRequest instance at:
    at emitErrorEvent (node:_http_client:107:11)
    at TLSSocket.socketOnEnd (node:_http_client:598:5)
    at TLSSocket.emit (node:events:531:35)
    at endReadableNT (node:internal/streams/readable:1698:12)
    at process.processTicksAndRejections (node:internal/process/task_queues:90:21) {
  code: 'ECONNRESET'
}
```