### PR TITLE
Fixed regression in #7595, image-addon uses experimental apis.

### DIFF
--- a/views/default-mobile.handlebars
+++ b/views/default-mobile.handlebars
@@ -5555,7 +5555,7 @@
 
                 // Setup the terminal with auto-fit
                 if (xterm != null) { xterm.dispose(); }
-                xterm = new Terminal();
+                xterm = new Terminal({ allowProposedApi: true });
                 xtermfit = new FitAddon.FitAddon();
                 xtermimage = new ImageAddon.ImageAddon();
                 if (xtermfit) { xterm.loadAddon(xtermfit); }

--- a/views/default.handlebars
+++ b/views/default.handlebars
@@ -11035,7 +11035,7 @@
                         if (xterm != null) { xterm.dispose(); }
                         xtermfit = new FitAddon.FitAddon();
                         xtermimage = new ImageAddon.ImageAddon();
-                        xterm = new Terminal();
+                        xterm = new Terminal({ allowProposedApi: true });
                         if (xtermfit) { xterm.loadAddon(xtermfit); }
                         xterm.loadAddon(xtermimage);
                         xterm.open(Q('termarea3xdiv')); // termarea3x

--- a/views/default3.handlebars
+++ b/views/default3.handlebars
@@ -12035,7 +12035,7 @@
                         if (xterm != null) { xterm.dispose(); }
                         xtermfit = new FitAddon.FitAddon();
                         xtermimage = new ImageAddon.ImageAddon();
-                        xterm = new Terminal();
+                        xterm = new Terminal({ allowProposedApi: true });
                         if (xtermfit) { xterm.loadAddon(xtermfit); }
                         xterm.loadAddon(xtermimage);
                         xterm.open(Q('termarea3xdiv')); // termarea3x

--- a/views/player.handlebars
+++ b/views/player.handlebars
@@ -1104,7 +1104,7 @@
             // Setup the terminal
             if (term != null) { term.dispose(); }
             termimage = new ImageAddon.ImageAddon();
-            term = new Terminal();
+            term = new Terminal({ allowProposedApi: true });
             term.loadAddon(termimage);
             term.open(Q('XTermParent'));
             term.resize(80, 25);

--- a/views/sharing-mobile.handlebars
+++ b/views/sharing-mobile.handlebars
@@ -1823,7 +1823,7 @@
 
                 // Setup the terminal with auto-fit
                 if (xterm != null) { xterm.dispose(); }
-                xterm = new Terminal();
+                xterm = new Terminal({ allowProposedApi: true });
                 xtermfit = new FitAddon.FitAddon();
                 xtermimage = new ImageAddon.ImageAddon();
                 if (xtermfit) { xterm.loadAddon(xtermfit); }

--- a/views/sharing.handlebars
+++ b/views/sharing.handlebars
@@ -1492,7 +1492,7 @@
                 if (xterm != null) { xterm.dispose(); }
                 xtermfit = new FitAddon.FitAddon();
                 xtermimage = new ImageAddon.ImageAddon();
-                xterm = new Terminal();
+                xterm = new Terminal({ allowProposedApi: true });
                 if (xtermfit) { xterm.loadAddon(xtermfit); }
                 xterm.loadAddon(xtermimage);
                 xterm.open(Q('termarea3xdiv')); // termarea3x

--- a/views/ssh.handlebars
+++ b/views/ssh.handlebars
@@ -106,7 +106,7 @@
             if (term != null) { term.dispose(); }
             if (urlargs.fixsize != 1) { termfit = new FitAddon.FitAddon(); }
             termimage = new ImageAddon.ImageAddon();
-            term = new Terminal();
+            term = new Terminal({ allowProposedApi: true });
             if (termfit) { term.loadAddon(termfit); }
             term.loadAddon(termimage);
             term.open(Q('terminal'));

--- a/views/xterm.handlebars
+++ b/views/xterm.handlebars
@@ -161,7 +161,7 @@
                 if (term != null) { term.dispose(); }
                 if (args.fixsize != 1) { termfit = new FitAddon.FitAddon(); }
                 termimage = new ImageAddon.ImageAddon();
-                term = new Terminal();
+                term = new Terminal({ allowProposedApi: true });
                 if (termfit) { term.loadAddon(termfit); }
                 term.loadAddon(termimage);
                 term.open(Q('terminal'));


### PR DESCRIPTION
This PR fixes a regression where browser terminal sessions stopped opening after `xterm-addon-image` support was added in #7595.

Desktop sessions continued to work, but terminal-capable views failed immediately in the browser with:
>Uncaught Error: You must set the allowProposedApi option to true to use proposed API

That failure occurs because xterm-addon-image uses xterm proposed (experimental) APIs, while several MeshCentral terminal views were still creating terminals with:
```
new Terminal()
```
instead of:
```
new Terminal({ allowProposedApi: true })
```

This change updates the relevant browser-side terminal constructors so any view that loads xterm-addon-image creates xterm with:
```
allowProposedApi: true
```

There are really only two options here due to the regression:

- Enable allowProposedApi anywhere we load xterm-addon-image
- Revert PR #7595 and restore terminal functionality until the image addon stops depending on experimental/proposed APIs

This has been tested and has restored functionality lost after #7595 was implemented.