### PR TITLE
Make the "Expand All"/"Collapse All" button larger

### DIFF
--- a/views/default.handlebars
+++ b/views/default.handlebars
@@ -324,8 +324,8 @@
                     <tr>
                         <td class=h1></td>
                         <td id=devListToolbar class=style14 style="display:none">
-                            <img style="cursor:pointer;margin-top:4px;display:none" title="Collapse All" id="CollapseAllButton" src="images/icon-collapse.png" width=9 height=11 onclick="cmexpandaction(2)" />
-                            <img style="cursor:pointer;margin-top:4px;display:none" title="Expand All" id="ExpandAllButton" src="images/icon-expand.png" width=9 height=11 onclick="cmexpandaction(1)" />
+                            <button type="button" title="Collapse All" id="CollapseAllButton" onclick="cmexpandaction(2)"><img src="images/icon-collapse.png" width="10" height="10"></button>
+                            <button type="button" title="Expand All" id="ExpandAllButton" onclick="cmexpandaction(1)"><img src="images/icon-expand.png" width="10" height="10"></button>
                             <input type=button id=SelectAllButton onclick="selectallButtonFunction();" value="Select All" />&nbsp;
                             <input type=button id=GroupActionButton disabled="disabled" value="Group Action" onclick=groupActionFunction() />&nbsp;
                             <input type=button id=ScrollToTopButton onclick="onDevicesScroll(true);" style="display:none;margin-right:4px" value="Scroll To Top" />
@@ -347,8 +347,8 @@
                             <span id="devsCustomUIBar"></span>
                         </td>
                         <td id=kvmListToolbar class=style14 style="display:none">
-                            <img style="cursor:pointer;margin-top:4px;display:none" title="Collapse All" id="CollapseAllButton2" src="images/icon-collapse.png" width=9 height=11 onclick="cmexpandaction(2)" />
-                            <img style="cursor:pointer;margin-top:4px;display:none" title="Expand All" id="ExpandAllButton2" src="images/icon-expand.png" width=9 height=11 onclick="cmexpandaction(1)" />
+                            <button type="button" title="Collapse All" id="CollapseAllButton2" onclick="cmexpandaction(2)"><img src="images/icon-collapse.png" width="10" height="10"></button>
+                            <button type="button" title="Expand All" id="ExpandAllButton2" onclick="cmexpandaction(1)"><img src="images/icon-expand.png" width="10" height="10"></button>
                             <span id=KvmDesktopButtons>
                                 <input type="button" onclick="connectAllKvmFunction()" value="Connect All" />&nbsp;
                                 <input type="button" onclick="disconnectAllKvmFunction()" value="Disconnect All" />&nbsp;

--- a/views/default3.handlebars
+++ b/views/default3.handlebars
@@ -442,14 +442,14 @@
                 </div>
                 <div id="devListToolbarSpan" class="noselect d-flex align-items-center p-1">
                     <div id=devListToolbar class="d-flex align-items-center visually-hidden"></td>
-                        <span class="fa-layers fa-fw me-1" role="button" style="display:none" title="Collapse All" id="CollapseAllButton" onclick="cmexpandaction(2)">
+                        <button class="btn btn-secondary btn-sm fa-layers fa-fw me-1" style="width: 30px; height: 31px; display:none" title="Collapse All" id="CollapseAllButton" onclick="cmexpandaction(2)">
                             <i class="fa-solid fa-chevron-up" data-fa-transform="down-6"></i>
                             <i class="fa-solid fa-chevron-down" data-fa-transform="up-6"></i>
-                        </span>
-                        <span class="fa-layers fa-fw me-1" role="button" style="display:none" title="Expand All" id="ExpandAllButton" onclick="cmexpandaction(1)">
+                        </button>
+                        <button class="btn btn-secondary btn-sm fa-layers fa-fw me-1" style="width: 30px; height: 31px; display:none" title="Expand All" id="ExpandAllButton" onclick="cmexpandaction(1)">
                             <i class="fa-solid fa-chevron-up" data-fa-transform="up-6"></i>
                             <i class="fa-solid fa-chevron-down" data-fa-transform="down-6"></i>
-                        </span>
+                        </button>
                         <input type=button class="btn btn-secondary me-1 btn-sm" id=SelectAllButton onclick="selectallButtonFunction();" value="Select All" />
                         <input type=button class="btn btn-primary me-1 btn-sm" id=GroupActionButton disabled="disabled" value="Group Action" onclick=groupActionFunction() />
                         <input type=button class="btn btn-secondary me-1 btn-sm" id=ScrollToTopButton onclick="onDevicesScroll(true);" value="Scroll To Top" />
@@ -476,14 +476,14 @@
                         <span id="devsCustomUIBar"></span>
                     </div>
                     <div id=kvmListToolbar class="d-flex align-items-center style14 visually-hidden">
-                        <span class="fa-layers fa-fw me-1" role="button" style="display:none" title="Collapse All" id="CollapseAllButton2" onclick="cmexpandaction(2)">
+                        <button class="btn btn-secondary btn-sm fa-layers fa-fw me-1" style="width: 30px; height: 31px; display:none" title="Collapse All" id="CollapseAllButton2" onclick="cmexpandaction(2)">
                             <i class="fa-solid fa-chevron-up" data-fa-transform="down-6"></i>
                             <i class="fa-solid fa-chevron-down" data-fa-transform="up-6"></i>
-                        </span>
-                        <span class="fa-layers fa-fw me-1" role="button" style="display:none" title="Expand All" id="ExpandAllButton2" onclick="cmexpandaction(1)">
+                        </button>
+                        <button class="btn btn-secondary btn-sm fa-layers fa-fw me-1" style="width: 30px; height: 31px; display:none" title="Expand All" id="ExpandAllButton2" onclick="cmexpandaction(1)">
                             <i class="fa-solid fa-chevron-up" data-fa-transform="up-6"></i>
                             <i class="fa-solid fa-chevron-down" data-fa-transform="down-6"></i>
-                        </span>
+                        </button>
                         <span id="KvmDesktopButtons">
                             <input type="button" class="btn btn-success me-1 btn-sm" onclick="connectAllKvmFunction()" value="Connect All" />
                             <input type="button" class="btn btn-danger me-1 btn-sm" onclick="disconnectAllKvmFunction()" value="Disconnect All" />


### PR DESCRIPTION
Cosmetic changes in the HTML to make the "Expand all"/"Collapse all" button larger and easier to click
Fixes #5360