### PR TITLE
fix(meshctrl): use userids instead of usernames in addusertodevicegroup

### DIFF
--- a/meshctrl.js
+++ b/meshctrl.js
@@ -1659,7 +1659,7 @@ function serverConnect() {
                 if (args.limitedevents) { meshrights |= 8192; }
                 if (args.chatnotify) { meshrights |= 16384; }
                 if (args.uninstall) { meshrights |= 32768; }
-                var op = { action: 'addmeshuser', usernames: [args.userid], meshadmin: meshrights, responseid: 'meshctrl' };
+                var op = { action: 'addmeshuser', userids: [args.userid], meshadmin: meshrights, responseid: 'meshctrl' };
                 if (args.id) { op.meshid = args.id; } else if (args.group) { op.meshname = args.group; }
                 ws.send(JSON.stringify(op));
                 break;


### PR DESCRIPTION
## Summary

- Fixes `meshctrl addusertodevicegroup` silently failing ("Nothing done") for SSO/Azure AD users
- One-line change: `usernames` → `userids` in the websocket command payload

## Problem

`meshctrl.js` line 1662 sends `--userid` values in the `usernames` field:
```javascript
var op = { action: 'addmeshuser', usernames: [args.userid], ... };
```

The server handler in `meshuser.js` treats `usernames` as short username lookups, which fails when `--userid` contains a full user ID like `user/domain/~azure:user@example.com`.

The corresponding `removeuserfromdevicegroup` command already uses `userid` correctly and works fine.

## Fix

```diff
- var op = { action: 'addmeshuser', usernames: [args.userid], meshadmin: meshrights, responseid: 'meshctrl' };
+ var op = { action: 'addmeshuser', userids: [args.userid], meshadmin: meshrights, responseid: 'meshctrl' };
```

Fixes #7740