### PR TITLE
entrypoint test_url function fix

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -14,8 +14,7 @@ function graceful_shutdown() {
 trap graceful_shutdown SIGTERM
 
 function test_url() {
-    wget --spider "$1" &> /dev/null
-    if "$?"; then
+    if wget --spider "$1" &> /dev/null; then
         echo "is ok."
         return 0
     else


### PR DESCRIPTION
@DaanSelen 3 days ago there was an update to entrypoint that created a little error for downloading StylishUI.

Fix for this entrypoint error:

```
Reached StylishUI install trigger, installing...

/opt/meshcentral/entrypoint.sh: line 18: 0: command not found

Testing compatibility schema URL...is NOT ok.

Compat URL failed.

Something fatal happened in the StylishUI install. Skipping...
```