### PR TITLE
Azure Ggroups and roles again

### DIFF
--- a/webserver.js
+++ b/webserver.js
@@ -8500,16 +8500,11 @@ module.exports.CreateWebServer = function (parent, db, args, certificates, doneF
                 if (strategy.groups && typeof user.preset == 'string') {
                     if((Array.isArray(strategy.custom.authorities) && strategy.custom.authorities.filter(x => x.trim().length > 0).length > 0) == false || strategy.custom.authorities.includes('groups')) { 
                         getGroups(user.preset, tokenset).then((groups) => {
-                            user = Object.assign(user, { 'groups': groups });
-							
-							if(strategy.custom.authorities.includes('roles')){
-		                        if(user.roles){
-		                            if(!strategy.custom.authorities.includes('groups')){
-		                                user.groups = user.roles;
-		                            } else {
-		                                user.groups = (user.groups || []).concat(user.roles);
-		                            }
-		                        }
+                            //user = Object.assign(user, { 'groups': groups });
+							user.groups = user.groups || [];
+							if(strategy.custom.authorities && strategy.custom.authorities.includes('roles')){
+                                // Check also for roles
+		                        user.groups = (user.groups || []).concat(user.roles);
 		                    }
 		                    parent.authLog('oidcCallback',`OIDC: USER GROUPS/ROLES: ${JSON.stringify(user)}`);
 		                    done(null, user);
@@ -8520,7 +8515,15 @@ module.exports.CreateWebServer = function (parent, db, args, certificates, doneF
                             user.groups = [];
                             done(null, user);
                         });
-                    }
+                    
+                    } else if (Array.isArray(strategy.custom.authorities) && strategy.custom.authorities.includes('roles')) {
+                        // Only roles are requested
+                        if (user.roles) {
+                            user.groups = user.roles;
+                        }
+                        parent.authLog('OIDC: USER ROLES:', user);
+                        done(null, user);
+                    }  
                 } else {
                     done(null, user);
                 }

--- a/webserver.js
+++ b/webserver.js
@@ -8500,8 +8500,7 @@ module.exports.CreateWebServer = function (parent, db, args, certificates, doneF
                 if (strategy.groups && typeof user.preset == 'string') {
                     if((Array.isArray(strategy.custom.authorities) && strategy.custom.authorities.filter(x => x.trim().length > 0).length > 0) == false || strategy.custom.authorities.includes('groups')) { 
                         getGroups(user.preset, tokenset).then((groups) => {
-                            //user = Object.assign(user, { 'groups': groups });
-							user.groups = user.groups || [];
+                            user = Object.assign(user, { 'groups': groups });
 							if(strategy.custom.authorities && strategy.custom.authorities.includes('roles')){
                                 // Check also for roles
 		                        user.groups = (user.groups || []).concat(user.roles);


### PR DESCRIPTION
Hi,
after I broke the Azure Groups by my Role PR this PR https://github.com/Ylianst/MeshCentral/pull/7763 broke the roles ;)
(I never see the async functions and think they will just run line by line, my bad)

This change does following check:
1. Check if groups
1b. Check if roles also are used
2. Check roles if no groups were used before

@marcinl26 @si458 
what do you think?