### PR TITLE
Fix jq arg variable expansion in database dynamic config docker entrypoint.sh

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -56,11 +56,11 @@ function dynamic_config() {
             --arg psql_user "$PSQL_USER" \
             --arg psql_pass "$PSQL_PASS" \
             --arg psql_db "$PSQL_DATABASE" \
-            '.settings.postgres.host = "$psql_host" |
-            .settings.postgres.port = "$psql_port" |
-            .settings.postgres.user = "$psql_user" |
-            .settings.postgres.password = "$psql_pass" |
-            .settings.postgres.database = "$psql_db"' \
+            '.settings.postgres.host = $psql_host |
+            .settings.postgres.port = $psql_port |
+            .settings.postgres.user = $psql_user |
+            .settings.postgres.password = $psql_pass |
+            .settings.postgres.database = $psql_db' \
             "$CONFIG_FILE" > temp_config.json && mv temp_config.json "$CONFIG_FILE"
     else
         echo "Disabling PostgreSQL-connector..."
@@ -76,11 +76,11 @@ function dynamic_config() {
             --arg mariadb_user "$MARIADB_USER" \
             --arg mariadb_pass "$MARIADB_PASS" \
             --arg mariadb_db "$MARIADB_DATABASE" \
-            '.settings.mariaDB.host = "$mariadb_host" |
-            .settings.mariaDB.port = "$mariadb_port" |
-            .settings.mariaDB.user = "$mariadb_user" |
-            .settings.mariaDB.password = "$mariadb_pass" |
-            .settings.mariaDB.database = "$mariadb_db"' \
+            '.settings.mariaDB.host = $mariadb_host |
+            .settings.mariaDB.port = $mariadb_port |
+            .settings.mariaDB.user = $mariadb_user |
+            .settings.mariaDB.password = $mariadb_pass |
+            .settings.mariaDB.database = $mariadb_db' \
             "$CONFIG_FILE" > temp_config.json && mv temp_config.json "$CONFIG_FILE"
     else
         echo "Disabling MariaDB-connector..."


### PR DESCRIPTION
This MR revert changes made in https://github.com/Ylianst/MeshCentral/pull/7738 that added quotes around jq arg variables in postgres and mariadb dynamic config script which prevent them from being expanded.
https://github.com/Ylianst/MeshCentral/blob/02e6d1c351dc47f64fe58a2fc48c4b556aff9b4f/docker/entrypoint.sh#L59-L63
https://github.com/Ylianst/MeshCentral/blob/02e6d1c351dc47f64fe58a2fc48c4b556aff9b4f/docker/entrypoint.sh#L79-L83  

This causes error when running the container with `DYNAMIC_CONFIG` even when all database environment variable exists.
```bash
meshcentral  | Setting minify... true
meshcentral  | {
meshcentral  |   "$schema": "https://raw.githubusercontent.com/Ylianst/MeshCentral/master/meshcentral-config-schema.json",
...
meshcentral  |     "postgres": {
meshcentral  |       "host": "$psql_host",
meshcentral  |       "port": "$psql_port",
meshcentral  |       "user": "$psql_user",
meshcentral  |       "password": "$psql_pass",
meshcentral  |       "database": "$psql_db"
meshcentral  |     },
...
meshcentral  | -------------------------------------------------------------
meshcentral  | Installing modules [ 'pg@8.16.3' ]
meshcentral  | ERR: node:net:1303
meshcentral  |     validatePort(port);
meshcentral  |     ^
meshcentral  |
meshcentral  | RangeError [ERR_SOCKET_BAD_PORT]: Port should be >= 0 and < 65536. Received type number (NaN).
meshcentral  |     at lookupAndConnect (node:net:1303:5)
meshcentral  |     at Socket.connect (node:net:1260:5)
meshcentral  |     at Connection.connect (/opt/meshcentral/meshcentral/node_modules/pg/lib/connection.js:43:17)
meshcentral  |     at Client._connect (/opt/meshcentral/meshcentral/node_modules/pg/lib/client.js:117:11)
meshcentral  |     at /opt/meshcentral/meshcentral/node_modules/pg/lib/client.js:171:12
meshcentral  |     at new Promise (<anonymous>)
meshcentral  |     at Client.connect (/opt/meshcentral/meshcentral/node_modules/pg/lib/client.js:170:12)
meshcentral  |     at module.exports.CreateDB (/opt/meshcentral/meshcentral/db.js:965:27)
meshcentral  |     at CreateMeshCentralServer.obj.StartEx (/opt/meshcentral/meshcentral/meshcentral.js:969:28)
meshcentral  |     at process.processTicksAndRejections (node:internal/process/task_queues:95:5) {
meshcentral  |   code: 'ERR_SOCKET_BAD_PORT'
meshcentral  | }
```
I'm currently able to temporarily fix this by removing the quotes before entrypoint.sh started.
```yaml
services:
  meshcentral:
    image: ghcr.io/ylianst/meshcentral:master-postgresql-debian
    entrypoint:
    - bash
    - -c
    - |-
      set -x
      sed -i -E 's/ += +"\$(.+)"/ = \$\1/g' /opt/meshcentral/entrypoint.sh
      exec env bash /opt/meshcentral/entrypoint.sh
```