### PR TITLE
Fix: Installation Type dropdown hidden for Linux and macOS invites

### DIFF
--- a/views/default.handlebars
+++ b/views/default.handlebars
@@ -5662,10 +5662,10 @@
             if (features & 64) {
                 QV('urlInviteDiv', Q('d2InviteType').value == 0);
                 QV('d2agentexpirediv', Q('agentInviteNameOs').value == 4);
-                QV('d2agentInstallTypeDiv2', Q('agentInviteNameOs').value < 2);
+                QV('d2agentInstallTypeDiv2', [0,1,2,3].indexOf(parseInt(Q('agentInviteNameOs').value)) > -1);
                 QV('emailInviteDiv', Q('d2InviteType').value == 1);
             }
-            QV('d2agentInstallTypeDiv', parseInt(Q('d2agentType').value) < 2);
+            QV('d2agentInstallTypeDiv', [0,1,2,4].indexOf(parseInt(Q('d2agentType').value)) > -1);
             validateAgentInvite();
             d2RequestInvitationLink();
         }
@@ -14887,7 +14887,7 @@
             QE('agentType', Q('agentJoinCheck').checked);
             QE('agentInviteType', Q('agentJoinCheck').checked);
             QE('idx_dlgOkButton', (Q('agentJoinCheck').checked == false) || (ok));
-            QV('d2agentInstallTypeDiv', parseInt(Q('agentType').value) < 2);
+            QV('d2agentInstallTypeDiv', [0,1,2,4].indexOf(parseInt(Q('agentType').value)) > -1);
         }
 
         function p20editmeshInviteCodeEx() {


### PR DESCRIPTION
## Problem

When creating an agent invite, the **Installation Type** dropdown is hidden when Linux or macOS is selected as the OS. It only appears for Windows (OS values 0 and 1).

This makes it impossible to create a one-time / interactive invite for Linux or macOS — the UI hides the control before the user has a chance to set it. The value persists in the DOM if you set it while Windows is selected and then switch, but there's no way to discover or use this as a regular user.

## Root cause

Three calls to `QV()` in `d2ChangedInviteType()` and related handlers use a `< 2` condition to decide whether to show the Installation Type div:

```js
// Before — only shows for OS 0 (Windows x64) and 1 (Windows x86)
QV('d2agentInstallTypeDiv', parseInt(Q('d2agentType').value) < 2)
QV('d2agentInstallTypeDiv2', Q('agentInviteNameOs').value < 2)
QV('d2agentInstallTypeDiv', parseInt(Q('agentType').value) < 2)
```

OS values in the invite dialog:
| Value | OS |
|-------|----|
| 0 | Windows x64 |
| 1 | Windows x86 |
| 2 | Linux |
| 3 | Linux (ARM) |
| 4 | macOS |

## Fix

Replace the `< 2` condition with an explicit allowlist using `indexOf()`:

```js
// After — shows for Windows, Linux, and macOS
QV('d2agentInstallTypeDiv', [0,1,2,4].indexOf(parseInt(Q('d2agentType').value)) > -1)
QV('d2agentInstallTypeDiv2', [0,1,2,3].indexOf(parseInt(Q('agentInviteNameOs').value)) > -1)
QV('d2agentInstallTypeDiv', [0,1,2,4].indexOf(parseInt(Q('agentType').value)) > -1)
```

The `installflags` parameter in the generated invite URL is already wired up correctly for Linux — this is purely a UI visibility bug.

## Testing

1. Open **My Mesh** → **Invite Agent**
2. Select **Linux** as the OS
3. Confirm the Installation Type dropdown is now visible
4. Set it to **Interactive Only** and generate the invite
5. Confirm `installflags=1` appears in the generated URL