### PR TITLE
Fix --resetaccount not clearing Duo 2FA (missing delete keyword)

### DIFF
--- a/meshcentral.js
+++ b/meshcentral.js
@@ -1024,7 +1024,7 @@ function CreateMeshCentralServer(config, args) {
                             if (err != null) { console.log("Database error: " + err); process.exit(); return; }
                             if ((docs == null) || (docs.length == 0)) { console.log("Unknown userid, usage: --resetaccount [userid] --domain (domain) --pass [password]."); process.exit(); return; }
                             const user = docs[0]; if ((user.siteadmin) && (user.siteadmin != 0xFFFFFFFF) && (user.siteadmin & 32) != 0) { user.siteadmin -= 32; } // Unlock the account.
-                            delete user.phone; delete user.otpekey; delete user.otpsecret; delete user.otpkeys; delete user.otphkeys; delete user.otpdev; delete user.otpsms; delete user.otpmsg; user.otpduo; // Disable 2FA
+                            delete user.phone; delete user.otpekey; delete user.otpsecret; delete user.otpkeys; delete user.otphkeys; delete user.otpdev; delete user.otpsms; delete user.otpmsg; delete user.otpduo; // Disable 2FA
                             delete user.msghandle; // Disable users 2fa messaging too
                             var config = getConfig(false);
                             if (config.domains[user.domain].auth || config.domains[user.domain].authstrategies) {


### PR DESCRIPTION
Follow-up to commit 1399ce35 ("forgot 2 extra otpduo to clear!"), which added otpduo cleanup in two places. The meshuser.js side correctly used `delete chguser.otpduo;`. The meshcentral.js --resetaccount path got `user.otpduo;` instead of `delete user.otpduo;` -- the `delete` keyword was lost. As a bare expression statement it has no effect.

Effect: an administrator running --resetaccount to unlock a user that has Duo 2FA configured will see all other 2FA fields cleared, but the Duo record on the user document survives. On next login the server still requires Duo authentication, defeating the account-recovery purpose.

Related historical reports of --resetaccount not clearing specific 2FA mechanisms: #3455 (original "not clearing 2 factor"), #5310 (ntfy variant), #5331 (messaging cleanup PR).