### PR TITLE
Fix PostgreSQL cleanup query that never deletes orphan mesh rows (and…

### DIFF
--- a/db.js
+++ b/db.js
@@ -454,7 +454,7 @@ module.exports.CreateDB = function (parent, func) {
 
                         } else if (obj.databaseType == DB_POSTGRESQL) {
                             // Postgres
-                            sqlDbQuery('DELETE FROM Main WHERE ((extra != NULL) AND (extra LIKE (\'mesh/%\')) AND (extra != ANY ($1)))', [meshlist], function (err, response) { });
+                            sqlDbQuery('DELETE FROM main WHERE extra LIKE \'mesh/%\' AND extra <> ALL ($1)', [meshlist], function (err, response) { });
                         } else if ((obj.databaseType == DB_MARIADB) || (obj.databaseType == DB_MYSQL)) {
                             // MariaDB
                             sqlDbQuery('DELETE FROM Main WHERE (extra LIKE ("mesh/%") AND (extra NOT IN ?)', [meshlist], function (err, response) { });


### PR DESCRIPTION
… would mass-delete if naively fixed)

The cleanup pass on PostgreSQL is supposed to garbage-collect rows whose `extra` references a mesh ID that no longer exists in the current `meshlist` (matching the MongoDB branch a few lines down). As written:

    DELETE FROM Main WHERE ((extra != NULL)
                       AND (extra LIKE ('mesh/%'))
                       AND (extra != ANY ($1)))

Two interlocking bugs:

1. `extra != NULL` is an invalid null comparison. In three-valued logic, `<expr> != NULL` evaluates to NULL, which the WHERE clause treats as falsy. The AND chain is therefore always NULL/falsy, and zero rows are never deleted. PostgreSQL's `transform_null_equals` setting only affects `=`, not `<>`/`!=`, and is off by default. Result today: cleanup silently no-ops on Postgres, and orphan mesh-extra rows accumulate forever.

2. `<> ANY (array)` is *not* "not in the list" semantics. It returns TRUE when at least one array element is not equal to the value -- which is true for almost every input as soon as `meshlist` has 2+ distinct elements. Naively fixing only bug 1 (e.g., to `extra IS NOT NULL`) would mass-delete every row matching `extra LIKE 'mesh/%'`, including rows whose mesh is in the current list. The correct form is `<> ALL (array)`.

This patch replaces both with:

    DELETE FROM main WHERE extra LIKE 'mesh/%' AND extra <> ALL ($1)

The redundant `extra != NULL` predicate is dropped because `extra LIKE 'mesh/%'` already filters out NULLs. The `<> ALL` form matches the intent of the parallel MongoDB query (`{ meshid: { $exists: true, $nin: meshlist } }`).

`Main` -> `main` is cosmetic only to match other queries throughout the file.