### PR TITLE
Fix RemoveAllNodeEvents callers passing only nodeid (silent no-op cleanup)

### DIFF
--- a/db.js
+++ b/db.js
@@ -241,7 +241,7 @@ module.exports.CreateDB = function (parent, func) {
                                     obj.Remove('si' + node._id);                          // Remove system information
                                     obj.Remove('al' + node._id);                          // Remove error log last time
                                     if (obj.RemoveSMBIOS) { obj.RemoveSMBIOS(node._id); } // Remove SMBios data
-                                    obj.RemoveAllNodeEvents(node._id);                    // Remove all events for this node
+                                    obj.RemoveAllNodeEvents(node.domain, node._id);       // Remove all events for this node
                                     obj.removeAllPowerEventsForNode(node._id);            // Remove all power events for this node
                                     if (typeof node.pmt == 'string') { obj.Remove('pmt_' + node.pmt); } // Remove Push Messaging Token
                                     obj.Get('ra' + node._id, function (err, nodes) {

--- a/meshagent.js
+++ b/meshagent.js
@@ -98,7 +98,7 @@ module.exports.CreateMeshAgent = function (parent, db, ws, req, args, domain) {
             db.Remove('si' + obj.dbNodeKey);                          // Remove system information
             db.Remove('al' + obj.dbNodeKey);                          // Remove error log last time
             if (db.RemoveSMBIOS) { db.RemoveSMBIOS(obj.dbNodeKey); }  // Remove SMBios data
-            db.RemoveAllNodeEvents(obj.dbNodeKey);                    // Remove all events for this node
+            db.RemoveAllNodeEvents(domain.id, obj.dbNodeKey);         // Remove all events for this node
             db.removeAllPowerEventsForNode(obj.dbNodeKey);            // Remove all power events for this node
 
             // Event node deletion

--- a/meshcentral.js
+++ b/meshcentral.js
@@ -1098,7 +1098,7 @@ function CreateMeshCentralServer(config, args) {
                                         db.Remove('lc' + node._id);                          // Remove last connect time
                                         db.Remove('si' + node._id);                          // Remove system information
                                         if (db.RemoveSMBIOS) { db.RemoveSMBIOS(node._id); }  // Remove SMBios data
-                                        db.RemoveAllNodeEvents(node._id);                    // Remove all events for this node
+                                        db.RemoveAllNodeEvents(node.domain, node._id);       // Remove all events for this node
                                         db.removeAllPowerEventsForNode(node._id);            // Remove all power events for this node
                                         if (typeof node.pmt == 'string') { db.Remove('pmt_' + node.pmt); } // Remove Push Messaging Token
                                         db.Get('ra' + node._id, function (err, nodes) {

--- a/meshuser.js
+++ b/meshuser.js
@@ -2852,7 +2852,7 @@ module.exports.CreateMeshUser = function (parent, db, ws, req, args, domain, use
                             db.Remove('si' + node._id);                          // Remove system information
                             db.Remove('al' + node._id);                          // Remove error log last time
                             if (db.RemoveSMBIOS) { db.RemoveSMBIOS(node._id); }  // Remove SMBios data
-                            db.RemoveAllNodeEvents(node._id);                    // Remove all events for this node
+                            db.RemoveAllNodeEvents(node.domain, node._id);       // Remove all events for this node
                             db.removeAllPowerEventsForNode(node._id);            // Remove all power events for this node
                             if (typeof node.pmt == 'string') { db.Remove('pmt_' + node.pmt); } // Remove Push Messaging Token
                             db.Get('ra' + node._id, function (err, nodes) {


### PR DESCRIPTION
_Loosely related (not duplicates): #7787 / #7788 / #7246 are about the time-based event-retention sweep being slow on large Postgres event tables. The per-device cleanup fixed here is a separate code path, but it contributes to the same observed symptom (event tables on SQL backends growing larger than expected) since every device removal since the bug landed has been skipping its event history._

`RemoveAllNodeEvents(domain, nodeid)` in every db.js backend starts with `if ((domain == null) || (nodeid == null)) return;` so a caller that passes only one argument leaves `nodeid` undefined and the early-return swallows the whole call. As a result, every device-removal path that should also clear the device's event history has been silently leaving those rows behind on every backend (NeDB/MongoDB TTL-expires them eventually; SQLite, PostgreSQL, MariaDB/MySQL, and AceBase keep them until manual cleanup).

Four callers fixed here:

  db.js:244           // removeInactiveDevices
  meshcentral.js:1101 // test/diagnostic-agent cleanup
  meshuser.js:2855    // user-triggered manual device removal
  meshagent.js:101    // agent self-removal on close (temporary/recovery flags)

For each, the domain string is already in scope -- `node.domain` on the node-iteration paths and `domain.id` in meshagent (parameter at line 18 of CreateMeshAgent).

- [ ] **_`A fifth caller exists at meshipkvm.js:244 with the same shape, but it is deliberately left for a follow-up. The IP-KVM auto-remove subsystem (Raritan / WebPowerSwitch, gated on the per-mesh auto-remove flag) is niche enough that I could not personally verify it and would rather not patch a path I cannot test.`_**



== How this was verified ==

Tested locally with a small harness using Node's built-in `node --test` (no new dependencies). Kept local to my fork rather than introducing a `test/` directory in MeshCentral; happy to send the harness as a separate PR if useful.

1. Arity scan: walks every .js file in the repo, finds every `RemoveAllNodeEvents(...)` call (paren-depth-aware, comment- and string-aware), and asserts each has exactly 2 args. Run on master, the test reports 5 buggy call sites. After this fix, only the intentionally-deferred meshipkvm.js:244 site remains -- the test makes that one easy to revisit.

2. Function-contract test: pins the canonical shape -- null/undefined domain or nodeid short-circuits (the F-DB-08 shape), valid pair reaches the datastore exactly once with the right query, and empty string '' (the default-domain id) is passed through (the guard is `== null`, not `!domain`, so '' is not nullish).