### PR TITLE
meshdevicefile: only pause source socket when HTTP write buffer fills

### DIFF
--- a/meshdevicefile.js
+++ b/meshdevicefile.js
@@ -224,10 +224,18 @@ module.exports.CreateMeshDeviceFile = function (parent, ws, res, req, domain, us
                         }
                     }
                 } else {
-                    var unpause = function unpauseFunc(err) { try { unpauseFunc.s.resume(); } catch (ex) { } }
-                    unpause.s = this._socket;
-                    this._socket.pause();
-                    try { this.res.write(data, unpause); } catch (ex) { }
+                    // Only apply backpressure when the HTTP write buffer actually fills,
+                    // instead of pausing/resuming the source socket on every chunk.
+                    // The previous unconditional pause+resume per chunk forced stop-and-wait
+                    // on every frame, capping device file download throughput around 2 Mbit/s
+                    // for any client whose RTT to the server is non-trivial.
+                    try {
+                        if (this.res.write(data) === false) {
+                            var sock = this._socket;
+                            sock.pause();
+                            this.res.once('drain', function () { try { sock.resume(); } catch (ex) { } });
+                        }
+                    } catch (ex) { }
                 }
             });
 


### PR DESCRIPTION
## Problem

`meshdevicefile.js` currently issues an unconditional `pause()` on the agent WebSocket for every binary frame, then resumes from the `res.write()` callback. This is correct backpressure handling but forces stop-and-wait on every chunk — each frame must wait for the HTTP write callback before the next one can flow from the agent.

Combined with the small chunk size the agent emits and any non-trivial RTT between agent and server, this caps device file download throughput at around **2 Mbit/s on real WAN agents** regardless of available bandwidth.

This is the root cause behind recurring slow-file-transfer reports such as #5347 and #3550.

## Fix

Standard Node.js streaming pattern: only call `pause()` when `res.write()` returns `false` (the HTTP write buffer actually is full), and resume on the next `drain` event. Otherwise frames flow continuously and TCP handles overload through its own backpressure.

```js
} else {
    try {
        if (this.res.write(data) === false) {
            var sock = this._socket;
            sock.pause();
            this.res.once('drain', function () { try { sock.resume(); } catch (ex) { } });
        }
    } catch (ex) { }
}
```

## Measurement

Production deployment, 29 random Win10/Win11 agents across distinct customer networks (10 MB random file, fetched via `/devicefile.ashx`):

| Metric | Before | After | Change |
|---|---|---|---|
| Median | 250 KB/s (~2 Mbit/s) | **2.71 MB/s (~21.7 Mbit/s)** | **~11×** |
| Mean | similar | 2.53 MB/s (~20 Mbit/s) | |
| P25–P75 | – | 2.60 – 2.74 MB/s (tight) | very stable |
| Best | – | 3.40 MB/s | |
| Errors | – | 0/29 | |

A 60 MB transfer drops from ~4 minutes to ~22 seconds for affected clients.

## Notes

- Agents that emit very small WS frames with their own host-side throttling (e.g. older Windows 7 MeshAgent builds from early 2025) do not benefit as much — there the agent itself is the bottleneck.
- No changes to the agent. Server-only.
- Affects only the binary-relay branch (HTTP download of agent files); the JSON/control path is untouched.