### PR TITLE
Fix typo: dev.temp.password -> dev.temp.pass in TLS-ACM activation

### DIFF
--- a/amtmanager.js
+++ b/amtmanager.js
@@ -2892,7 +2892,7 @@ module.exports.CreateAmtManager = function (parent) {
 
         // See what admin password to use
         dev.aquired.user = 'admin';
-        dev.aquired.pass = dev.temp.password;
+        dev.aquired.pass = dev.temp.pass;
 
         // Set the account password
         if (typeof dev.temp.mebxpass == 'string') {


### PR DESCRIPTION
In activateIntelAmtTlsAcm(), the selected AMT password is stored as dev.temp.pass. activateIntelAmtTlsAcmEx1() logs that same field at line 2889, but then assigns dev.aquired.pass = dev.temp.password at line 2895. No code in this flow writes dev.temp.password, so dev.aquired.pass becomes undefined. The TLS ACM admin-password call then computes the Digest HA1 from dev.aquired.pass at line 2905 (or line 2917 after the MEBx-password branch), making the configured AMT admin credential deterministic.

The parallel CCM (lines 2689, 2717) and non-TLS ACM (lines 2977, 3034) activation paths already use dev.temp.pass correctly.

Note: Verified by Claude Code (Claude Opus 4.7, 1M context) and independent second-pass review by OpenAI Codex
