### PR TITLE
Fix typo: pass -> password key in bare-metal ACM activation log entry

### DIFF
--- a/amtprovisioningserver.js
+++ b/amtprovisioningserver.js
@@ -479,7 +479,22 @@ module.exports.CreateAmtProvisioningServer = function (parent, config) {
 
             // Save activation data to amtactivation.log
             var domain = parent.config.domains[dev.domainid];
-            obj.logAmtActivation(domain, { time: new Date(), action: 'acmactivate-bare-metal', domain: dev.domainid, amtUuid: dev.guid, newmebx: config.newmebxpassword, mesh: dev.meshid, amtRealm: dev.aquired.realm, amtver: dev.aquired.version, host: dev.aquired.host, ip: dev.addr, user: dev.aquired.user, pass: dev.aquired.pass, tls: dev.aquired.tls, tlshash: dev.aquired.hash });
+            obj.logAmtActivation(domain, {
+                time: new Date(),
+                action: 'acmactivate-bare-metal',
+                domain: dev.domainid,
+                amtUuid: dev.guid,
+                newmebx: config.newmebxpassword,
+                mesh: dev.meshid,
+                amtRealm: dev.aquired.realm,
+                amtver: dev.aquired.version,
+                host: dev.aquired.host,
+                ip: dev.addr,
+                user: dev.aquired.user,
+                password: dev.aquired.pass,
+                tls: dev.aquired.tls,
+                tlshash: dev.aquired.hash
+            });
 
             // Update device in the database
             if (UpdateDevice(dev) == false) return;


### PR DESCRIPTION
The bare-metal ACM activation path at amtprovisioningserver.js:482 writes its log entry under the key 'pass', while every other credential-bearing logAmtActivation caller uses 'password':
  amtmanager.js:731 (runtime password change)
  amtmanager.js:2684 (CCM activation)
  amtmanager.js:2889 (TLS-ACM activation)
  certoperations.js:120 (ACM sign request)

Because the startup loader (meshcentral.js:3800) and the in-line consumer in this same file (amtprovisioningserver.js:635) both gate on typeof <obj>.password == 'string', bare-metal entries write to disk but never enter the in-memory amtPasswords cache. The multi-password fallback in amtmanager.js:577-579 therefore has no cached candidate to try for these devices.

Forward-only: existing 'pass'-keyed entries remain skipped by the loader.

Note: Verified by Claude Code (Claude Opus 4.7, 1M context) and independent second-pass review by OpenAI Codex.
