### PR TITLE
win-wmi-fixed: Make query() and queryAsync() more robust and failsafe

### DIFF
--- a/agents/meshcore.js
+++ b/agents/meshcore.js
@@ -4630,7 +4630,9 @@ function processConsoleCommand(cmd, args, rights, sessionid) {
                 var q = (args['_'][1]).trim();
                 var wmi = require('win-wmi-fixed');
                 var output = function (res) { sendConsoleText(res && res[0] ? JSON.stringify(res, null, ((opt.indexOf('p') !== -1) ? 2 : 0)) : 'No results', sessionid); };
-                var error = function (e) { var msg = (e && e.message) ? e.message : (typeof e === 'string' ? e : JSON.stringify(e)); sendConsoleText('Error: ' + msg, sessionid);};
+                var error = function (e) {
+                    var msg = (e && e.message) ? e.message : (typeof e === 'string' ? e : JSON.stringify(e));
+                    sendConsoleText((e.results ? 'Partial result:\r\n' + JSON.stringify(e.results) + '\r\nPartial resultcount: ' + e.results.length : '') + '\r\nError: ' + msg, sessionid);};
                 sendConsoleText('Performing query. Response can take a while (sometimes >60s)', sessionid);
                 if (opt.indexOf('a') !== -1) {
                     wmi.queryAsync(ns, q, null, (opt.indexOf('i') !== -1), ((opt.indexOf('s') !== -1) ? sessionid : null))

--- a/agents/meshcore.js
+++ b/agents/meshcore.js
@@ -4620,26 +4620,33 @@ function processConsoleCommand(cmd, args, rights, sessionid) {
                     break;
                 }
                 if (args['_'].length < 2 || args['_'].length > 3) {
-                    response = 'Execute a WMI query.\r\nUsage: wmi namespace "query" [(a)sync][(p)rettyless][(s)ilent][(i)ncludesystemproperties]\r\n' +
-                            'Example: wmi [ROOT\\]CIMV2 "SELECT Name,ProcessId FROM Win32_Process WHERE Name=\'meshagent.exe\'" ia\r\n';
+                    response = 'Execute a WMI query.\r\nUsage: wmi namespace "query" [(n)sync][(u)npretty][(s)ilence][(i)ncludesystemproperties]\r\n' +
+                            'Default: async, pretty and shows progress\r\n' +
+                            'Note: Sync queries block the agent for the duration of the query\r\n' +
+                            'Example: wmi CIMV2 "SELECT Name,ProcessId FROM Win32_Process WHERE Name=\'meshagent.exe\'" in\r\n';
                     break;
                 }
                 var opt = (args['_'][2]|| '').toLowerCase();
                 var ns = args['_'][0].trim();
                 if (!/^root\\\w/i.test(ns)) { ns = 'ROOT\\' + ns; }
                 var q = (args['_'][1]).trim();
+                var indent = (opt.indexOf('u') === -1); // unpretty, so default true
+                var showProgress = (opt.indexOf('s') === -1);   //s is now silence
+                var includeSysProp = (opt.indexOf('i') !== -1);
+                var async = opt.indexOf('n') === -1;
                 var wmi = require('win-wmi-fixed');
-                var output = function (res) { sendConsoleText(res && res[0] ? JSON.stringify(res, null, ((opt.indexOf('p') === -1) ? 2 : 0)) : 'No results', sessionid); };
+                var output = function (res) { sendConsoleText((res && res.length > 0) ? (JSON.stringify(res, null, (indent ? 2 : 0))) : 'No results', sessionid); };
                 var error = function (e) {
-                    var msg = (e && e.message) ? e.message : (typeof e === 'string' ? e : JSON.stringify(e));
-                    sendConsoleText((e.results ? 'Partial result:\r\n' + JSON.stringify(e.results, null, ((opt.indexOf('p') === -1) ? 2 : 0)) + '\r\nPartial resultcount: ' + e.results.length : '') + '\r\nError: ' + msg, sessionid);};
-                if (opt.indexOf('s') === -1) { sendConsoleText('Performing query.', sessionid); }
-                if (opt.indexOf('a') !== -1) {
-                    wmi.queryAsync(ns, q, null, (opt.indexOf('i') !== -1), null, ((opt.indexOf('s') === -1) ? sessionid : null))
+                    e = e || {};
+                    sendConsoleText(((e.results && e.results.length) ? 'Partial result:\r\n' + JSON.stringify(e.results, null, (indent ? 2 : 0)) + '\r\nPartial resultcount: ' + e.results.length + '\r\n' : '') +
+                        'Error: ' + (e.message || JSON.stringify(e)), sessionid); };
+                if (showProgress) { sendConsoleText('Performing ' + (async ? 'asynchronous ': '') + 'query ' + (async ? '': 'synchronously (be careful with large queries as it blocks the agent for the duration)'), sessionid); }
+                if (async) {
+                    wmi.queryAsync(ns, q, null, includeSysProp, null, (showProgress ? sessionid : null))
                     .then( output )
                     .catch( error );
                 } else {
-                    try { output(wmi.query(ns, q, null, (opt.indexOf('i') !== -1), null, ((opt.indexOf('s') === -1) ? sessionid : null) )); } catch (e) { error(e); }
+                    try { output(wmi.query(ns, q, null, includeSysProp, null, (showProgress ? sessionid : null) )); } catch (e) { error(e); }
                 }
                 break;
             case 'translations': {

--- a/agents/meshcore.js
+++ b/agents/meshcore.js
@@ -4620,8 +4620,8 @@ function processConsoleCommand(cmd, args, rights, sessionid) {
                     break;
                 }
                 if (args['_'].length < 2 || args['_'].length > 3) {
-                    response = 'Execute a WMI query.\r\nUsage: wmi namespace "query" [(a)sync][(p)retty]\r\n' +
-                            'Example: wmi [ROOT\\]CIMV2 "SELECT Name,ProcessId FROM Win32_Process WHERE Name=\'meshagent.exe\'" ap\r\n';
+                    response = 'Execute a WMI query.\r\nUsage: wmi namespace "query" [(a)sync][(p)retty][(s)showprogress][(i)ncludesystemproperties]\r\n' +
+                            'Example: wmi [ROOT\\]CIMV2 "SELECT Name,ProcessId FROM Win32_Process WHERE Name=\'meshagent.exe\'" aps\r\n';
                     break;
                 }
                 var opt = (args['_'][2]|| '').toLowerCase();
@@ -4633,11 +4633,11 @@ function processConsoleCommand(cmd, args, rights, sessionid) {
                 var error = function (e) { var msg = (e && e.message) ? e.message : (typeof e === 'string' ? e : JSON.stringify(e)); sendConsoleText('Error: ' + msg, sessionid);};
                 sendConsoleText('Performing query. Response can take a while (sometimes >60s)', sessionid);
                 if (opt.indexOf('a') !== -1) {
-                    wmi.queryAsync(ns, q)
+                    wmi.queryAsync(ns, q, null, (opt.indexOf('i') !== -1), ((opt.indexOf('s') !== -1) ? sessionid : null))
                     .then( output )
                     .catch( error );
                 } else {
-                    try { output(wmi.query(ns, q)); } catch (e) { error(e); }
+                    try { output(wmi.query(ns, q, null, (opt.indexOf('i') !== -1), ((opt.indexOf('s') !== -1) ? sessionid : null) )); } catch (e) { error(e); }
                 }
                 break;
             case 'translations': {

--- a/agents/meshcore.js
+++ b/agents/meshcore.js
@@ -4620,8 +4620,8 @@ function processConsoleCommand(cmd, args, rights, sessionid) {
                     break;
                 }
                 if (args['_'].length < 2 || args['_'].length > 3) {
-                    response = 'Execute a WMI query.\r\nUsage: wmi namespace "query" [(a)sync][(p)retty][(s)showprogress][(i)ncludesystemproperties]\r\n' +
-                            'Example: wmi [ROOT\\]CIMV2 "SELECT Name,ProcessId FROM Win32_Process WHERE Name=\'meshagent.exe\'" aps\r\n';
+                    response = 'Execute a WMI query.\r\nUsage: wmi namespace "query" [(a)sync][(p)rettyless][(s)ilent][(i)ncludesystemproperties]\r\n' +
+                            'Example: wmi [ROOT\\]CIMV2 "SELECT Name,ProcessId FROM Win32_Process WHERE Name=\'meshagent.exe\'" ia\r\n';
                     break;
                 }
                 var opt = (args['_'][2]|| '').toLowerCase();
@@ -4629,17 +4629,17 @@ function processConsoleCommand(cmd, args, rights, sessionid) {
                 if (!/^root\\\w/i.test(ns)) { ns = 'ROOT\\' + ns; }
                 var q = (args['_'][1]).trim();
                 var wmi = require('win-wmi-fixed');
-                var output = function (res) { sendConsoleText(res && res[0] ? JSON.stringify(res, null, ((opt.indexOf('p') !== -1) ? 2 : 0)) : 'No results', sessionid); };
+                var output = function (res) { sendConsoleText(res && res[0] ? JSON.stringify(res, null, ((opt.indexOf('p') === -1) ? 2 : 0)) : 'No results', sessionid); };
                 var error = function (e) {
                     var msg = (e && e.message) ? e.message : (typeof e === 'string' ? e : JSON.stringify(e));
-                    sendConsoleText((e.results ? 'Partial result:\r\n' + JSON.stringify(e.results) + '\r\nPartial resultcount: ' + e.results.length : '') + '\r\nError: ' + msg, sessionid);};
-                sendConsoleText('Performing query. Response can take a while (sometimes >60s)', sessionid);
+                    sendConsoleText((e.results ? 'Partial result:\r\n' + JSON.stringify(e.results, null, ((opt.indexOf('p') === -1) ? 2 : 0)) + '\r\nPartial resultcount: ' + e.results.length : '') + '\r\nError: ' + msg, sessionid);};
+                if (opt.indexOf('s') === -1) { sendConsoleText('Performing query.', sessionid); }
                 if (opt.indexOf('a') !== -1) {
-                    wmi.queryAsync(ns, q, null, (opt.indexOf('i') !== -1), ((opt.indexOf('s') !== -1) ? sessionid : null))
+                    wmi.queryAsync(ns, q, null, (opt.indexOf('i') !== -1), null, ((opt.indexOf('s') === -1) ? sessionid : null))
                     .then( output )
                     .catch( error );
                 } else {
-                    try { output(wmi.query(ns, q, null, (opt.indexOf('i') !== -1), ((opt.indexOf('s') !== -1) ? sessionid : null) )); } catch (e) { error(e); }
+                    try { output(wmi.query(ns, q, null, (opt.indexOf('i') !== -1), ((opt.indexOf('s') === -1) ? sessionid : null) )); } catch (e) { error(e); }
                 }
                 break;
             case 'translations': {

--- a/agents/meshcore.js
+++ b/agents/meshcore.js
@@ -4639,7 +4639,7 @@ function processConsoleCommand(cmd, args, rights, sessionid) {
                     .then( output )
                     .catch( error );
                 } else {
-                    try { output(wmi.query(ns, q, null, (opt.indexOf('i') !== -1), ((opt.indexOf('s') === -1) ? sessionid : null) )); } catch (e) { error(e); }
+                    try { output(wmi.query(ns, q, null, (opt.indexOf('i') !== -1), null, ((opt.indexOf('s') === -1) ? sessionid : null) )); } catch (e) { error(e); }
                 }
                 break;
             case 'translations': {

--- a/agents/modules_meshcore/win-wmi-fixed.js
+++ b/agents/modules_meshcore/win-wmi-fixed.js
@@ -178,7 +178,7 @@ const QueryAsyncHandler =
             cx: 12, parms: 1, name: 'Release', func: function ()
             {
                 // console.log('Release: ' + this.refcount);
-                if (--this.refcount === 0) { console.log('Released');
+                if (--this.refcount === 0) { // console.log('Released');
                     destroy(this); }
                 return GM.CreateVariable(4).increment(this.refcount >>> 0, true);   // return new refCount
             }
@@ -187,7 +187,7 @@ const QueryAsyncHandler =
             cx: 13, parms: 3, name: 'Indicate', func: function (sink, count, arr)
             {
                 // console.log('Indicate: ' + count.Val);
-                if (this._abandoned || this.results === null) { return (GM.CreateVariable(4).increment(0, true)); }   // discard
+                if (this._abandoned) { return (GM.CreateVariable(4).increment(0, true)); }   // discard
                 if (this.sessionid) {
                     this.progress += count.Val;
                     var now = Date.now();
@@ -198,11 +198,16 @@ const QueryAsyncHandler =
                 for (var i = 0; i < count.Val; ++i)
                 {
                     var wmiResultObj  = arr.Deref((i * GM.PointerSize) + 0, GM.PointerSize);
-                    if (this.reqFields != null) {
-                        this.results.push(enumerateProperties(wmiResultObj , this.reqFields, this.fixedNameVars));
-                    } else {
-                        var e = this.cache.forRow(wmiResultObj );
-                        this.results.push(enumerateProperties(wmiResultObj , e.propNames, e.propNameVars));
+                    try {
+                        if (this.reqFields != null) {
+                            this.results.push(enumerateProperties(wmiResultObj, this.reqFields, this.fixedNameVars));
+                        } else {
+                            var c = this.cache.forRow(wmiResultObj);
+                            this.results.push(enumerateProperties(wmiResultObj, c.propNames, c.propNameVars));
+                        }
+                    } catch (e) {
+                        // only skip, not throw
+                        console.log('win-wmi Indicate row error: ' + (e && e.message ? e.message : e));
                     }
                 }
                 return GM.CreateVariable(4).increment(0, true); //Indicate must always return WBEM_S_NO_ERROR=0
@@ -483,7 +488,6 @@ function enumerateProperties(wmiResultObj, propNames, propNameVars)
         }
         OleAut32.VariantClear(propVal);
     }
-
     return (values);
 }
 
@@ -501,7 +505,6 @@ function queryAsync(resourceString, queryString, fields, includeSysProp, timeout
         if (GM.PointerSize == 4 && Object.keys(wmi_handlers).length != 0) {
             setImmediate(function(){ p.reject(new Error('Another AsyncQuery is already running, only one AsyncQuery possible at a time on 32-bit Windows')); }); return (p); }
         if (!timeout || typeof timeout !== 'number') { timeout = 120 * 1000 };       //Default timeout set to 2m
-        if (timeout < 500) { timeout *= 1000 }  // assume timeout given in seconds, as quicker than 500ms timeouts are unrealistic
         var pq = prepareQuery(queryString, fields);
         queryString = pq.q;
         var reqFields = pq.f;
@@ -551,8 +554,8 @@ function queryAsync(resourceString, queryString, fields, includeSysProp, timeout
             // Reject the promise and clean that part up, hoping the wmi query resolves eventually and cleans itself up through SetStatus
             // There seems to be not other way to stop a hung/long query
             handlers._abandoned = true;     // Signal SetStatus we'll reject
-            var e = new Error('WMI query timed out');
-            if (handlers.sessionid && handlers.results.length > 0) { e.results = handlers.results; }
+            var e = new Error('WMI query timed out after ' + (timeout/1000) + ' seconds');
+            if (handlers.results.length > 0) { e.results = handlers.results; }
             handlers.p.reject(e);
         }, timeout);
     } catch (e) {
@@ -567,11 +570,14 @@ function queryAsync(resourceString, queryString, fields, includeSysProp, timeout
 }
 
 // (optional) includeSysProp, default=false. Include system properties (__CLASS, etc.)
+// (optional) timeout, default=120 seconds. Query duration timeout in ms
 // (optional) sessionid, default=null. Report progress back to the given sessionid.
-function query(resourceString, queryString, fields, includeSysProp, sessionid)
+function query(resourceString, queryString, fields, includeSysProp, timeout, sessionid)
 {
+    const uCount = 32;  // number of rows to retrieve per round
     var ret = [];
     try {
+        if (!timeout || typeof timeout !== 'number') { timeout = 120 * 1000 };       //Default timeout set to 2m
         var pq = prepareQuery(queryString, fields);
         queryString = pq.q;
         var reqFields = pq.f;
@@ -586,7 +592,7 @@ function query(resourceString, queryString, fields, includeSysProp, sessionid)
         var language = GM.CreateVariable("WQL", { wide: true });
         var query = GM.CreateVariable(queryString, { wide: true });
         var results = GM.CreatePointer();
-        if (sessionid) { var MA = require('MeshAgent'), progress = 0, lastProg =  0, progStart = Date.now(); }
+        if (sessionid) { var MA = require('MeshAgent'), progress = 0, lastProg =  0 }
         // Connect the locator connection for WMI
         var locator = COM.createInstance(COM.CLSIDFromString(CLSID_WbemAdministrativeLocator), COM.IID_IUnknown);
         locator.funcs = COM.marshalFunctions(locator, LocatorFunctions);
@@ -604,47 +610,56 @@ function query(resourceString, queryString, fields, includeSysProp, sessionid)
         if ((hr = services.funcs.ExecQuery(services.Deref(), language, query, WBEM_FLAG_FORWARD_ONLY | WBEM_FLAG_RETURN_IMMEDIATELY, 0, results).Val >>> 0) != 0) {
             throw new Error('ExecQuery() failed: ' + (WBEM_ERRORS[hr] || 'unknown') + ' (0x' + hr.toString(16) + ')'); }
 
-        results.funcs = COM.marshalFunctions(results.Deref(), ResultsFunctions);
-        var returnedCount = GM.CreateVariable(8);
-        var result = GM.CreatePointer();
-        var nextRes;
         // https://learn.microsoft.com/en-us/windows/win32/api/wbemcli/nf-wbemcli-ienumwbemclassobject-next
-        var retries = 0, rowTimeout = 10*1000; // rowTimeout was WBEM_INFINITE. in ms. Prevents blocking.
+        // Batch retrieve per round instead of the original 1. Improves speed on larger sets as it lowers COM calls, like the asyncHandler does
+        // nextRes=WBEM_S_FALSE: signals the last set. Check returnedCount if rows left to process
+        // nextRes=WBEM_S_NO_ERROR: returnedCount equal to requested number
+        results.funcs = COM.marshalFunctions(results.Deref(), ResultsFunctions);
+        var apObjects = GM.CreateVariable(uCount * GM.PointerSize);
+        var returnedCount = GM.CreateVariable(4);   // ULONG puReturned
+        var retries = 0, rowTimeout = 10 * 1000;    // rowTimeout was WBEM_INFINITE. in ms. Prevents blocking. Generates WBEM_S_TIMEDOUT on timeout
+        var progStart = Date.now();
         while (true) {
-            nextRes = results.funcs.Next(results.Deref(), rowTimeout, 1, result, returnedCount).Val >>> 0;
-            if (nextRes === WBEM_S_FALSE) break; // normal exit
-            if (nextRes >= 0x80000000 ) { throw new Error('Next() failed: ' + (WBEM_ERRORS[nextRes] || 'unknown') + ' (0x' + nextRes.toString(16) + ')'); }
-            if (nextRes !== WBEM_S_NO_ERROR) {
+            if ((Date.now()-progStart) > timeout) { throw new Error('WMI query timed out after ' + (timeout/1000) + ' seconds'); }
+            var nextRes = results.funcs.Next(results.Deref(), rowTimeout, uCount, apObjects, returnedCount).Val >>> 0;
+            if (nextRes >= 0x80000000) { throw new Error('Next() failed: ' + (WBEM_ERRORS[nextRes] || 'unknown') + ' (0x' + nextRes.toString(16) + ')'); }
+            var returnedRows = (nextRes === WBEM_S_NO_ERROR) ? uCount : returnedCount.toBuffer().readUInt32LE();   // Only use returnedCount on last set, as WBEM_S_NO_ERROR implies a full batch
+
+            if (returnedRows === 0) {  // handle special case, no rows returned
+                if (nextRes === WBEM_S_FALSE) { break; }    // Done. Exit.
                 if (++retries > 6) { throw new Error('Next() errored too many times: ' + (WBEM_ERRORS[nextRes] || 'unknown') + ' (0x' + nextRes.toString(16) + ')'); }
-                if (sessionid) { MA.SendCommand({ action: 'msg', type: 'console', value: 'Queryprogress: issue ' + (WBEM_ERRORS[nextRes] || 'unknown') + ' (0x' + nextRes.toString(16) + ') on row: ' + (progress+1), sessionid: sessionid }); }
-                continue;
+                if (sessionid) { MA.SendCommand({ action: 'msg', type: 'console', value: 'Queryprogress: issue ' + (WBEM_ERRORS[nextRes] || 'unknown') + ' (0x' + nextRes.toString(16) + ') after ' + progress + ' results', sessionid: sessionid }); }
+                continue; // timed out, retry
             }
             retries = 0;
-            if (sessionid) {
-                ++progress;
-                var now = Date.now();
-                if ((now - lastProg) > 2000) {  //max 1 msg/2s, otherwise it gets throttled and possibly lose the result msg
-                    lastProg = now;
-                    MA.SendCommand({ action: 'msg', type: 'console', value: 'Queryprogress: ' + progress +  ' results', sessionid: sessionid }); }
+
+            for (var row = 0; row < returnedRows; ++row) {
+                var rowObj = apObjects.Deref(row * GM.PointerSize, GM.PointerSize);
+                rowObj.funcs = COM.marshalFunctions(rowObj.Deref(), ResultFunctions);
+                try {
+                    if (reqFields != null) { ret.push(enumerateProperties(rowObj, reqFields, fixedNameVars)); }
+                    else { var c = cache.forRow(rowObj); ret.push(enumerateProperties(rowObj, c.propNames, c.propNameVars)); }
+                } catch (rowErr) {
+                    console.log('win-wmi query row error: ' + (rowErr && rowErr.message ? rowErr.message : rowErr));
+                } finally {
+                    rowObj.funcs.Release(rowObj.Deref());
                 }
-            //result.funcs = COM.marshalFunctions(result.Deref(), ResultFunctions);
-            try {
-                if (reqFields != null) {
-                    ret.push(enumerateProperties(result, reqFields, fixedNameVars));
-                } else {
-                    var e = cache.forRow(result);
-                    ret.push(enumerateProperties(result, e.propNames, e.propNameVars));
-                }
-            } finally {
-                result.funcs.Release(result.Deref());
             }
+
+            if (sessionid) {
+                progress += returnedRows;
+                var now = Date.now();
+                if ((now - lastProg) > 2000) {
+                    lastProg = now;
+                    MA.SendCommand({ action: 'msg', type: 'console', value: 'Queryprogress: ' + progress + ' results', sessionid: sessionid });
+                }
+            }
+
+            if (nextRes === WBEM_S_FALSE) { break; }   // last (partial) batch done. Exit
         }
-        if (sessionid) { MA.SendCommand({ action: 'msg', type: 'console', value: 'Querytotal: ' + ret.length +  ' results, time take: ' + (Date.now()-progStart)/1000 + ' seconds', sessionid: sessionid }); }
     } catch (e) {
         console.log('win-wmi query error: ' + e.message);
-        if (ret.length > 0) {
-            e.results = ret;
-        }
+        if (ret.length > 0) { e.results = ret; }
         throw (e);
     } finally {
         results = releaseCOM(results, true);
@@ -652,6 +667,8 @@ function query(resourceString, queryString, fields, includeSysProp, sessionid)
         locator = releaseCOM(locator, false);
     }
     // console.log(JSON.stringify(ret).substring(0,200));
+    if (sessionid) {
+        MA.SendCommand({ action: 'msg', type: 'console', value: 'Querytotal: ' + ret.length + ' results, time take: ' + (Date.now()-progStart)/1000 + ' seconds', sessionid: sessionid }); }
     return (ret);
 }
 

--- a/agents/modules_meshcore/win-wmi-fixed.js
+++ b/agents/modules_meshcore/win-wmi-fixed.js
@@ -376,9 +376,9 @@ function enumerateProperties(wmiResultObj, propNames, propNameVars)
     if (!wmiResultObj.funcs) { wmiResultObj.funcs = COM.marshalFunctions(wmiResultObj.Deref(), ResultFunctions); }
 
     // Now we need to introspect the Array Fields
+    var propVal = GM.CreateVariable(24);
     for (var i = 0; i < propNames.length; ++i)
     {
-        var propVal = GM.CreateVariable(24);
         if (wmiResultObj.funcs.Get(wmiResultObj.Deref(), propNameVars[i], 0, propVal, 0, 0).Val == 0)
         {
             //
@@ -500,7 +500,7 @@ function queryAsync(resourceString, queryString, fields, includeSysProp, timeout
         //32-bit windows cannot do more than 1 async query at a time because of the hardcoded vtable for the cx pre-compiled __stdcall custom handlers in iLibDuktape_GenericMarshal.c
         if (GM.PointerSize == 4 && Object.keys(wmi_handlers).length != 0) {
             setImmediate(function(){ p.reject(new Error('Another AsyncQuery is already running, only one AsyncQuery possible at a time on 32-bit Windows')); }); return (p); }
-        if (!timeout || typeof timeout !== 'number') { timeout = 2 * 1000 };       //Default timeout set to 2m
+        if (!timeout || typeof timeout !== 'number') { timeout = 120 * 1000 };       //Default timeout set to 2m
         if (timeout < 500) { timeout *= 1000 }  // assume timeout given in seconds, as quicker than 500ms timeouts are unrealistic
         var pq = prepareQuery(queryString, fields);
         queryString = pq.q;
@@ -627,14 +627,17 @@ function query(resourceString, queryString, fields, includeSysProp, sessionid)
                     lastProg = now;
                     MA.SendCommand({ action: 'msg', type: 'console', value: 'Queryprogress: ' + progress +  ' results', sessionid: sessionid }); }
                 }
-            result.funcs = COM.marshalFunctions(result.Deref(), ResultFunctions);
-            if (reqFields != null) {
-                ret.push(enumerateProperties(result, reqFields, fixedNameVars));
-            } else {
-                var e = cache.forRow(result);
-                ret.push(enumerateProperties(result, e.propNames, e.propNameVars));
+            //result.funcs = COM.marshalFunctions(result.Deref(), ResultFunctions);
+            try {
+                if (reqFields != null) {
+                    ret.push(enumerateProperties(result, reqFields, fixedNameVars));
+                } else {
+                    var e = cache.forRow(result);
+                    ret.push(enumerateProperties(result, e.propNames, e.propNameVars));
+                }
+            } finally {
+                result.funcs.Release(result.Deref());
             }
-            result.funcs.Release(result.Deref());
         }
         if (sessionid) { MA.SendCommand({ action: 'msg', type: 'console', value: 'Querytotal: ' + ret.length +  ' results, time take: ' + (Date.now()-progStart)/1000 + ' seconds', sessionid: sessionid }); }
     } catch (e) {

--- a/agents/modules_meshcore/win-wmi-fixed.js
+++ b/agents/modules_meshcore/win-wmi-fixed.js
@@ -20,6 +20,7 @@ var COM = require('win-com');
 var sm = require('service-manager');
 const CLSID_WbemAdministrativeLocator = '{CB8555CC-9128-11D1-AD9B-00C04FD8FDFF}';
 const IID_WbemLocator = '{dc12a687-737f-11cf-884d-00aa004b2e24}';
+const WMI_FIELD = /^[A-Za-z_][A-Za-z0-9_]*$/;
 const WBEM_FLAG_BIDIRECTIONAL = 0;
 const WBEM_FLAG_NONSYSTEM_ONLY = 0x40;
 const WBEM_INFINITE = -1;
@@ -168,7 +169,10 @@ const QueryAsyncHandler =
                 if (!this.results) return GM.CreateVariable(4).increment(0, true);
                 if (this.sessionid) {
                     this.progress += count.Val;
-                    MA.SendCommand({ action: 'msg', type: 'console', value: 'Queryprogress: ' + this.progress +  ' results', sessionid: this.sessionid });
+                    var now = Date.now();
+                    if ((now - this.lastProg) > 2000) {     //max 1 msg/2s, otherwise it gets throttled and possibly lose the result msg
+                        this.lastProg = now;
+                        require('MeshAgent').SendCommand({ action: 'msg', type: 'console', value: 'Queryprogress: ' + this.progress +  ' results', sessionid: this.sessionid }); }
                 }
                 for (var i = 0; i < count.Val; ++i)
                 {
@@ -222,6 +226,54 @@ function releaseCOM(obj, deref) {
     return null;
 }
 
+function extractFields(queryString) {
+    if (typeof queryString !== 'string') { return null; }
+
+    // get between 'select' and 'from'
+    var props = /^\s*SELECT\s+(.+?)\s+FROM\s/i.exec(queryString);
+    if (props == null) { return null; }
+
+    var list = props[1].trim();
+    if (list === '*') { return null; }
+
+    var parts = list.split(',');
+    var fields = [];
+    for (var i = 0; i < parts.length; ++i) {
+        var name = parts[i].trim();
+        // check if wmi field, otherwise exit, fallback to GetNames in enum
+        if (!WMI_FIELD.test(name)) { return null; }
+        fields.push(name);
+    }
+    return (fields.length > 0 ? fields : null);
+}
+
+// Optimze query: If a 'select * from' query has the 'fields' argument, rewrite query to replace the * with fields argument
+// Except for event/notification queries (WITHIN or FROM __)
+// This gives a significant perfomance boost as enumerateProperties is very costly if it needs to get all properties every row
+// Always try to do:  queryString='select [field1][,field2][...] from [class]', fields=['field1','field2',...]
+// Keeping the fields argument filled helps with the enumerateProperties function not getting all the names every row.
+// And the reverse, if there are fields between 'select' and 'from', extract them and return it as the fields argument
+function prepareQuery (queryString, fields) {
+    if (typeof(queryString) !=='string' || queryString.trim().length === 0) { throw new Error('No querystring'); }
+    // Always check if wmi service is running
+    var s = sm.manager.getService('winmgmt');
+    if (!s.isRunning()) { throw new Error('WMI service not running'); }
+    if (!Array.isArray(fields) || fields.length === 0) {
+        fields = extractFields(queryString); }
+    else {
+        for (var i = 0; i < fields.length; ++i) {
+            if (typeof fields[i] !== 'string' || !WMI_FIELD.test(fields[i])) {
+                throw new Error('win-wmi: invalid field name: ' + fields[i]);
+            }
+        }
+        //skip 'within' clause and system event queries
+        if ( !(/\bWITHIN\b/i.test(queryString) || /\bFROM\s+__/i.test(queryString)) ) {
+            queryString = queryString.replace(/^(\s*SELECT\s+)\*(\s+FROM\s)/i, '$1' + fields.join(',') + '$2');// queryString.replace(/SELECT\s+\*/i, 'SELECT ' + fields.join(','));
+        }    
+    }
+    //console.log('   optiquery: ' + queryString + ' fields: ' + fields);
+    return { q: queryString, f: fields };
+}
 
 function enumerateProperties(j, fields, includeSysProp)
 {
@@ -377,12 +429,12 @@ function queryAsync(resourceString, queryString, fields, includeSysProp, session
 {
     var queryStarted = false;
     try {
-        var s = sm.manager.getService('winmgmt');
-        if (!s.isRunning()) { throw new Error ('WMI service not running')};
         //32-bit windows cannot do more than 1 async query at a time because of the hardcoded vtable for the cx pre-compiled __stdcall custom handlers in iLibDuktape_GenericMarshal.c
         if (GM.PointerSize == 4 && Object.keys(wmi_handlers).length != 0) {
             throw new Error('Another AsyncQuery is already running, only one AsyncQuery possible at a time on 32-bit Windows'); }
-        var p = new promise(promise.defaultInit);
+        var pq = prepareQuery(queryString, fields);
+        queryString = pq.q;
+        fields = pq.f;        var p = new promise(promise.defaultInit);
         var resource = GM.CreateVariable(resourceString, { wide: true });
         var language = GM.CreateVariable("WQL", { wide: true });
         var query = GM.CreateVariable(queryString, { wide: true });
@@ -393,7 +445,7 @@ function queryAsync(resourceString, queryString, fields, includeSysProp, session
         handlers.results = [];
         handlers.fields = fields;
         handlers.incSysProp = includeSysProp;
-        if (sessionid) { handlers.sessionid = sessionid; handlers.progress = 0; MA = require('MeshAgent') }
+        if (sessionid) { handlers.sessionid = sessionid; handlers.progress = 0; handlers.lastProg = 0; }
         handlers.locator = COM.createInstance(COM.CLSIDFromString(CLSID_WbemAdministrativeLocator), COM.IID_IUnknown);
         handlers.locator.funcs = COM.marshalFunctions(handlers.locator, LocatorFunctions);
 
@@ -430,13 +482,15 @@ function queryAsync(resourceString, queryString, fields, includeSysProp, session
 function query(resourceString, queryString, fields, includeSysProp, sessionid)
 {
     try {
-        var s = sm.manager.getService('winmgmt');
-        if (!s.isRunning()) { throw new Error ('WMI service not running')};
+        var pq = prepareQuery(queryString, fields);
+        queryString = pq.q;
+        fields = pq.f;
         var resource = GM.CreateVariable(resourceString, { wide: true });
         var language = GM.CreateVariable("WQL", { wide: true });
         var query = GM.CreateVariable(queryString, { wide: true });
         var results = GM.CreatePointer();
         var progress = 0;
+        var lastProg =  0;
         if (sessionid) { MA = require('MeshAgent'); }
         // Connect the locator connection for WMI
         var locator = COM.createInstance(COM.CLSIDFromString(CLSID_WbemAdministrativeLocator), COM.IID_IUnknown);
@@ -461,10 +515,15 @@ function query(resourceString, queryString, fields, includeSysProp, sessionid)
         // Enumerate the results
         while (results.funcs.Next(results.Deref(), WBEM_INFINITE, 1, result, returnedCount).Val == 0)
         {
-            if (sessionid && (++progress % 200) == 0) { 
-                MA.SendCommand({ action: 'msg', type: 'console', value: 'Queryprogress: ' + progress +  ' results', sessionid: sessionid }); }
-            ret.push(enumerateProperties(result, fields, includeSysProp));
-            result.funcs.Release(result.Deref());
+            if (sessionid) {
+                ++progress;
+                var now = Date.now();
+                if ((now - lastProg) > 2000) {  //max 1 msg/2s, otherwise it gets throttled and possibly lose the result msg
+                    lastProg = now;
+                    require('MeshAgent').SendCommand({ action: 'msg', type: 'console', value: 'Queryprogress: ' + progress +  ' results', sessionid: sessionid }); }
+                ret.push(enumerateProperties(result, fields, includeSysProp));
+                result.funcs.Release(result.Deref());
+            }
         }
     } catch (e) {
         console.log('win-wmi query error: ' + e.message);

--- a/agents/modules_meshcore/win-wmi-fixed.js
+++ b/agents/modules_meshcore/win-wmi-fixed.js
@@ -141,7 +141,9 @@ const ResultFunctions = [
 ];
 
 // https://learn.microsoft.com/en-us/windows/win32/wmisdk/iwbemobjectsink
-//
+// A COM interface consists at least of QueryInterface, Addref and Release, which are called by the windows system to manage the COM object
+// Indicate gets resultsets pushed and SetStatus gets called when finished
+// When refCount hits 0, which normally happens after the SetStatus call through the system calling the Release function, clean everything up
 const QueryAsyncHandler =
     [
         {
@@ -154,7 +156,7 @@ const QueryAsyncHandler =
                     case '0000000000000000C000000000000046': // IID_IUnknown
                     case '0178857C8173CF11884D00AA004B2E24': // IID_IWmiObjectSink
                         sink.pointerBuffer().copy(ppv.Deref(0, GM.PointerSize).toBuffer());
-                        ret.increment(0, true);
+                        ret.increment(0, true); //return WBEM_S_NO_ERROR=0
                         ++this.refcount;
                         break;
                     default:
@@ -169,26 +171,27 @@ const QueryAsyncHandler =
             cx: 11, parms: 1, name: 'AddRef', func: function ()
             {
                 // console.log('AddRef: ' + this.refcount);
-                return (GM.CreateVariable(4).increment(++this.refcount, true));
+                return (GM.CreateVariable(4).increment(++this.refcount, true)); // return new refCount
             }
         },
         {
             cx: 12, parms: 1, name: 'Release', func: function ()
             {
                 // console.log('Release: ' + this.refcount);
-                if (--this.refcount === 0) { destroy(this); }
-                return GM.CreateVariable(4).increment(this.refcount >>> 0, true);
+                if (--this.refcount === 0) { console.log('Released');
+                    destroy(this); }
+                return GM.CreateVariable(4).increment(this.refcount >>> 0, true);   // return new refCount
             }
         },
         {
             cx: 13, parms: 3, name: 'Indicate', func: function (sink, count, arr)
             {
                 // console.log('Indicate: ' + count.Val);
-                if (!this.results) return GM.CreateVariable(4).increment(0, true);
+                if (this._abandoned || this.results === null) { return (GM.CreateVariable(4).increment(0, true)); }   // discard
                 if (this.sessionid) {
                     this.progress += count.Val;
                     var now = Date.now();
-                    if ((now - this.lastProg) > 2000) {     //max 1 msg/2s, otherwise it gets throttled and possibly lose the result msg
+                    if ((now - this.lastProg) > 2000) {     //wait at least 2 seconds per msg, otherwise it gets throttled and possibly lose the result msg
                         this.lastProg = now;
                         this.MA.SendCommand({ action: 'msg', type: 'console', value: 'Queryprogress: ' + this.progress +  ' results', sessionid: this.sessionid }); }
                 }
@@ -202,36 +205,38 @@ const QueryAsyncHandler =
                         this.results.push(enumerateProperties(wmiResultObj , e.propNames, e.propNameVars));
                     }
                 }
-                return GM.CreateVariable(4).increment(0, true);
+                return GM.CreateVariable(4).increment(0, true); //Indicate must always return WBEM_S_NO_ERROR=0
             }
         },
         {
             cx: 14, parms: 5, name: 'SetStatus', func: function (sink, lFlags, hResult, strParam, pObjParam)
             {
                 // console.log('SetStatus ' + lFlags.Val);
-                if (hResult.Val == 0)
-                {
+                var ret = GM.CreateVariable(4).increment(0, true);  // SetStatus must always return WBEM_S_NO_ERROR=0
+                if (lFlags.Val !== WBEM_STATUS_COMPLETE) { return (ret); }  // SetStatus can receive other messages, skip those
+
+                if (this._timer) { clearTimeout(this._timer); this._timer = null; } // Finished before the settimeout, remove timer
+                var self = this;
+                setImmediate(function () { if (--self.refcount === 0) { destroy(self); } });    // decrement self set refCount of 1 at init
+                if (this._abandoned) { return (ret); }  // timeout settled the promise
+                this._abandoned = true;                 // Signal timeout function
+                if (hResult.Val == 0) {     // Everything ok, msg & resolve
                     if (this.sessionid) {
                         this.MA.SendCommand({ action: 'msg', type: 'console', value: 'Querytotal: ' + this.results.length + ' results, time take: ' + (Date.now()-this.progStart)/1000 + ' seconds', sessionid: this.sessionid });
                     }
-                    this.p.resolve(this.results);
-                }
-                else
-                {
+                    this.p.resolve(this.results); }
+                else {
                     var e = new Error('WMI async query error: ' + (WBEM_ERRORS[hResult.Val>>>0] || 'unknown') + ' (0x' + (hResult.Val>>>0).toString(16) + ')');
                     if (this.results.length > 0) { e.results = this.results; }
                     this.p.reject(e);
                 }
-                var self = this;
-                setImmediate(function () {
-                    if (--self.refcount === 0) { destroy(self); }
-                });
-                return GM.CreateVariable(4).increment(0, true);
+                return (ret);
             }
         }
     ];
 
 function destroy(h) {
+    // console.log('Destroy oh boy!');
     if (h.cleanup) { h.cleanup(); }
     h.p = null;
     delete wmi_handlers[h._hashCode()];
@@ -484,27 +489,34 @@ function enumerateProperties(wmiResultObj, propNames, propNameVars)
 
 
 // (optional) includeSysProp, default=false. Include system properties (__CLASS, etc.)
+// (optional) timeout, default=120 seconds. Query duration timeout in ms
 // (optional) sessionid, default=null. Report progress back to the given sessionid.
-function queryAsync(resourceString, queryString, fields, includeSysProp, sessionid)
+function queryAsync(resourceString, queryString, fields, includeSysProp, timeout, sessionid)
 {
     var queryStarted = false;
+    var handlers = null;
     try {
+        var p = new promise(promise.defaultInit);
         //32-bit windows cannot do more than 1 async query at a time because of the hardcoded vtable for the cx pre-compiled __stdcall custom handlers in iLibDuktape_GenericMarshal.c
         if (GM.PointerSize == 4 && Object.keys(wmi_handlers).length != 0) {
-            throw new Error('Another AsyncQuery is already running, only one AsyncQuery possible at a time on 32-bit Windows'); }
+            setImmediate(function(){ p.reject(new Error('Another AsyncQuery is already running, only one AsyncQuery possible at a time on 32-bit Windows')); }); return (p); }
+        if (!timeout || typeof timeout !== 'number') { timeout = 2 * 1000 };       //Default timeout set to 2m
+        if (timeout < 500) { timeout *= 1000 }  // assume timeout given in seconds, as quicker than 500ms timeouts are unrealistic
         var pq = prepareQuery(queryString, fields);
         queryString = pq.q;
         var reqFields = pq.f;
-        var p = new promise(promise.defaultInit);
         var resource = GM.CreateVariable(resourceString, { wide: true });
         var language = GM.CreateVariable("WQL", { wide: true });
         var query = GM.CreateVariable(queryString, { wide: true });
 
         // Setup the Async COM handler for QueryAsync() 
-        var handlers = COM.marshalInterface(QueryAsyncHandler);
+        handlers = COM.marshalInterface(QueryAsyncHandler);
         handlers.refcount = 1;
         handlers.results = [];
         handlers.reqFields = reqFields;
+        handlers.query = resourceString + ':' + queryString;
+        handlers._timer = null;
+        handlers._abandoned = false;
         if (reqFields != null && Array.isArray(reqFields)) {
             handlers.fixedNameVars = reqFields.map(function (f) { return GM.CreateVariable(f, { wide: true }); });
         } else {
@@ -516,28 +528,40 @@ function queryAsync(resourceString, queryString, fields, includeSysProp, session
 
         handlers.services = GM.CreatePointer();
 
-        // For easier debugging in case a certain WMI component is not available
-        var hr = handlers.locator.funcs.ConnectToServer(handlers.locator, resource, 0, 0, 0, 0, 0, 0, handlers.services).Val;
+        // https://learn.microsoft.com/en-us/windows/win32/api/wbemcli/nf-wbemcli-iwbemlocator-connectserver
+        // WBEM_FLAG_CONNECT_USE_MAX_WAIT=wait max 2 minutes instead of infinite. Prevents blocking.
+        var hr = handlers.locator.funcs.ConnectToServer(handlers.locator, resource, 0, 0, 0, WBEM_FLAG_CONNECT_USE_MAX_WAIT, 0, 0, handlers.services).Val >>> 0;
         if (hr != 0) {
-            var hex = (hr < 0 ? hr + 0x100000000 : hr).toString(16).toUpperCase();
-            throw ('queryAsync: Error calling ConnectToServer: HRESULT=0x' + hex + ' resource=' + resourceString);
-        }
+            throw (new Error('ConnectToServer(' + resourceString + ') failed: ' + (WBEM_ERRORS[hr] || 'unknown') + ' (0x' + hr.toString(16) + ')')); }
 
         handlers.services.funcs = COM.marshalFunctions(handlers.services.Deref(), ServiceFunctions);
         handlers.p = p;
         
         // Make the COM call
-        if (handlers.services.funcs.ExecQueryAsync(handlers.services.Deref(), language, query, WBEM_FLAG_BIDIRECTIONAL, 0, handlers).Val != 0)  { throw new Error('Error in Query'); }
+        var execRes = handlers.services.funcs.ExecQueryAsync(handlers.services.Deref(), language, query, WBEM_FLAG_BIDIRECTIONAL, 0, handlers).Val >>> 0;
+        if (execRes !== 0) {
+            throw new Error('ExecQueryAsync(' + handlers.query + ') failed: ' + (WBEM_ERRORS[execRes] || 'unknown') + ' (0x' + execRes.toString(16) + ')'); }
         queryStarted = true;
         // Hold a reference to the callback object
         wmi_handlers[handlers._hashCode()] = handlers;
+        handlers._timer = setTimeout(function () {
+            handlers._timer = null;
+            if (handlers._abandoned) { return; }    //Signal from SetStatus, it settled
+            // WMI CancelAsyncCall causes a fatal exception. Only way to cancel is through abandonment.
+            // Reject the promise and clean that part up, hoping the wmi query resolves eventually and cleans itself up through SetStatus
+            // There seems to be not other way to stop a hung/long query
+            handlers._abandoned = true;     // Signal SetStatus we'll reject
+            var e = new Error('WMI query timed out');
+            if (handlers.sessionid && handlers.results.length > 0) { e.results = handlers.results; }
+            handlers.p.reject(e);
+        }, timeout);
     } catch (e) {
         console.log('win-wmi queryAsync error: ' + e.message);
         if (!queryStarted && handlers) {
             handlers.refcount = 0;
             destroy(handlers);
         }
-        throw (e);    
+        p.reject(e);
     }
     return (p);
 }

--- a/agents/modules_meshcore/win-wmi-fixed.js
+++ b/agents/modules_meshcore/win-wmi-fixed.js
@@ -25,24 +25,25 @@ const WBEM_FLAG_BIDIRECTIONAL = 0;
 const WBEM_FLAG_RETURN_IMMEDIATELY = 0x10;
 const WBEM_FLAG_FORWARD_ONLY = 0x20;
 const WBEM_FLAG_NONSYSTEM_ONLY = 0x40;
+const WBEM_FLAG_CONNECT_USE_MAX_WAIT = 0x80;
 const WBEM_INFINITE = -1;
 const WBEM_FLAG_ALWAYS = 0;
 const E_NOINTERFACE = 0x80004002;
 const WBEM_S_NO_ERROR = 0;
 const WBEM_S_FALSE = 1;
 const WBEM_S_TIMEDOUT = 0x40004;
+const WBEM_STATUS_COMPLETE = 0;
 const WBEM_ERRORS = {
-    0x80041010: 'Invalid class',
-    0x80041017: 'Invalid query',
-    0x8004100E: 'Invalid namespace',
-    0x80041003: 'Access denied',
     0x80041001: 'Generic failure',
-    0x80041004: 'Provider failure',
     0x80041002: 'Object not found',
     0x80041003: 'Access denied',
+    0x80041004: 'Provider failure',
     0x80041006: 'Out of memory',
     0x80041008: 'Invalid parameter',
     0x80041009: 'Resource not available',
+    0x8004100E: 'Invalid namespace',
+    0x80041010: 'Invalid class',
+    0x80041017: 'Invalid query',
     0x80041013: 'Provider not found',
     0x80041021: 'Invalid syntax',
     0x80070422: 'Service unavailable'
@@ -139,8 +140,6 @@ const ResultFunctions = [
             'GetMethodOrigin'
 ];
 
-//
-// Reference to IWbemObjectSink can be found at:
 // https://learn.microsoft.com/en-us/windows/win32/wmisdk/iwbemobjectsink
 //
 const QueryAsyncHandler =
@@ -568,26 +567,25 @@ function query(resourceString, queryString, fields, includeSysProp, sessionid)
         var locator = COM.createInstance(COM.CLSIDFromString(CLSID_WbemAdministrativeLocator), COM.IID_IUnknown);
         locator.funcs = COM.marshalFunctions(locator, LocatorFunctions);
         var services = GM.CreatePointer();
-        
-        // For easier debugging in case a certain WMI component is not available
-        var hr = locator.funcs.ConnectToServer(locator, resource, 0, 0, 0, 0, 0, 0, services).Val;
+
+       // https://learn.microsoft.com/en-us/windows/win32/api/wbemcli/nf-wbemcli-iwbemlocator-connectserver
+        // WBEM_FLAG_CONNECT_USE_MAX_WAIT=wait max 2 minutes instead of infinite. Prevents blocking.
+        var hr = locator.funcs.ConnectToServer(locator, resource, 0, 0, 0, WBEM_FLAG_CONNECT_USE_MAX_WAIT, 0, 0, services).Val >>> 0;
         if (hr != 0) {
-            var hex = (hr < 0 ? hr + 0x100000000 : hr).toString(16).toUpperCase();
-            throw ('query: Error calling ConnectToServer: HRESULT=0x' + hex + ' resource=' + resourceString);
-        }
+            throw new Error('ConnectToServer(' + resourceString + ') failed: ' + (WBEM_ERRORS[hr] || 'unknown') + ' (0x' + hr.toString(16) + ')'); }
 
         // Execute the Query
+        // FORWARD_ONLY & RETURN_IMMEDIATELY instead of BIDIRECTIONAL, faster and less memory. https://learn.microsoft.com/en-us/windows/win32/api/wbemcli/nf-wbemcli-iwbemservices-execquery
         services.funcs = COM.marshalFunctions(services.Deref(), ServiceFunctions);
         if ((hr = services.funcs.ExecQuery(services.Deref(), language, query, WBEM_FLAG_FORWARD_ONLY | WBEM_FLAG_RETURN_IMMEDIATELY, 0, results).Val >>> 0) != 0) {
-            throw new Error('ExecQuery() failed: ' + (WBEM_ERRORS[hr] || 'unknown') + ' (0x' + hr.toString(16) + ')');
-        }
+            throw new Error('ExecQuery() failed: ' + (WBEM_ERRORS[hr] || 'unknown') + ' (0x' + hr.toString(16) + ')'); }
 
         results.funcs = COM.marshalFunctions(results.Deref(), ResultsFunctions);
         var returnedCount = GM.CreateVariable(8);
         var result = GM.CreatePointer();
         var nextRes;
         // https://learn.microsoft.com/en-us/windows/win32/api/wbemcli/nf-wbemcli-ienumwbemclassobject-next
-        var retries = 0, rowTimeout = 10*1000; // was WBEM_INFINITE. in ms. Prevents blocking.
+        var retries = 0, rowTimeout = 10*1000; // rowTimeout was WBEM_INFINITE. in ms. Prevents blocking.
         while (true) {
             nextRes = results.funcs.Next(results.Deref(), rowTimeout, 1, result, returnedCount).Val >>> 0;
             if (nextRes === WBEM_S_FALSE) break; // normal exit

--- a/agents/modules_meshcore/win-wmi-fixed.js
+++ b/agents/modules_meshcore/win-wmi-fixed.js
@@ -464,6 +464,7 @@ function query(resourceString, queryString, fields, includeSysProp, sessionid)
             if (sessionid && (++progress % 200) == 0) { 
                 MA.SendCommand({ action: 'msg', type: 'console', value: 'Queryprogress: ' + progress +  ' results', sessionid: sessionid }); }
             ret.push(enumerateProperties(result, fields, includeSysProp));
+            result.funcs.Release(result.Deref());
         }
     } catch (e) {
         console.log('win-wmi query error: ' + e.message);

--- a/agents/modules_meshcore/win-wmi-fixed.js
+++ b/agents/modules_meshcore/win-wmi-fixed.js
@@ -403,6 +403,9 @@ function enumerateProperties(wmiResultObj, propNames, propNameVars)
                 var arrayData = GM.CreatePointer();
                 OleAut32.SafeArrayAccessData(safeArray, arrayData);
                 
+                // VT_I8 & VT_UI8 (64-bit types) aren't used (yet?) in wmi, added for completeness
+                // added float type VT_R4 and VT_R8, uncommon but used
+                // VT_DECIMAL not mapped in wmi
                 var arrayValues = [];
                 for (var k = 0; k < arrayLength; ++k)
                 {
@@ -415,9 +418,20 @@ function enumerateProperties(wmiResultObj, propNames, propNameVars)
                         case 0x0016:    // VT_INT
                             arrayValues.push(arrayData.Deref().Deref(k * 4, 4).toBuffer().readInt32LE());
                             break;
+                        case 0x0004:    // VT_R4
+                            arrayValues.push(arrayData.Deref().Deref(k * 4, 4).toBuffer().readFloatLE(0));
+                            break;
+                        case 0x0005:    // VT_R8
+                            arrayValues.push(arrayData.Deref().Deref(k * 8, 8).toBuffer().readDoubleLE(0));
+                            break;
+                        case 0x0008:    // VT_BSTR
+                            arrayValues.push(arrayData.Deref().Deref(k * GM.PointerSize, GM.PointerSize).Deref().Wide2UTF8);
+                            break;
                         case 0x000B:    // VT_BOOL
                             arrayValues.push(arrayData.Deref().Deref(k * 2, 2).toBuffer().readInt16LE() != 0);
                             break;
+                        // case 0x000E:    //VT_DECIMAL
+                        //     break;
                         case 0x0010:    // VT_I1
                             arrayValues.push(arrayData.Deref().Deref(k, 1).toBuffer().readInt8());
                             break;
@@ -431,8 +445,19 @@ function enumerateProperties(wmiResultObj, propNames, propNameVars)
                         case 0x0017:    // VT_UINT
                             arrayValues.push(arrayData.Deref().Deref(k * 4, 4).toBuffer().readUInt32LE());
                             break;
-                        case 0x0008:    // VT_BSTR
-                            arrayValues.push(arrayData.Deref().Deref(k * GM.PointerSize, GM.PointerSize).Deref().Wide2UTF8);
+/*
+                        case 0x0014:    // VT_I8 (signed 64-bit)
+                            var ai8 = arrayData.Deref().Deref(k * 8, 8).toBuffer();
+                            // recombine the two 32-bit halves; exact up to 2^53 (high word signed)
+                            arrayValues.push(ai8.readInt32LE(4) * 0x100000000 + ai8.readUInt32LE(0));
+                            break;
+                        case 0x0015:    // VT_UI8 (unsigned 64-bit)
+                            var aui8 = arrayData.Deref().Deref(k * 8, 8).toBuffer();
+                            arrayValues.push(aui8.readUInt32LE(4) * 0x100000000 + aui8.readUInt32LE(0));
+                            break;
+*/
+                        default:
+                            console.info1('VARTYPE (array element): 0x' + baseType.toString(16));
                             break;
                     }
                 }
@@ -455,11 +480,20 @@ function enumerateProperties(wmiResultObj, propNames, propNameVars)
                     case 0x0016:    // VT_INT
                         values[propNames[i]] = propVal.Deref(8, GM.PointerSize).toBuffer().readInt32LE();
                         break;
+                    case 0x0004:    // VT_R4
+                        values[propNames[i]] = propVal.Deref(8, 4).toBuffer().readFloatLE(0);
+                        break;
+                    case 0x0005:    // VT_R8
+                        values[propNames[i]] = propVal.Deref(8, 8).toBuffer().readDoubleLE(0);
+                        break;
+                    case 0x0008:    // VT_BSTR
+                        values[propNames[i]] = propVal.Deref(8, GM.PointerSize).Deref().Wide2UTF8;
+                        break;
                     case 0x000B:    // VT_BOOL
                         values[propNames[i]] = propVal.Deref(8, GM.PointerSize).toBuffer().readInt32LE() != 0;
                         break;
-                    case 0x000E:    // VT_DECIMAL
-                        break;
+                    // case 0x000E:    // VT_DECIMAL
+                    //     break;
                     case 0x0010:    // VT_I1
                         values[propNames[i]] = propVal.Deref(8, GM.PointerSize).toBuffer().readInt8();
                         break;
@@ -473,15 +507,19 @@ function enumerateProperties(wmiResultObj, propNames, propNameVars)
                     case 0x0017:    // VT_UINT
                         values[propNames[i]] = propVal.Deref(8, GM.PointerSize).toBuffer().readUInt32LE();
                         break;
-                    //case 0x0014:    // VT_I8
-                    //    break;
-                    //case 0x0015:    // VT_UI8
-                    //    break;
-                    case 0x0008:    // VT_BSTR
-                        values[propNames[i]] = propVal.Deref(8, GM.PointerSize).Deref().Wide2UTF8;
+/*
+                    case 0x0014:    // VT_I8
+                        var i8 = propVal.Deref(8, 8).toBuffer();
+                        // recombine the two 32-bit halves; exact up to 2^53 (high word is signed)
+                        values[propNames[i]] = i8.readInt32LE(4) * 0x100000000 + i8.readUInt32LE(0);
                         break;
+                    case 0x0015:    // VT_UI8
+                        var ui8 = propVal.Deref(8, 8).toBuffer();
+                        values[propNames[i]] = ui8.readUInt32LE(4) * 0x100000000 + ui8.readUInt32LE(0);
+                        break;
+*/
                     default:
-                        console.info1('VARTYPE: ' + vartype);
+                        console.info1('VARTYPE: 0x' + vartype.toString(16));
                         break;
                 }
             }

--- a/agents/modules_meshcore/win-wmi-fixed.js
+++ b/agents/modules_meshcore/win-wmi-fixed.js
@@ -172,7 +172,7 @@ const QueryAsyncHandler =
                     var now = Date.now();
                     if ((now - this.lastProg) > 2000) {     //max 1 msg/2s, otherwise it gets throttled and possibly lose the result msg
                         this.lastProg = now;
-                        require('MeshAgent').SendCommand({ action: 'msg', type: 'console', value: 'Queryprogress: ' + this.progress +  ' results', sessionid: this.sessionid }); }
+                        this.MA.SendCommand({ action: 'msg', type: 'console', value: 'Queryprogress: ' + this.progress +  ' results', sessionid: this.sessionid }); }
                 }
                 for (var i = 0; i < count.Val; ++i)
                 {
@@ -445,7 +445,7 @@ function queryAsync(resourceString, queryString, fields, includeSysProp, session
         handlers.results = [];
         handlers.fields = fields;
         handlers.incSysProp = includeSysProp;
-        if (sessionid) { handlers.sessionid = sessionid; handlers.progress = 0; handlers.lastProg = 0; }
+        if (sessionid) { handlers.sessionid = sessionid; handlers.progress = 0; handlers.lastProg = 0; handlers.MA = require('MeshAgent'); }
         handlers.locator = COM.createInstance(COM.CLSIDFromString(CLSID_WbemAdministrativeLocator), COM.IID_IUnknown);
         handlers.locator.funcs = COM.marshalFunctions(handlers.locator, LocatorFunctions);
 
@@ -491,7 +491,7 @@ function query(resourceString, queryString, fields, includeSysProp, sessionid)
         var results = GM.CreatePointer();
         var progress = 0;
         var lastProg =  0;
-        if (sessionid) { MA = require('MeshAgent'); }
+        if (sessionid) { var MA = require('MeshAgent'); }
         // Connect the locator connection for WMI
         var locator = COM.createInstance(COM.CLSIDFromString(CLSID_WbemAdministrativeLocator), COM.IID_IUnknown);
         locator.funcs = COM.marshalFunctions(locator, LocatorFunctions);
@@ -520,10 +520,11 @@ function query(resourceString, queryString, fields, includeSysProp, sessionid)
                 var now = Date.now();
                 if ((now - lastProg) > 2000) {  //max 1 msg/2s, otherwise it gets throttled and possibly lose the result msg
                     lastProg = now;
-                    require('MeshAgent').SendCommand({ action: 'msg', type: 'console', value: 'Queryprogress: ' + progress +  ' results', sessionid: sessionid }); }
-                ret.push(enumerateProperties(result, fields, includeSysProp));
-                result.funcs.Release(result.Deref());
-            }
+                    MA.SendCommand({ action: 'msg', type: 'console', value: 'Queryprogress: ' + progress +  ' results', sessionid: sessionid }); }
+                }
+            result.funcs = COM.marshalFunctions(result.Deref(), ResultFunctions);
+            try { ret.push(enumerateProperties(result, fields, includeSysProp)); }
+            finally { result.funcs.Release(result.Deref()); }
         }
     } catch (e) {
         console.log('win-wmi query error: ' + e.message);

--- a/agents/modules_meshcore/win-wmi-fixed.js
+++ b/agents/modules_meshcore/win-wmi-fixed.js
@@ -21,6 +21,7 @@ var sm = require('service-manager');
 const CLSID_WbemAdministrativeLocator = '{CB8555CC-9128-11D1-AD9B-00C04FD8FDFF}';
 const IID_WbemLocator = '{dc12a687-737f-11cf-884d-00aa004b2e24}';
 const WBEM_FLAG_BIDIRECTIONAL = 0;
+const WBEM_FLAG_NONSYSTEM_ONLY = 0x40;
 const WBEM_INFINITE = -1;
 const WBEM_FLAG_ALWAYS = 0;
 const E_NOINTERFACE = 0x80004002;
@@ -165,11 +166,14 @@ const QueryAsyncHandler =
             {
                 //console.log('Indicate: ' + count.Val);
                 if (!this.results) return GM.CreateVariable(4).increment(0, true);
-
+                if (this.sessionid) {
+                    this.progress += count.Val;
+                    MA.SendCommand({ action: 'msg', type: 'console', value: 'Queryprogress: ' + this.progress +  ' results', sessionid: this.sessionid });
+                }
                 for (var i = 0; i < count.Val; ++i)
                 {
                     j = arr.Deref((i * GM.PointerSize) + 0, GM.PointerSize);
-                    this.results.push(enumerateProperties(j, this.fields));
+                    this.results.push(enumerateProperties(j, this.fields, this.incSysProp));
                 }
 
                 return GM.CreateVariable(4).increment(0, true);
@@ -219,7 +223,7 @@ function releaseCOM(obj, deref) {
 }
 
 
-function enumerateProperties(j, fields)
+function enumerateProperties(j, fields, includeSysProp)
 {
     //
     // Reference to SafeArrayAccessData() can be found at:
@@ -229,7 +233,7 @@ function enumerateProperties(j, fields)
     var nme, len, nn;
     var properties = [];
     var values = {};
-
+    if (typeof(includeSysProp) != 'boolean') {includeSysProp = false};
     j.funcs = COM.marshalFunctions(j.Deref(), ResultFunctions);
 
     // First we need to enumerate the COM Array
@@ -240,7 +244,7 @@ function enumerateProperties(j, fields)
     else
     {
         nme = GM.CreatePointer();
-        j.funcs.GetNames(j.Deref(), 0, WBEM_FLAG_ALWAYS, 0, nme);
+        j.funcs.GetNames(j.Deref(), 0, (includeSysProp ? WBEM_FLAG_ALWAYS: WBEM_FLAG_NONSYSTEM_ONLY), 0, nme);
         len = nme.Deref().Deref(GM.PointerSize == 8 ? 24 : 16, 4).toBuffer().readUInt32LE();
         nn = GM.CreatePointer();
         OleAut32.SafeArrayAccessData(nme.Deref(), nn);
@@ -366,7 +370,10 @@ function enumerateProperties(j, fields)
     return (values);
 }
 
-function queryAsync(resourceString, queryString, fields)
+
+// (optional) includeSysProp, default=false. Include system properties (__CLASS, etc.)
+// (optional) sessionid, default=null. Report progress back to the given sessionid.
+function queryAsync(resourceString, queryString, fields, includeSysProp, sessionid)
 {
     var queryStarted = false;
     try {
@@ -385,6 +392,8 @@ function queryAsync(resourceString, queryString, fields)
         handlers.refcount = 1;
         handlers.results = [];
         handlers.fields = fields;
+        handlers.incSysProp = includeSysProp;
+        if (sessionid) { handlers.sessionid = sessionid; handlers.progress = 0; MA = require('MeshAgent') }
         handlers.locator = COM.createInstance(COM.CLSIDFromString(CLSID_WbemAdministrativeLocator), COM.IID_IUnknown);
         handlers.locator.funcs = COM.marshalFunctions(handlers.locator, LocatorFunctions);
 
@@ -416,7 +425,9 @@ function queryAsync(resourceString, queryString, fields)
     return (p);
 }
 
-function query(resourceString, queryString, fields)
+// (optional) includeSysProp, default=false. Include system properties (__CLASS, etc.)
+// (optional) sessionid, default=null. Report progress back to the given sessionid.
+function query(resourceString, queryString, fields, includeSysProp, sessionid)
 {
     try {
         var s = sm.manager.getService('winmgmt');
@@ -425,7 +436,8 @@ function query(resourceString, queryString, fields)
         var language = GM.CreateVariable("WQL", { wide: true });
         var query = GM.CreateVariable(queryString, { wide: true });
         var results = GM.CreatePointer();
-
+        var progress = 0;
+        if (sessionid) { MA = require('MeshAgent'); }
         // Connect the locator connection for WMI
         var locator = COM.createInstance(COM.CLSIDFromString(CLSID_WbemAdministrativeLocator), COM.IID_IUnknown);
         locator.funcs = COM.marshalFunctions(locator, LocatorFunctions);
@@ -446,11 +458,12 @@ function query(resourceString, queryString, fields)
         var returnedCount = GM.CreateVariable(8);
         var result = GM.CreatePointer();
         var ret = [];
-
         // Enumerate the results
         while (results.funcs.Next(results.Deref(), WBEM_INFINITE, 1, result, returnedCount).Val == 0)
         {
-            ret.push(enumerateProperties(result, fields));
+            if (sessionid && (++progress % 200) == 0) { 
+                MA.SendCommand({ action: 'msg', type: 'console', value: 'Queryprogress: ' + progress +  ' results', sessionid: sessionid }); }
+            ret.push(enumerateProperties(result, fields, includeSysProp));
         }
     } catch (e) {
         console.log('win-wmi query error: ' + e.message);

--- a/agents/modules_meshcore/win-wmi-fixed.js
+++ b/agents/modules_meshcore/win-wmi-fixed.js
@@ -22,15 +22,37 @@ const CLSID_WbemAdministrativeLocator = '{CB8555CC-9128-11D1-AD9B-00C04FD8FDFF}'
 const IID_WbemLocator = '{dc12a687-737f-11cf-884d-00aa004b2e24}';
 const WMI_FIELD = /^[A-Za-z_][A-Za-z0-9_]*$/;
 const WBEM_FLAG_BIDIRECTIONAL = 0;
+const WBEM_FLAG_RETURN_IMMEDIATELY = 0x10;
+const WBEM_FLAG_FORWARD_ONLY = 0x20;
 const WBEM_FLAG_NONSYSTEM_ONLY = 0x40;
 const WBEM_INFINITE = -1;
 const WBEM_FLAG_ALWAYS = 0;
 const E_NOINTERFACE = 0x80004002;
 const WBEM_S_NO_ERROR = 0;
+const WBEM_S_FALSE = 1;
+const WBEM_S_TIMEDOUT = 0x40004;
+const WBEM_ERRORS = {
+    0x80041010: 'Invalid class',
+    0x80041017: 'Invalid query',
+    0x8004100E: 'Invalid namespace',
+    0x80041003: 'Access denied',
+    0x80041001: 'Generic failure',
+    0x80041004: 'Provider failure',
+    0x80041002: 'Object not found',
+    0x80041003: 'Access denied',
+    0x80041006: 'Out of memory',
+    0x80041008: 'Invalid parameter',
+    0x80041009: 'Resource not available',
+    0x80041013: 'Provider not found',
+    0x80041021: 'Invalid syntax',
+    0x80070422: 'Service unavailable'
+};
+
 var OleAut32 = GM.CreateNativeProxy('OleAut32.dll');
 OleAut32.CreateMethod('SafeArrayAccessData');
 OleAut32.CreateMethod('SafeArrayUnaccessData');
-
+OleAut32.CreateMethod('SafeArrayDestroy');
+OleAut32.CreateMethod('VariantClear');
 var wmi_handlers = {};
 
 const LocatorFunctions = ['QueryInterface', 'AddRef', 'Release', 'ConnectToServer'];
@@ -124,7 +146,7 @@ const ResultFunctions = [
 const QueryAsyncHandler =
     [
         {
-            cx: 10, parms: 3, name: 'QueryInterface', func: function (j, riid, ppv)
+            cx: 10, parms: 3, name: 'QueryInterface', func: function (sink, riid, ppv)
             {
                 var ret = GM.CreateVariable(4);
                 // console.log('QueryInterface', riid.Deref(0, 16).toBuffer().toString('hex'));
@@ -132,14 +154,12 @@ const QueryAsyncHandler =
                 {
                     case '0000000000000000C000000000000046': // IID_IUnknown
                     case '0178857C8173CF11884D00AA004B2E24': // IID_IWmiObjectSink
-                        j.pointerBuffer().copy(ppv.Deref(0, GM.PointerSize).toBuffer());
+                        sink.pointerBuffer().copy(ppv.Deref(0, GM.PointerSize).toBuffer());
                         ret.increment(0, true);
                         ++this.refcount;
-                        //console.log('QueryInterface ' +  riid.Deref(0, 16).toBuffer().toString('hex') + ' refcount: ' + this.refcount);
                         break;
                     default:
                         ret.increment(E_NOINTERFACE, true);
-                        //console.log(riid.Deref(0, 16).toBuffer().toString('hex'), 'returning E_NOINTERFACE');
                         break;
                 }
 
@@ -149,23 +169,22 @@ const QueryAsyncHandler =
         {
             cx: 11, parms: 1, name: 'AddRef', func: function ()
             {
-                //console.log('AddRef: ' + this.refcount);
+                // console.log('AddRef: ' + this.refcount);
                 return (GM.CreateVariable(4).increment(++this.refcount, true));
             }
         },
         {
             cx: 12, parms: 1, name: 'Release', func: function ()
             {
-                //console.log('Release: ' + this.refcount);
-                //--this.refcount;
+                // console.log('Release: ' + this.refcount);
                 if (--this.refcount === 0) { destroy(this); }
                 return GM.CreateVariable(4).increment(this.refcount >>> 0, true);
             }
         },
         {
-            cx: 13, parms: 3, name: 'Indicate', func: function (j, count, arr)
+            cx: 13, parms: 3, name: 'Indicate', func: function (sink, count, arr)
             {
-                //console.log('Indicate: ' + count.Val);
+                // console.log('Indicate: ' + count.Val);
                 if (!this.results) return GM.CreateVariable(4).increment(0, true);
                 if (this.sessionid) {
                     this.progress += count.Val;
@@ -176,28 +195,36 @@ const QueryAsyncHandler =
                 }
                 for (var i = 0; i < count.Val; ++i)
                 {
-                    j = arr.Deref((i * GM.PointerSize) + 0, GM.PointerSize);
-                    this.results.push(enumerateProperties(j, this.fields, this.incSysProp));
+                    var wmiResultObj  = arr.Deref((i * GM.PointerSize) + 0, GM.PointerSize);
+                    if (this.reqFields != null) {
+                        this.results.push(enumerateProperties(wmiResultObj , this.reqFields, this.fixedNameVars));
+                    } else {
+                        var e = this.cache.forRow(wmiResultObj );
+                        this.results.push(enumerateProperties(wmiResultObj , e.propNames, e.propNameVars));
+                    }
                 }
-
                 return GM.CreateVariable(4).increment(0, true);
             }
         },
         {
-            cx: 14, parms: 5, name: 'SetStatus', func: function (j, lFlags, hResult, strParam, pObjParam)
+            cx: 14, parms: 5, name: 'SetStatus', func: function (sink, lFlags, hResult, strParam, pObjParam)
             {
-                //console.log('SetStatus');
+                // console.log('SetStatus ' + lFlags.Val);
                 if (hResult.Val == 0)
                 {
+                    if (this.sessionid) {
+                        this.MA.SendCommand({ action: 'msg', type: 'console', value: 'Querytotal: ' + this.results.length + ' results, time take: ' + (Date.now()-this.progStart)/1000 + ' seconds', sessionid: this.sessionid });
+                    }
                     this.p.resolve(this.results);
                 }
                 else
                 {
-                    this.p.reject(new Error('WMI async query error: 0x' + (hResult.Val >>> 0).toString(16)));
+                    var e = new Error('WMI async query error: ' + (WBEM_ERRORS[hResult.Val>>>0] || 'unknown') + ' (0x' + (hResult.Val>>>0).toString(16) + ')');
+                    if (this.results.length > 0) { e.results = this.results; }
+                    this.p.reject(e);
                 }
                 var self = this;
                 setImmediate(function () {
-                    // console.log('SetStatus refcount: ' + self.refcount);
                     if (--self.refcount === 0) { destroy(self); }
                 });
                 return GM.CreateVariable(4).increment(0, true);
@@ -221,7 +248,7 @@ function destroy(h) {
 function releaseCOM(obj, deref) {
     if (obj && obj.funcs) {
         try { obj.funcs.Release(deref ? obj.Deref() : obj); }
-        catch (e) { console.log('releaseCOM error: ' + (e && e.message ? e.message : e)); }
+        catch (e) { console.log('WMI: releaseCOM error = ' + (e && e.message ? e.message : e)); }
     }
     return null;
 }
@@ -267,69 +294,102 @@ function prepareQuery (queryString, fields) {
             }
         }
         //skip 'within' clause and system event queries
-        if ( !(/\bWITHIN\b/i.test(queryString) || /\bFROM\s+__/i.test(queryString)) ) {
-            queryString = queryString.replace(/^(\s*SELECT\s+)\*(\s+FROM\s)/i, '$1' + fields.join(',') + '$2');// queryString.replace(/SELECT\s+\*/i, 'SELECT ' + fields.join(','));
-        }    
+        if ( !(/\bWITHIN\b/i.test(queryString) || /\bFROM\s+__/i.test(queryString))) {
+            queryString = queryString.replace(/^(\s*SELECT\s+)\*(\s+FROM\s)/i, '$1' + fields.join(',') + '$2');
+        }
     }
-    //console.log('   optiquery: ' + queryString + ' fields: ' + fields);
+    // console.info1('WMI: prepared query = ' + queryString + ' fields: ' + fields);
     return { q: queryString, f: fields };
 }
 
-function enumerateProperties(j, fields, includeSysProp)
+// get all property names for a wmi result
+function getAllNames(wmiResultObj, includeSysProp)
+{
+    if (!wmiResultObj.funcs) { wmiResultObj.funcs = COM.marshalFunctions(wmiResultObj.Deref(), ResultFunctions); }
+
+    var saNames = GM.CreatePointer();
+    // https://learn.microsoft.com/en-us/windows/win32/api/wbemcli/nf-wbemcli-iwbemclassobject-getnames
+    var res = (wmiResultObj.funcs.GetNames(wmiResultObj.Deref(), 0, (includeSysProp ? WBEM_FLAG_ALWAYS : WBEM_FLAG_NONSYSTEM_ONLY), 0, saNames));
+    if (res.Val != 0) { return []; }
+    var len = saNames.Deref().Deref(GM.PointerSize == 8 ? 24 : 16, 4).toBuffer().readUInt32LE();
+    var pNamesArray = GM.CreatePointer();
+    OleAut32.SafeArrayAccessData(saNames.Deref(), pNamesArray);
+
+    var propNames = [];
+    for (var i = 0; i < len; ++i) {
+        var propName = pNamesArray.Deref().increment(i * GM.PointerSize).Deref().Wide2UTF8;
+        if (propName.length === 0) { continue; }
+        propNames.push(propName);
+    }
+    OleAut32.SafeArrayUnaccessData(saNames.Deref());
+    OleAut32.SafeArrayDestroy(saNames.Deref());   // saNames is caller-owned
+    // console.info1('WMI: getAllNames(propNames) = ' + JSON.stringify(propNames));
+    return propNames;
+}
+
+function NameCache(includeSysProp)
+{
+    this.includeSysProp = (typeof(includeSysProp) == 'boolean') ? includeSysProp : false;
+    this.byClass = {};
+    this._classNameVar = GM.CreateVariable('__CLASS', { wide: true }); // reused every row
+}
+
+NameCache.prototype.forRow = function (wmiResultObj)
+{
+    if (!wmiResultObj.funcs) { wmiResultObj.funcs = COM.marshalFunctions(wmiResultObj.Deref(), ResultFunctions); }
+
+    // Read __CLASS (system property, always a BSTR). Falls back to '' if absent.
+    var key = '';
+    var val = GM.CreateVariable(24);
+    try {
+        if (wmiResultObj.funcs.Get(wmiResultObj.Deref(), this._classNameVar, 0, val, 0, 0).Val == 0 && val.toBuffer().readUInt16LE() == 0x0008) {
+            key = val.Deref(8, GM.PointerSize).Deref().Wide2UTF8; 
+        }
+    } finally {
+        OleAut32.VariantClear(val);
+    }
+    
+    var entry = this.byClass[key];
+    if (!entry) {
+        var propNames = getAllNames(wmiResultObj, this.includeSysProp);
+        var propNameVars = [];
+        for (var n = 0; n < propNames.length; ++n) {
+            propNameVars.push(GM.CreateVariable(propNames[n], { wide: true }));
+        }
+        entry = this.byClass[key] = { propNames: propNames, propNameVars: propNameVars };
+    }
+    return entry;
+};
+
+function enumerateProperties(wmiResultObj, propNames, propNameVars)
 {
     //
     // Reference to SafeArrayAccessData() can be found at:
     // https://learn.microsoft.com/en-us/windows/win32/api/oleauto/nf-oleauto-safearrayaccessdata
     //
 
-    var nme, len, nn;
-    var properties = [];
     var values = {};
-    if (typeof(includeSysProp) != 'boolean') {includeSysProp = false};
-    j.funcs = COM.marshalFunctions(j.Deref(), ResultFunctions);
-
-    // First we need to enumerate the COM Array
-    if (fields != null && Array.isArray(fields))
-    {
-        properties = fields;
-    }
-    else
-    {
-        nme = GM.CreatePointer();
-        j.funcs.GetNames(j.Deref(), 0, (includeSysProp ? WBEM_FLAG_ALWAYS: WBEM_FLAG_NONSYSTEM_ONLY), 0, nme);
-        len = nme.Deref().Deref(GM.PointerSize == 8 ? 24 : 16, 4).toBuffer().readUInt32LE();
-        nn = GM.CreatePointer();
-        OleAut32.SafeArrayAccessData(nme.Deref(), nn);
-
-
-        for (var i = 0; i < len; ++i)
-        {
-            var propName = nn.Deref().increment(i * GM.PointerSize).Deref().Wide2UTF8;
-            if (propName.length === 0) { continue; }
-            properties.push(propName);
-        }
-        OleAut32.SafeArrayUnaccessData(nme.Deref());
-    }
+    if (!wmiResultObj.funcs) { wmiResultObj.funcs = COM.marshalFunctions(wmiResultObj.Deref(), ResultFunctions); }
 
     // Now we need to introspect the Array Fields
-    for (var i = 0; i < properties.length; ++i)
+    for (var i = 0; i < propNames.length; ++i)
     {
-        var tmp1 = GM.CreateVariable(24);
-        if (j.funcs.Get(j.Deref(), GM.CreateVariable(properties[i], { wide: true }), 0, tmp1, 0, 0).Val == 0)
+        var propVal = GM.CreateVariable(24);
+        if (wmiResultObj.funcs.Get(wmiResultObj.Deref(), propNameVars[i], 0, propVal, 0, 0).Val == 0)
         {
             //
             // Reference for IWbemClassObject::Get() can be found at:
             // https://learn.microsoft.com/en-us/windows/win32/api/wbemcli/nf-wbemcli-iwbemclassobject-get
             //
 
-            var vartype = tmp1.toBuffer().readUInt16LE();
+            var vartype = propVal.toBuffer().readUInt16LE();
             var isArray = (vartype & 0x2000) != 0;  // VT_ARRAY flag
             var baseType = vartype & 0x0FFF;
 
             if (isArray)
             {
                 // Handle array types (VT_ARRAY | base type)
-                var safeArray = tmp1.Deref(8, GM.PointerSize).Deref();
+                var safeArray = propVal.Deref(8, GM.PointerSize).Deref();
                 var arrayLength = safeArray.Deref(GM.PointerSize == 8 ? 24 : 16, 4).toBuffer().readUInt32LE();
                 var arrayData = GM.CreatePointer();
                 OleAut32.SafeArrayAccessData(safeArray, arrayData);
@@ -368,7 +428,7 @@ function enumerateProperties(j, fields, includeSysProp)
                     }
                 }
                 OleAut32.SafeArrayUnaccessData(safeArray);
-                values[properties[i]] = arrayValues;
+                values[propNames[i]] = arrayValues;
             }
             else
             {
@@ -377,39 +437,39 @@ function enumerateProperties(j, fields, includeSysProp)
                 {
                     case 0x0000:    // VT_EMPTY
                     case 0x0001:    // VT_NULL
-                        values[properties[i]] = null;
+                        values[propNames[i]] = null;
                         break;
                     case 0x0002:    // VT_I2
-                        values[properties[i]] = tmp1.Deref(8, GM.PointerSize).toBuffer().readInt16LE();
+                        values[propNames[i]] = propVal.Deref(8, GM.PointerSize).toBuffer().readInt16LE();
                         break;
                     case 0x0003:    // VT_I4
                     case 0x0016:    // VT_INT
-                        values[properties[i]] = tmp1.Deref(8, GM.PointerSize).toBuffer().readInt32LE();
+                        values[propNames[i]] = propVal.Deref(8, GM.PointerSize).toBuffer().readInt32LE();
                         break;
                     case 0x000B:    // VT_BOOL
-                        values[properties[i]] = tmp1.Deref(8, GM.PointerSize).toBuffer().readInt32LE() != 0;
+                        values[propNames[i]] = propVal.Deref(8, GM.PointerSize).toBuffer().readInt32LE() != 0;
                         break;
                     case 0x000E:    // VT_DECIMAL
                         break;
                     case 0x0010:    // VT_I1
-                        values[properties[i]] = tmp1.Deref(8, GM.PointerSize).toBuffer().readInt8();
+                        values[propNames[i]] = propVal.Deref(8, GM.PointerSize).toBuffer().readInt8();
                         break;
                     case 0x0011:    // VT_UI1
-                        values[properties[i]] = tmp1.Deref(8, GM.PointerSize).toBuffer().readUInt8();
+                        values[propNames[i]] = propVal.Deref(8, GM.PointerSize).toBuffer().readUInt8();
                         break;
                     case 0x0012:    // VT_UI2
-                        values[properties[i]] = tmp1.Deref(8, GM.PointerSize).toBuffer().readUInt16LE();
+                        values[propNames[i]] = propVal.Deref(8, GM.PointerSize).toBuffer().readUInt16LE();
                         break;
                     case 0x0013:    // VT_UI4
                     case 0x0017:    // VT_UINT
-                        values[properties[i]] = tmp1.Deref(8, GM.PointerSize).toBuffer().readUInt32LE();
+                        values[propNames[i]] = propVal.Deref(8, GM.PointerSize).toBuffer().readUInt32LE();
                         break;
                     //case 0x0014:    // VT_I8
                     //    break;
                     //case 0x0015:    // VT_UI8
                     //    break;
                     case 0x0008:    // VT_BSTR
-                        values[properties[i]] = tmp1.Deref(8, GM.PointerSize).Deref().Wide2UTF8;
+                        values[propNames[i]] = propVal.Deref(8, GM.PointerSize).Deref().Wide2UTF8;
                         break;
                     default:
                         console.info1('VARTYPE: ' + vartype);
@@ -417,6 +477,7 @@ function enumerateProperties(j, fields, includeSysProp)
                 }
             }
         }
+        OleAut32.VariantClear(propVal);
     }
 
     return (values);
@@ -434,7 +495,8 @@ function queryAsync(resourceString, queryString, fields, includeSysProp, session
             throw new Error('Another AsyncQuery is already running, only one AsyncQuery possible at a time on 32-bit Windows'); }
         var pq = prepareQuery(queryString, fields);
         queryString = pq.q;
-        fields = pq.f;        var p = new promise(promise.defaultInit);
+        var reqFields = pq.f;
+        var p = new promise(promise.defaultInit);
         var resource = GM.CreateVariable(resourceString, { wide: true });
         var language = GM.CreateVariable("WQL", { wide: true });
         var query = GM.CreateVariable(queryString, { wide: true });
@@ -443,9 +505,13 @@ function queryAsync(resourceString, queryString, fields, includeSysProp, session
         var handlers = COM.marshalInterface(QueryAsyncHandler);
         handlers.refcount = 1;
         handlers.results = [];
-        handlers.fields = fields;
-        handlers.incSysProp = includeSysProp;
-        if (sessionid) { handlers.sessionid = sessionid; handlers.progress = 0; handlers.lastProg = 0; handlers.MA = require('MeshAgent'); }
+        handlers.reqFields = reqFields;
+        if (reqFields != null && Array.isArray(reqFields)) {
+            handlers.fixedNameVars = reqFields.map(function (f) { return GM.CreateVariable(f, { wide: true }); });
+        } else {
+            handlers.cache = new NameCache(includeSysProp);
+        }
+        if (sessionid) { handlers.sessionid = sessionid; handlers.progStart = Date.now(); handlers.progress = 0; handlers.lastProg = 0; handlers.MA = require('MeshAgent'); }
         handlers.locator = COM.createInstance(COM.CLSIDFromString(CLSID_WbemAdministrativeLocator), COM.IID_IUnknown);
         handlers.locator.funcs = COM.marshalFunctions(handlers.locator, LocatorFunctions);
 
@@ -481,17 +547,23 @@ function queryAsync(resourceString, queryString, fields, includeSysProp, session
 // (optional) sessionid, default=null. Report progress back to the given sessionid.
 function query(resourceString, queryString, fields, includeSysProp, sessionid)
 {
+    var ret = [];
     try {
         var pq = prepareQuery(queryString, fields);
         queryString = pq.q;
-        fields = pq.f;
+        var reqFields = pq.f;
+        var fixedNameVars = null;
+        var cache = null;
+        if (reqFields != null && Array.isArray(reqFields)) {
+            fixedNameVars = reqFields.map(function (f) { return GM.CreateVariable(f, { wide: true }); });
+        } else {
+            cache = new NameCache(includeSysProp);
+        }
         var resource = GM.CreateVariable(resourceString, { wide: true });
         var language = GM.CreateVariable("WQL", { wide: true });
         var query = GM.CreateVariable(queryString, { wide: true });
         var results = GM.CreatePointer();
-        var progress = 0;
-        var lastProg =  0;
-        if (sessionid) { var MA = require('MeshAgent'); }
+        if (sessionid) { var MA = require('MeshAgent'), progress = 0, lastProg =  0, progStart = Date.now(); }
         // Connect the locator connection for WMI
         var locator = COM.createInstance(COM.CLSIDFromString(CLSID_WbemAdministrativeLocator), COM.IID_IUnknown);
         locator.funcs = COM.marshalFunctions(locator, LocatorFunctions);
@@ -506,15 +578,26 @@ function query(resourceString, queryString, fields, includeSysProp, sessionid)
 
         // Execute the Query
         services.funcs = COM.marshalFunctions(services.Deref(), ServiceFunctions);
-        if (services.funcs.ExecQuery(services.Deref(), language, query, WBEM_FLAG_BIDIRECTIONAL, 0, results).Val != 0) { throw ('Error in Query'); }
+        if ((hr = services.funcs.ExecQuery(services.Deref(), language, query, WBEM_FLAG_FORWARD_ONLY | WBEM_FLAG_RETURN_IMMEDIATELY, 0, results).Val >>> 0) != 0) {
+            throw new Error('ExecQuery() failed: ' + (WBEM_ERRORS[hr] || 'unknown') + ' (0x' + hr.toString(16) + ')');
+        }
 
         results.funcs = COM.marshalFunctions(results.Deref(), ResultsFunctions);
         var returnedCount = GM.CreateVariable(8);
         var result = GM.CreatePointer();
-        var ret = [];
-        // Enumerate the results
-        while (results.funcs.Next(results.Deref(), WBEM_INFINITE, 1, result, returnedCount).Val == 0)
-        {
+        var nextRes;
+        // https://learn.microsoft.com/en-us/windows/win32/api/wbemcli/nf-wbemcli-ienumwbemclassobject-next
+        var retries = 0, rowTimeout = 10*1000; // was WBEM_INFINITE. in ms. Prevents blocking.
+        while (true) {
+            nextRes = results.funcs.Next(results.Deref(), rowTimeout, 1, result, returnedCount).Val >>> 0;
+            if (nextRes === WBEM_S_FALSE) break; // normal exit
+            if (nextRes >= 0x80000000 ) { throw new Error('Next() failed: ' + (WBEM_ERRORS[nextRes] || 'unknown') + ' (0x' + nextRes.toString(16) + ')'); }
+            if (nextRes !== WBEM_S_NO_ERROR) {
+                if (++retries > 6) { throw new Error('Next() errored too many times: ' + (WBEM_ERRORS[nextRes] || 'unknown') + ' (0x' + nextRes.toString(16) + ')'); }
+                if (sessionid) { MA.SendCommand({ action: 'msg', type: 'console', value: 'Queryprogress: issue ' + (WBEM_ERRORS[nextRes] || 'unknown') + ' (0x' + nextRes.toString(16) + ') on row: ' + (progress+1), sessionid: sessionid }); }
+                continue;
+            }
+            retries = 0;
             if (sessionid) {
                 ++progress;
                 var now = Date.now();
@@ -523,17 +606,27 @@ function query(resourceString, queryString, fields, includeSysProp, sessionid)
                     MA.SendCommand({ action: 'msg', type: 'console', value: 'Queryprogress: ' + progress +  ' results', sessionid: sessionid }); }
                 }
             result.funcs = COM.marshalFunctions(result.Deref(), ResultFunctions);
-            try { ret.push(enumerateProperties(result, fields, includeSysProp)); }
-            finally { result.funcs.Release(result.Deref()); }
+            if (reqFields != null) {
+                ret.push(enumerateProperties(result, reqFields, fixedNameVars));
+            } else {
+                var e = cache.forRow(result);
+                ret.push(enumerateProperties(result, e.propNames, e.propNameVars));
+            }
+            result.funcs.Release(result.Deref());
         }
+        if (sessionid) { MA.SendCommand({ action: 'msg', type: 'console', value: 'Querytotal: ' + ret.length +  ' results, time take: ' + (Date.now()-progStart)/1000 + ' seconds', sessionid: sessionid }); }
     } catch (e) {
         console.log('win-wmi query error: ' + e.message);
+        if (ret.length > 0) {
+            e.results = ret;
+        }
         throw (e);
     } finally {
         results = releaseCOM(results, true);
         services = releaseCOM(services, true);
         locator = releaseCOM(locator, false);
     }
+    // console.log(JSON.stringify(ret).substring(0,200));
     return (ret);
 }
 


### PR DESCRIPTION
Adds i(ncludesystemprops) option to the wmi command:
By default the wmi query now ignores the systemproperties (All properties starting with __). This makes the query faster and system properties are normally not needed.

Adds s(how) option to the wmi command:
Gives a progress update regarding the total rows fetched. Try f.e. 'wmi cimv2 "select * from win32_comclass'

Adds prepareQuery():
Check the fields and tries to optimize the query or the fields argument.
'select * from...' is a costly operation because enumerateProperties is run on every row. With the * it will do a GetNames to fetch all property fields, every row. If the fields argument is used, the GetNames part is skipped giving another performance boost on larger queries.

Best way at this moment to use wmi queries in modules, is to do it like this:
query='select caption,processid from win32_process';
**Try to avoid using 'select * from' in your code. Only get what you need.**