### PR TITLE
Fix stuck modifier keys after Alt+Tab in RDP remote desktop (#330)

### DIFF
--- a/public/mstsc/client.js
+++ b/public/mstsc/client.js
@@ -141,6 +141,13 @@
 				return false;
 			});
 			
+			window.addEventListener('blur', function () {
+				if (!self.socket || !self.activeSession) return;
+				// Release modifiers so they can't get stuck on the remote after an Alt+Tab (issue #330).
+				var mods = [42, 54, 29, 57373, 56, 57400, 57435, 57436];
+				for (var i = 0; i < mods.length; i++) { self.socket.send(JSON.stringify(['scancode', mods[i], false])); }
+			});
+
 			return this;
         },
         /**

--- a/public/scripts/agent-rdp-0.0.1.js
+++ b/public/scripts/agent-rdp-0.0.1.js
@@ -125,10 +125,12 @@ var CreateRDPDesktop = function (canvasid, domainUrl) {
             }
         };
         obj.socket.onclose = function () { changeState(0); };
+        window.addEventListener('blur', obj.m.releaseModifiers);
         changeState(1);
     }
 
     obj.Stop = function () {
+        window.removeEventListener('blur', obj.m.releaseModifiers);
         obj.Canvas.fillRect(0, 0, obj.ScreenWidth, obj.ScreenHeight);
         if (obj.socket) { obj.socket.close(); }
     }
@@ -200,6 +202,13 @@ var CreateRDPDesktop = function (canvasid, domainUrl) {
         obj.socket.send(JSON.stringify(['scancode', Mstsc.scancode(e), true]));
         e.preventDefault();
         return false;
+    }
+    obj.m.releaseModifiers = function () {
+        if (!obj.socket || (obj.State != 3)) return;
+        // Release modifier keys so they can't get stuck on the remote when the browser loses
+        // focus during an Alt+Tab (issue #330). L/R Shift, L/R Ctrl, L/R Alt, L/R Win.
+        var mods = [42, 54, 29, 57373, 56, 57400, 57435, 57436];
+        for (var i = 0; i < mods.length; i++) { obj.socket.send(JSON.stringify(['scancode', mods[i], false])); }
     }
     obj.m.mousewheel = function (e) {
         if (!obj.socket || (obj.State != 3)) return;


### PR DESCRIPTION
## Problem

In a browser **RDP** remote desktop (both the agent‑RDP client and the mstsc relay client), pressing **Alt+Tab** to switch away from the browser and back leaves a modifier key stuck "down" on the remote machine. The browser receives the modifier *key‑down* but never the *key‑up* (it loses focus mid‑combo), so the remote keeps treating the modifier as held. Most visibly, the next **Enter** is interpreted as **Alt+Enter** and toggles the Windows console to fullscreen; more generally every subsequent keypress behaves as `Alt+<key>` until the session is reconnected.

### Steps to reproduce
1. Open a remote **RDP** desktop to a Windows host and focus a console (e.g. PowerShell).
2. Press **Alt+Tab** to another local app, then Alt+Tab back to the browser.
3. Press **Enter** → the remote console goes fullscreen (Alt+Enter) instead of inserting a newline.

## Root cause

Issue #330 was previously fixed for the **agent KVM desktop** viewer (which re‑releases modifiers on each screen refresh), but the fix was never applied to the **RDP clients** (`public/scripts/agent-rdp-0.0.1.js` and `public/mstsc/client.js`). Both bind `keydown`/`keyup` to `window` with no handling for focus loss, so a key‑up dropped during Alt+Tab is never sent to the remote.

## Fix

Release the modifier keys on window **`blur`** — the moment focus is lost, i.e. when Alt+Tab strands the key. This matches the approach used by other browser remote‑desktop clients (noVNC, Guacamole) and the intent of the existing agent‑desktop fix, but uses the correct trigger for the RDP clients. Scancodes released: L/R Shift, Ctrl, Alt, Win (the extended ones are already flagged correctly server‑side in `apprelays.js`).

- **`public/scripts/agent-rdp-0.0.1.js`** — adds `obj.m.releaseModifiers`, attached on connect (`obj.Start`) and detached on disconnect (`obj.Stop`).
- **`public/mstsc/client.js`** — adds a `blur` listener alongside the existing keyboard listeners.

> Note: changes are to the unminified sources; the corresponding `*-min.js` files should be regenerated by the build/minify step.

## Testing
Reproduced the stuck‑Alt / console‑fullscreen on a stock RDP session, then verified with the patch: Alt+Tab away/back, press Enter → normal newline; other modifier combinations no longer stick. Verified in production on a self‑hosted MeshCentral instance (agent‑RDP path).

Addresses #330 for the RDP clients.


DISCLAIMER: Claude AI was used