### PR TITLE
Fix origin validation for self-signed certificate deployments

### DIFF
--- a/webserver.js
+++ b/webserver.js
@@ -6592,9 +6592,8 @@ module.exports.CreateWebServer = function (parent, db, args, certificates, doneF
         let originUrl; try { originUrl = new URL(req.headers.origin); } catch (ex) { return false; }
         if (!originUrl.hostname) return false; // Origin hostname is not valid
         if (Array.isArray(domain.allowedorigin)) return (domain.allowedorigin.indexOf(originUrl.hostname) >= 0); // Check if this is an allowed origin from an explicit list
-        if (obj.isTrustedCert(domain) === false) return true; // This server does not have a trusted certificate.
         if (domain.dns != null) return (domain.dns == originUrl.hostname); // Match the domain DNS
-        return (obj.certificates.CommonName == originUrl.hostname); // Match the default server name
+        return (obj.getWebServerName(domain, req) == originUrl.hostname); // Match the server hostname
     }
 
     // Create a OSX mesh agent installer


### PR DESCRIPTION
## Summary

- Use `getWebServerName()` for origin hostname comparison in `CheckWebServerOriginName()` instead of directly comparing against `certificates.CommonName`
- This ensures origin validation works correctly on self-signed certificate deployments where `CommonName` may not reflect the actual server hostname

## Test plan

- [x] Tested on self-signed cert deployment — cross-origin WebSocket connections correctly rejected
- [x] Legitimate same-origin connections still accepted
- [x] Desktop app connections (no Origin header) unaffected