### PR TITLE
Add extra volume and bitlocker info, change sysinfo db format

### DIFF
--- a/agents/meshcore.js
+++ b/agents/meshcore.js
@@ -2325,6 +2325,12 @@ function getSystemInformation(func) {
         replaceSpacesWithUnderscoresRec(results);
         var hasher = require('SHA384Stream').create();
 
+        var finalizeResults = function ()
+        {
+            results.hash = hasher.syncHash(JSON.stringify(results)).toString('hex');
+            func(results);
+        };
+
         // On Windows platforms, get volume information - Needs more testing.
         if (process.platform == 'win32')
         {
@@ -2334,21 +2340,19 @@ function getSystemInformation(func) {
                 var p = require('win-volumes').volumes_promise();
                 p.then(function (res)
                 {
-                    results.hardware.windows.volumes = cleanGetBitLockerVolumeInfo(res);
-                    results.hash = hasher.syncHash(JSON.stringify(results)).toString('hex');
-                    func(results);
+                    // volumes_promise always resolves (with partial data on error); guard so a parse error can't swallow the callback and stall info collection
+                    try { results.hardware.windows.volumes = cleanGetBitLockerVolumeInfo(res); } catch (ex) { }
+                    finalizeResults();
                 });
             }
             else
             {
-                results.hash = hasher.syncHash(JSON.stringify(results)).toString('hex');
-                func(results);
+                finalizeResults();
             }
         }
         else
         {
-            results.hash = hasher.syncHash(JSON.stringify(results)).toString('hex');
-            func(results);
+            finalizeResults();
         }
         
     } catch (ex) { func(null, ex); }
@@ -7119,16 +7123,26 @@ function sortObject(obj) { return Object.keys(obj).sort().reduce(function(a, v) 
 
 // Fix the incoming data and cut down how much data we use
 function cleanGetBitLockerVolumeInfo(volumes) {
+    // Convert the codes to strings. TODO: Do this serverside TODODO: preserve codes in database and convert in UI, which means a schema change and migration
+    // Win32_EncryptableVolume.ConversionStatus (0 = FullyDecrypted, omitted as it is used for the check)
+    var conversionStatuses = { 1: 'FullyEncrypted', 2: 'EncryptionInProgress', 3: 'DecryptionInProgress', 4: 'EncryptionPaused', 5: 'DecryptionPaused' };
+    // Win32_EncryptableVolume.EncryptionMethod (0 = None, omitted for the check)
+    var encryptionMethods = { 1: 'AES_128_WITH_DIFFUSER', 2: 'AES_256_WITH_DIFFUSER', 3: 'AES_128', 4: 'AES_256', 5: 'HARDWARE_ENCRYPTION', 6: 'XTS_AES_128', 7: 'XTS_AES_256' };
     for (var i in volumes) {
         const v = volumes[i];
         if (typeof v.size == 'string') { v.size = parseInt(v.size); }
         if (typeof v.sizeremaining == 'string') { v.sizeremaining = parseInt(v.sizeremaining); }
         if (v.identifier == '') { delete v.identifier; }
         if (v.name == '') { delete v.name; }
-        if (v.removable != true) { delete v.removable; }
-        if (v.cdrom != true) { delete v.cdrom; }
-        if (v.protectionStatus == 'On') { v.protectionStatus = true; } else { delete v.protectionStatus; }
-        if (v.volumeStatus == 'FullyDecrypted') { delete v.volumeStatus; }
+        // Win32_LogicalDisk.DriveType: 2 = Removable, 4 = Network, 5 = CD-ROM
+        if (v.dType == 2) { v.removable = true; }
+        else if (v.dType == 4) { v.network = true; }
+        else if (v.dType == 5) { v.cdrom = true; }
+        delete v.dType;
+        // ProtectionStatus: 0 = Off, 1 = On, 2 = Unknown
+        if (v.protectionStatus == 1) { v.protectionStatus = true; } else { delete v.protectionStatus; }
+        if (conversionStatuses[v.volumeStatus]) { v.volumeStatus = conversionStatuses[v.volumeStatus]; } else { delete v.volumeStatus; }
+        if (encryptionMethods[v.encryptionMethod]) { v.encryptionMethod = encryptionMethods[v.encryptionMethod]; } else { delete v.encryptionMethod; }
         if (v.recoveryPassword == '') { delete v.recoveryPassword; }
     }
     return sortObject(volumes);

--- a/agents/meshcore.js
+++ b/agents/meshcore.js
@@ -5674,8 +5674,11 @@ function processConsoleCommand(cmd, args, rights, sessionid) {
                     if (results == null) {
                         sendConsoleText(err, this.sessionid);
                     } else {
-                        sendConsoleText(JSON.stringify(results, null, 1), this.sessionid);
+                        // Send the full data to the server first
                         mesh.SendCommand({ action: 'sysinfo', sessionid: this.sessionid, data: results });
+                        // Mask BitLocker recovery keys for non-admins in the console output only
+                        var replacer = (rights != MESHRIGHT_ADMIN) ? function (k, val) { return (k == 'recoveryPassword') ? '(Only admins)' : val; } : null;
+                        sendConsoleText(JSON.stringify(results, replacer, 1), this.sessionid);
                     }
                 });
                 break;

--- a/agents/meshcore.js
+++ b/agents/meshcore.js
@@ -5676,8 +5676,28 @@ function processConsoleCommand(cmd, args, rights, sessionid) {
                     } else {
                         // Send the full data to the server first
                         mesh.SendCommand({ action: 'sysinfo', sessionid: this.sessionid, data: results });
-                        // Mask BitLocker recovery keys for non-admins in the console output only
-                        var replacer = (rights != MESHRIGHT_ADMIN) ? function (k, val) { return (k == 'recoveryPassword') ? '(Only admins)' : val; } : null;
+                        // Mask BitLocker recovery keys for non-admins in the console output only and optionally replace codes with strings
+                        pretty = !(args['_'].length > 0 && args['_'][0] == 'raw');
+                        const encMethod = { 0: '', 1: "AES-128 with diffuser", 2: "AES-256 with diffuser", 3: 'AES-128', 4: 'AES-256', 5: "Hardware encryption", 6: 'XTS-AES-128', 7: 'XTS-AES-256' };
+                        const driveType = { 0: "Unknown", 1: "No Root Directory", 2: "Removable Disk", 3: "Local Disk", 4: "Network Drive", 5: "Compact Disc", 6: "RAM Disk" };
+                        const conversionStatus = { "-1": "Unknown", 1: "Fully Encrypted", 2: "Encryption In Progress", 3: "Decryption In Progress", 4: "Encryption Paused", 5: "Decryption Paused" };
+                        const protectionStatus = { 0: "Off", 1: "On", 2: "Locked"};
+                        var replacer = function (k, val) {
+                            if ( k === 'recoveryPassword' && rights != MESHRIGHT_ADMIN) { return '(Only admins)'; }
+                            else if (pretty && typeof val === 'number') {
+                                switch (k) {
+                                    case 'encryptionMethod':
+                                        return (val >= 1 && val <= 7)  ? encMethod[val] : val;
+                                    case 'protectionStatus':
+                                        return (val >= 0 && val <= 2) ? protectionStatus[val] : val;
+                                    case 'volumeStatus':
+                                        return (val >= -1 && val <= 5) ? conversionStatus[val] : val;
+                                    case 'dType':
+                                        return (val >= 1 && val <= 6) ? driveType[val]: val;
+                                }
+                            }
+                            return val;
+                        };
                         sendConsoleText(JSON.stringify(results, replacer, 1), this.sessionid);
                     }
                 });

--- a/agents/meshcore.js
+++ b/agents/meshcore.js
@@ -2338,10 +2338,8 @@ function getSystemInformation(func) {
             if (require('win-volumes').volumes_promise != null)
             {
                 var p = require('win-volumes').volumes_promise();
-                p.then(function (res)
-                {
-                    // volumes_promise always resolves (with partial data on error); guard so a parse error can't swallow the callback and stall info collection
-                    try { results.hardware.windows.volumes = cleanGetBitLockerVolumeInfo(res); } catch (ex) { }
+                p.then(function (res) {
+                    if (res && res.drives) { try { results.hardware.windows.volumes = cleanGetBitLockerVolumeInfo(res.drives); } catch (ex) { } }
                     finalizeResults();
                 });
             }
@@ -4723,8 +4721,17 @@ function processConsoleCommand(cmd, args, rights, sessionid) {
                 if (process.platform == 'win32') {
                     if (require('win-volumes').volumes_promise != null) {
                         var p = require('win-volumes').volumes_promise();
-                        p.then(function (res) { sendConsoleText(JSON.stringify(cleanGetBitLockerVolumeInfo(res), null, 1), this.session); });
+                        p.sessionid = sessionid;
+                        p.then(function (res) {
+                            if (res && res.error) { sendConsoleText('bitlocker error: ' + (res.error.message ? res.error.message : res.error), this.sessionid); }
+                            try { sendConsoleText('(Partial) result: \r\n' + JSON.stringify(cleanGetBitLockerVolumeInfo(res ? res.drives : {}), null, 1), this.sessionid); }
+                            catch (ex) { sendConsoleText('Clean bitlockerinfo error: ' + (ex && ex.message ? ex.message : ex), this.sessionid); }
+                        });
+                    } else {
+                        sendConsoleText('BitLocker info not available.', sessionid);
                     }
+                } else {
+                    sendConsoleText('"bitLocker" is only supported on Windows.', sessionid);
                 }
                 break;
             case 'dhcp': // This command is only supported on Linux, this is because Linux does not give us the DNS suffix for each network adapter independently so we have to ask the DHCP server.

--- a/agents/meshcore.js
+++ b/agents/meshcore.js
@@ -44,6 +44,7 @@ var MESHRIGHT_LIMITEVENTS = 8192;
 var MESHRIGHT_CHATNOTIFY = 16384;
 var MESHRIGHT_UNINSTALL = 32768;
 var MESHRIGHT_NODESKTOP = 65536;
+var MESHRIGHT_ADMIN = 0xFFFFFFFF;
 
 var pendingSetClip = false; // This is a temporary hack to prevent multiple setclips at the same time to stop the agent from crashing.
 
@@ -4725,8 +4726,22 @@ function processConsoleCommand(cmd, args, rights, sessionid) {
                             p.sessionid = sessionid;
                             p.then(function (res) {
                                 if (res && res.error) { sendConsoleText('Bitlocker error: ' + (res.error.message ? res.error.message : res.error), this.sessionid); }
-                                try { sendConsoleText(JSON.stringify(cleanGetBitLockerVolumeInfo(res ? res.drives : {}), null, 1), this.sessionid); }
-                                catch (ex) { sendConsoleText('Clean BitlockerInfo error: ' + (ex && ex.message ? ex.message : ex), this.sessionid); }
+                                var drives = (res && res.drives && (Object.keys(res.drives).length !== 0)) ? res.drives : null;     // win-volumes returns 'drives' as at least {}, so also check on empty object
+                                if (drives) {
+                                    var conversionStatuses = { 0: 'FullyDecrypted', 1: 'FullyEncrypted', 2: 'EncryptionInProgress', 3: 'DecryptionInProgress', 4: 'EncryptionPaused', 5: 'DecryptionPaused' };
+                                    var encryptionMethods = { 0: 'None', 1: 'AES_128_WITH_DIFFUSER', 2: 'AES_256_WITH_DIFFUSER', 3: 'AES_128', 4: 'AES_256', 5: 'HARDWARE_ENCRYPTION', 6: 'XTS_AES_128', 7: 'XTS_AES_256' };
+                                    var protectionStatuses = { 0: 'Off', 1: 'On', 2: 'Locked'};
+                                    var driveType = { 0: "Unknown", 1: "No Root Directory", 2: "Removable Disk", 3: "Local Disk", 4: "Network Drive", 5: "Compact Disc", 6: "RAM Disk" };
+                                    for (var i in drives) {
+                                        const v = drives[i];
+                                        if (conversionStatuses[v.volumeStatus]) { v.volumeStatus = conversionStatuses[v.volumeStatus]; } else { v.volumeStatus = 'Unknown'; }
+                                        if (encryptionMethods[v.encryptionMethod]) { v.encryptionMethod = encryptionMethods[v.encryptionMethod]; } else { v.encryptionMethod = 'Unknown'; }
+                                        if (protectionStatuses[v.protectionStatus]) { v.protectionStatus = protectionStatuses[v.protectionStatus]; } else { v.protectionStatus = 'Unknown'; }
+                                        if (driveType[v.dType]) {v.dType = driveType[v.dType]; } else { v.dType = 'Unknown'; }
+                                        if (v.recoveryPassword && (rights != MESHRIGHT_ADMIN)) { v.recoveryPassword = '(Only admins)'; }
+                                    }
+                                }
+                                sendConsoleText(JSON.stringify((drives ? drives : 'No volume/bitlocker info'), null, 1), this.sessionid);
                             });
                         } else {
                             sendConsoleText('BitLocker info not available.', sessionid);
@@ -7134,27 +7149,17 @@ function sortObject(obj) { return Object.keys(obj).sort().reduce(function(a, v) 
 
 // Fix the incoming data and cut down how much data we use
 function cleanGetBitLockerVolumeInfo(volumes) {
-    // Convert the codes to strings. TODO: Do this serverside TODODO: preserve codes in database and convert in UI, which means a schema change and migration
-    // Win32_EncryptableVolume.ConversionStatus (0 = FullyDecrypted, omitted as it is used for the check)
-    var conversionStatuses = { 1: 'FullyEncrypted', 2: 'EncryptionInProgress', 3: 'DecryptionInProgress', 4: 'EncryptionPaused', 5: 'DecryptionPaused' };
-    // Win32_EncryptableVolume.EncryptionMethod (0 = None, omitted for the check)
-    var encryptionMethods = { 1: 'AES_128_WITH_DIFFUSER', 2: 'AES_256_WITH_DIFFUSER', 3: 'AES_128', 4: 'AES_256', 5: 'HARDWARE_ENCRYPTION', 6: 'XTS_AES_128', 7: 'XTS_AES_256' };
+    // Keep the raw codes info and let the view convert to strings
     for (var i in volumes) {
         const v = volumes[i];
         if (typeof v.size == 'string') { v.size = parseInt(v.size); }
         if (typeof v.sizeremaining == 'string') { v.sizeremaining = parseInt(v.sizeremaining); }
         if (v.identifier == '') { delete v.identifier; }
         if (v.name == '') { delete v.name; }
-        // Win32_LogicalDisk.DriveType: 2 = Removable, 4 = Network, 5 = CD-ROM
-        if (v.dType == 2) { v.removable = true; }
-        else if (v.dType == 4) { v.network = true; }
-        else if (v.dType == 5) { v.cdrom = true; }
-        delete v.dType;
-        // ProtectionStatus: 0 = Off, 1 = On, 2 = Unknown
-        if (v.protectionStatus == 1) { v.protectionStatus = true; } else { delete v.protectionStatus; }
-        if (conversionStatuses[v.volumeStatus]) { v.volumeStatus = conversionStatuses[v.volumeStatus]; } else { delete v.volumeStatus; }
-        if (encryptionMethods[v.encryptionMethod]) { v.encryptionMethod = encryptionMethods[v.encryptionMethod]; } else { delete v.encryptionMethod; }
         if (v.recoveryPassword == '') { delete v.recoveryPassword; }
+        if (v.volumeStatus === 0) { delete v.volumeStatus; }
+        if (v.encryptionMethod === 0) { delete v.encryptionMethod; }
+        if (v.protectionStatus === 0) { delete v.protectionStatus; }
     }
     return sortObject(volumes);
 }

--- a/agents/meshcore.js
+++ b/agents/meshcore.js
@@ -4719,19 +4719,23 @@ function processConsoleCommand(cmd, args, rights, sessionid) {
                 break;
             case 'bitlocker':
                 if (process.platform == 'win32') {
-                    if (require('win-volumes').volumes_promise != null) {
-                        var p = require('win-volumes').volumes_promise();
-                        p.sessionid = sessionid;
-                        p.then(function (res) {
-                            if (res && res.error) { sendConsoleText('bitlocker error: ' + (res.error.message ? res.error.message : res.error), this.sessionid); }
-                            try { sendConsoleText('(Partial) result: \r\n' + JSON.stringify(cleanGetBitLockerVolumeInfo(res ? res.drives : {}), null, 1), this.sessionid); }
-                            catch (ex) { sendConsoleText('Clean bitlockerinfo error: ' + (ex && ex.message ? ex.message : ex), this.sessionid); }
-                        });
+                    if (require('user-sessions').isRoot()) {
+                        if (require('win-volumes').volumes_promise != null) {
+                            var p = require('win-volumes').volumes_promise();
+                            p.sessionid = sessionid;
+                            p.then(function (res) {
+                                if (res && res.error) { sendConsoleText('Bitlocker error: ' + (res.error.message ? res.error.message : res.error), this.sessionid); }
+                                try { sendConsoleText(JSON.stringify(cleanGetBitLockerVolumeInfo(res ? res.drives : {}), null, 1), this.sessionid); }
+                                catch (ex) { sendConsoleText('Clean BitlockerInfo error: ' + (ex && ex.message ? ex.message : ex), this.sessionid); }
+                            });
+                        } else {
+                            sendConsoleText('BitLocker info not available.', sessionid);
+                        }
                     } else {
-                        sendConsoleText('BitLocker info not available.', sessionid);
+                        sendConsoleText('Bitlocker info requires an elevated agent', sessionid);
                     }
                 } else {
-                    sendConsoleText('"bitLocker" is only supported on Windows.', sessionid);
+                    sendConsoleText('BitLocker is only supported on Windows.', sessionid);
                 }
                 break;
             case 'dhcp': // This command is only supported on Linux, this is because Linux does not give us the DNS suffix for each network adapter independently so we have to ask the DHCP server.

--- a/agents/modules_meshcore/win-volumes.js
+++ b/agents/modules_meshcore/win-volumes.js
@@ -62,10 +62,14 @@ function windows_volumes()
     // RegExps for the specific patterns in the manage-bde output, case-insensitive multiline
     var reID = new RegExp("{[A-F0-9]{8}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{12}}", "mi");
     var rePass = new RegExp("[0-9]{6}-[0-9]{6}-[0-9]{6}-[0-9]{6}-[0-9]{6}-[0-9]{6}-[0-9]{6}-[0-9]{6}", "mi");
+
+    var pending = 0, done = false;
+    function resolver() { if (done && (pending === 0)) { p1._res({ error: error, drives: drives }); } }
+
     try {
         var wmi = require('win-wmi-fixed');
 
-        wmi.query('ROOT\\CIMV2', 'SELECT * FROM Win32_LogicalDisk', ['DeviceID', 'VolumeName', 'FileSystem', 'Size', 'FreeSpace', 'DriveType'])
+        wmi.query('ROOT\\CIMV2', 'SELECT DeviceID,VolumeName,FileSystem,Size,FreeSpace,DriveType FROM Win32_LogicalDisk', ['DeviceID', 'VolumeName', 'FileSystem', 'Size', 'FreeSpace', 'DriveType'], false, 5000)
             .forEach(function (disk) {
                 if (!disk || !disk['DeviceID']) { return; }   // skip rows without a DeviceID. Shouldn't be possible, but could in case of wmi funkyness
                 var drive = disk['DeviceID'].slice(0, -1);
@@ -81,7 +85,7 @@ function windows_volumes()
         // The MicrosoftVolumeEncryption namespace is admin-only and manage-bde needs elevation; skip both entirely when not elevated, saves waiting unneccessary on time-out of wmi-query if run as user
         if (require('user-sessions').isRoot()) {
             var child_process = require('child_process');
-            wmi.query('ROOT\\CIMV2\\Security\\MicrosoftVolumeEncryption', 'SELECT * FROM Win32_EncryptableVolume', ['DriveLetter', 'ConversionStatus', 'ProtectionStatus', 'EncryptionMethod'])
+            wmi.query('ROOT\\CIMV2\\Security\\MicrosoftVolumeEncryption', 'SELECT DriveLetter,ConversionStatus,ProtectionStatus,EncryptionMethod FROM Win32_EncryptableVolume', ['DriveLetter', 'ConversionStatus', 'ProtectionStatus', 'EncryptionMethod'], false, 5000)
                 .forEach(function (vol) {
                     if (!vol || !vol['DriveLetter']) { return; }   // there can be volumes without a DriveLetter(=null), which errors the slice
                     var drive = vol['DriveLetter'].slice(0, -1);
@@ -91,16 +95,24 @@ function windows_volumes()
                     drives[drive].protectionStatus = vol['ProtectionStatus'];
                     // Only run manage-bde on encrypted drives (ConversionStatus/volumeStatus 0 = FullyDecrypted, otherwise some sort of encryption)
                     if (drives[drive].volumeStatus != 0) {
-                        var keychild = child_process.execFile(process.env['windir'] + '\\system32\\cmd.exe', ['/c', 'manage-bde -protectors -get ' + drive + ': -Type recoverypassword'], {});
+                        pending++;
+                        var keychild = child_process.execFile(process.env['windir'] + '\\system32\\manage-bde.exe', ['manage-bde', '-protectors', '-get', drive + ':', '-Type', 'recoverypassword'], {});
                         keychild.stdout.str = '';
                         keychild.stdout.on('data', function (c) { this.str += c.toString(); });
-                        keychild.waitExit(4000);
-                        var id = keychild.stdout.str.match(reID);
-                        var rp = keychild.stdout.str.match(rePass);
-                        // a recovery password protector should always have an identifier
-                        if (id) { drives[drive].identifier = id[0]; }
-                        // recoveryPW can be empty if volume is locked
-                        if (rp) { drives[drive].recoveryPassword = rp[0]; }
+                        keychild.target = drive;
+                        // Guard against a hung manage-bde
+                        keychild.timeout = setTimeout(function () { try { keychild.kill(); } catch (ex) { } }, 4000);
+                        keychild.on('exit', function () {
+                            clearTimeout(this.timeout);
+                            var id = this.stdout.str.match(reID);
+                            var rp = this.stdout.str.match(rePass);
+                            // a recovery password protector should always have an identifier
+                            if (id) { drives[this.target].identifier = id[0]; }
+                            // recoveryPW can be empty if volume is locked
+                            if (rp) { drives[this.target].recoveryPassword = rp[0]; }
+                            pending--;
+                            resolver();
+                        });
                     }
                 });
         }
@@ -108,7 +120,8 @@ function windows_volumes()
         console.log('windows_volumes error: ' + (e && e.message ? e.message : e));
         error = e;    // add error, fall through to resolve below
     }
-    p1._res({ error: error, drives: drives });    // always resolve; error is null on success, partial drives kept on failure.
+    done = true;
+    resolver();    // if not root, resolve with partial info, otherwise the last child process resolves
     return (p1);
 }
 

--- a/agents/modules_meshcore/win-volumes.js
+++ b/agents/modules_meshcore/win-volumes.js
@@ -55,59 +55,52 @@ function getVolumes()
 
 function windows_volumes()
 {
+    var drives = {};
     var promise = require('promise');
     var p1 = new promise(function (res, rej) { this._res = res; this._rej = rej; });
-    var ret = {};
-    var values = require('win-wmi-fixed').query('ROOT\\CIMV2', 'SELECT * FROM Win32_LogicalDisk', ['DeviceID', 'VolumeName', 'FileSystem', 'Size', 'FreeSpace', 'DriveType']);
-    if(values[0]){
-        for (var i = 0; i < values.length; ++i) {
-            if (!values[i]['DeviceID']) { continue; }   //always check for null to be sure
-            var drive = values[i]['DeviceID'].slice(0,-1);
-            ret[drive] = {
-                name: (values[i]['VolumeName'] ? values[i]['VolumeName'] : ""),
-                type: (values[i]['FileSystem'] ? values[i]['FileSystem'] : "Unknown"),
-                size: (values[i]['Size'] ? values[i]['Size'] : 0),
-                sizeremaining: (values[i]['FreeSpace'] ? values[i]['FreeSpace'] : 0),
-                removable: (values[i]['DriveType'] == 2),
-                cdrom: (values[i]['DriveType'] == 5)
-            };
-        }
-    }
+    // RegExps for the specific patterns in the manage-bde output, case-insensitive multiline
+    var reID = new RegExp("{[A-F0-9]{8}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{12}}", "mi");
+    var rePass = new RegExp("[0-9]{6}-[0-9]{6}-[0-9]{6}-[0-9]{6}-[0-9]{6}-[0-9]{6}-[0-9]{6}-[0-9]{6}", "mi");
     try {
-        values = require('win-wmi-fixed').query('ROOT\\CIMV2\\Security\\MicrosoftVolumeEncryption', 'SELECT * FROM Win32_EncryptableVolume', ['DriveLetter','ConversionStatus','ProtectionStatus']);
-        if(values[0]){
-            // RegExps for the specific patterns in the manage-bde output, case-insensitive multiline
-            var reID = new RegExp("{[A-F0-9]{8}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{12}}", "mi");
-            var rePass = new RegExp("[0-9]{6}-[0-9]{6}-[0-9]{6}-[0-9]{6}-[0-9]{6}-[0-9]{6}-[0-9]{6}-[0-9]{6}", "mi");
-            var id, rp;
-            for (var i = 0; i < values.length; ++i) {
-                if (!values[i]['DriveLetter']) { continue; }   //There can be volumes withouth a DriveLetter(=null), which errors the slice. Skip for now, fix later
-                var drive = values[i]['DriveLetter'].slice(0,-1);
-                var statuses = {
-                    0: 'FullyDecrypted',
-                    1: 'FullyEncrypted',
-                    2: 'EncryptionInProgress',
-                    3: 'DecryptionInProgress',
-                    4: 'EncryptionPaused',
-                    5: 'DecryptionPaused'
+        var child_process = require('child_process');
+        var wmi = require('win-wmi-fixed');
+
+        wmi.query('ROOT\\CIMV2', 'SELECT * FROM Win32_LogicalDisk', ['DeviceID', 'VolumeName', 'FileSystem', 'Size', 'FreeSpace', 'DriveType'])
+            .forEach(function (disk) {
+                if (!disk || !disk['DeviceID']) { return; }   // skip rows without a DeviceID. Shouldn't be possible, but could in case of wmi funkyness
+                var drive = disk['DeviceID'].slice(0, -1);
+                drives[drive] = {
+                    name: disk['VolumeName'] || '',
+                    type: disk['FileSystem'] || 'Unknown',
+                    size: parseInt(disk['Size']) || 0,
+                    sizeremaining: parseInt(disk['FreeSpace']) || 0,
+                    dType: disk['DriveType'] || 0
                 };
-                ret[drive].volumeStatus = statuses.hasOwnProperty(values[i].ConversionStatus) ? statuses[values[i].ConversionStatus] : 'FullyDecrypted';
-                ret[drive].protectionStatus = (values[i].ProtectionStatus == 0 ? 'Off' : (values[i].ProtectionStatus == 1 ? 'On' : 'Unknown'));
-                try {
-                    var keychild = require('child_process').execFile(process.env['windir'] + '\\system32\\cmd.exe', ['/c', 'manage-bde -protectors -get ' + drive + ': -Type recoverypassword'], {});
-                    keychild.stdout.str = ''; keychild.stdout.on('data', function (c) { this.str += c.toString(); });
-                    keychild.waitExit();
-                    // find position of pattern, or null if not found
-                    id = keychild.stdout.str.match(reID);
-                    rp = keychild.stdout.str.match(rePass);
-                    // recoveryPW can be empty if volume is locked
-                    if (id) { ret[drive].identifier = id[0]; }
-                    if (rp) { ret[drive].recoveryPassword = rp[0]; }
-                } catch(ex) { } // just carry on as we cant get bitlocker key
-            }
-        }
-        p1._res(ret);
-    } catch (ex) { p1._res(ret); } // just return volumes as cant get encryption/bitlocker
+            });
+
+        wmi.query('ROOT\\CIMV2\\Security\\MicrosoftVolumeEncryption', 'SELECT * FROM Win32_EncryptableVolume', ['DriveLetter', 'ConversionStatus', 'ProtectionStatus', 'EncryptionMethod'])
+            .forEach(function (vol) {
+                if (!vol || !vol['DriveLetter']) { return; }   // there can be volumes without a DriveLetter(=null), which errors the slice
+                var drive = vol['DriveLetter'].slice(0, -1);
+                if (!drives[drive]) { return; }                // no matching logical disk, skip for now.
+                drives[drive].volumeStatus = vol['ConversionStatus'];
+                drives[drive].encryptionMethod = vol['EncryptionMethod'];
+                drives[drive].protectionStatus = vol['ProtectionStatus'];
+                var keychild = child_process.execFile(process.env['windir'] + '\\system32\\cmd.exe', ['/c', 'manage-bde -protectors -get ' + drive + ': -Type recoverypassword'], {});
+                keychild.stdout.str = '';
+                keychild.stdout.on('data', function (c) { this.str += c.toString(); });
+                keychild.waitExit();
+                var id = keychild.stdout.str.match(reID);
+                var rp = keychild.stdout.str.match(rePass);
+                // a recovery password protector should always have an identifier
+                if (id) { drives[drive].identifier = id[0]; }
+                // recoveryPW can be empty if volume is locked
+                if (rp) { drives[drive].recoveryPassword = rp[0]; }
+            });
+    } catch (e) {
+        console.log('windows_volumes error: ' + (e && e.message ? e.message : e));
+    }
+    p1._res(drives);    // always resolve. Partial results if an error occurred
     return (p1);
 }
 

--- a/agents/modules_meshcore/win-volumes.js
+++ b/agents/modules_meshcore/win-volumes.js
@@ -63,7 +63,6 @@ function windows_volumes()
     var reID = new RegExp("{[A-F0-9]{8}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{4}-[A-F0-9]{12}}", "mi");
     var rePass = new RegExp("[0-9]{6}-[0-9]{6}-[0-9]{6}-[0-9]{6}-[0-9]{6}-[0-9]{6}-[0-9]{6}-[0-9]{6}", "mi");
     try {
-        var child_process = require('child_process');
         var wmi = require('win-wmi-fixed');
 
         wmi.query('ROOT\\CIMV2', 'SELECT * FROM Win32_LogicalDisk', ['DeviceID', 'VolumeName', 'FileSystem', 'Size', 'FreeSpace', 'DriveType'])
@@ -79,30 +78,37 @@ function windows_volumes()
                 };
             });
 
-        wmi.query('ROOT\\CIMV2\\Security\\MicrosoftVolumeEncryption', 'SELECT * FROM Win32_EncryptableVolume', ['DriveLetter', 'ConversionStatus', 'ProtectionStatus', 'EncryptionMethod'])
-            .forEach(function (vol) {
-                if (!vol || !vol['DriveLetter']) { return; }   // there can be volumes without a DriveLetter(=null), which errors the slice
-                var drive = vol['DriveLetter'].slice(0, -1);
-                if (!drives[drive]) { return; }                // no matching logical disk, skip for now.
-                drives[drive].volumeStatus = vol['ConversionStatus'];
-                drives[drive].encryptionMethod = vol['EncryptionMethod'];
-                drives[drive].protectionStatus = vol['ProtectionStatus'];
-                var keychild = child_process.execFile(process.env['windir'] + '\\system32\\cmd.exe', ['/c', 'manage-bde -protectors -get ' + drive + ': -Type recoverypassword'], {});
-                keychild.stdout.str = '';
-                keychild.stdout.on('data', function (c) { this.str += c.toString(); });
-                keychild.waitExit();
-                var id = keychild.stdout.str.match(reID);
-                var rp = keychild.stdout.str.match(rePass);
-                // a recovery password protector should always have an identifier
-                if (id) { drives[drive].identifier = id[0]; }
-                // recoveryPW can be empty if volume is locked
-                if (rp) { drives[drive].recoveryPassword = rp[0]; }
-            });
+        // The MicrosoftVolumeEncryption namespace is admin-only and manage-bde needs elevation; skip both entirely when not elevated, saves waiting unneccessary on time-out of wmi-query if run as user
+        if (require('user-sessions').isRoot()) {
+            var child_process = require('child_process');
+            wmi.query('ROOT\\CIMV2\\Security\\MicrosoftVolumeEncryption', 'SELECT * FROM Win32_EncryptableVolume', ['DriveLetter', 'ConversionStatus', 'ProtectionStatus', 'EncryptionMethod'])
+                .forEach(function (vol) {
+                    if (!vol || !vol['DriveLetter']) { return; }   // there can be volumes without a DriveLetter(=null), which errors the slice
+                    var drive = vol['DriveLetter'].slice(0, -1);
+                    if (!drives[drive]) { return; }                // no matching logical disk, skip for now.
+                    drives[drive].volumeStatus = vol['ConversionStatus'];
+                    drives[drive].encryptionMethod = vol['EncryptionMethod'];
+                    drives[drive].protectionStatus = vol['ProtectionStatus'];
+                    // Only run manage-bde on encrypted drives (ConversionStatus/volumeStatus 0 = FullyDecrypted, otherwise some sort of encryption)
+                    if (drives[drive].volumeStatus != 0) {
+                        var keychild = child_process.execFile(process.env['windir'] + '\\system32\\cmd.exe', ['/c', 'manage-bde -protectors -get ' + drive + ': -Type recoverypassword'], {});
+                        keychild.stdout.str = '';
+                        keychild.stdout.on('data', function (c) { this.str += c.toString(); });
+                        keychild.waitExit();
+                        var id = keychild.stdout.str.match(reID);
+                        var rp = keychild.stdout.str.match(rePass);
+                        // a recovery password protector should always have an identifier
+                        if (id) { drives[drive].identifier = id[0]; }
+                        // recoveryPW can be empty if volume is locked
+                        if (rp) { drives[drive].recoveryPassword = rp[0]; }
+                    }
+                });
+        }
     } catch (e) {
         console.log('windows_volumes error: ' + (e && e.message ? e.message : e));
-        error = e;    // add error, fall through to the single resolve below
+        error = e;    // add error, fall through to resolve below
     }
-    p1._res({ error: error, drives: drives });    // always resolve; error is null on success, partial drives kept on failure
+    p1._res({ error: error, drives: drives });    // always resolve; error is null on success, partial drives kept on failure.
     return (p1);
 }
 

--- a/agents/modules_meshcore/win-volumes.js
+++ b/agents/modules_meshcore/win-volumes.js
@@ -94,7 +94,7 @@ function windows_volumes()
                         var keychild = child_process.execFile(process.env['windir'] + '\\system32\\cmd.exe', ['/c', 'manage-bde -protectors -get ' + drive + ': -Type recoverypassword'], {});
                         keychild.stdout.str = '';
                         keychild.stdout.on('data', function (c) { this.str += c.toString(); });
-                        keychild.waitExit();
+                        keychild.waitExit(4000);
                         var id = keychild.stdout.str.match(reID);
                         var rp = keychild.stdout.str.match(rePass);
                         // a recovery password protector should always have an identifier

--- a/agents/modules_meshcore/win-volumes.js
+++ b/agents/modules_meshcore/win-volumes.js
@@ -56,6 +56,7 @@ function getVolumes()
 function windows_volumes()
 {
     var drives = {};
+    var error = null;
     var promise = require('promise');
     var p1 = new promise(function (res, rej) { this._res = res; this._rej = rej; });
     // RegExps for the specific patterns in the manage-bde output, case-insensitive multiline
@@ -99,8 +100,9 @@ function windows_volumes()
             });
     } catch (e) {
         console.log('windows_volumes error: ' + (e && e.message ? e.message : e));
+        error = e;    // add error, fall through to the single resolve below
     }
-    p1._res(drives);    // always resolve. Partial results if an error occurred
+    p1._res({ error: error, drives: drives });    // always resolve; error is null on success, partial drives kept on failure
     return (p1);
 }
 

--- a/meshagent.js
+++ b/meshagent.js
@@ -1461,11 +1461,43 @@ module.exports.CreateMeshAgent = function (parent, db, ws, req, args, domain) {
                         command.data.type = 'sysinfo';
                         command.data.domain = domain.id;
                         command.data.time = Date.now();
-                        db.Set(command.data); // Update system information in the database.
 
-                        // Event the new sysinfo hash, this will notify everyone that the sysinfo document was changed
-                        var event = { etype: 'node', action: 'sysinfohash', nodeid: obj.dbNodeKey, domain: domain.id, hash: command.data.hash, nolog: 1 };
-                        parent.parent.DispatchEvent(parent.CreateMeshDispatchTargets(obj.dbMeshKey, [obj.dbNodeKey]), obj, event);
+                        // Store the document and notify viewers that the sysinfo hash changed.
+                        var saveSysInfo = function () {
+                            db.Set(command.data);
+                            // Event the new sysinfo hash, this will notify everyone that the sysinfo document was changed
+                            var event = { etype: 'node', action: 'sysinfohash', nodeid: obj.dbNodeKey, domain: domain.id, hash: command.data.hash, nolog: 1 };
+                            parent.parent.DispatchEvent(parent.CreateMeshDispatchTargets(obj.dbMeshKey, [obj.dbNodeKey]), obj, event);
+                        };
+
+                        var volumes = command.data.hardware?.windows?.volumes;
+                        if (volumes) {
+                            // BitLocker recovery keys are kept in hardware.windows.bitlocker, keyed by protector identifier
+                            // (decoupled from the drive letter, which can change). A key is retained for 'bitlockerKeyRetentionDays'
+                            // days after it was last read; 0 (default) disables carry-forward, keeping only keys read in this scan.
+                            var ttl = (parent.parent.config.settings?.bitlockerkeyretentiondays > 0) ? (parent.parent.config.settings.bitlockerkeyretentiondays * 86400000) : 0;
+                            var updateBLKeys = function (prevKeys) {
+                                var keys = {};
+                                // Carry forward keys last read within the retention window.
+                                if ((ttl > 0) && prevKeys) {
+                                    for (const id in prevKeys) { if ((command.data.time - prevKeys[id].t) <= ttl) { keys[id] = prevKeys[id]; } }
+                                }
+                                // Record keys actually read this scan (refreshes the timestamp).
+                                for (const v of Object.values(volumes)) {
+                                    if (v.identifier && v.recoveryPassword) { keys[v.identifier] = { rp: v.recoveryPassword, t: command.data.time }; }
+                                }
+                                command.data.hardware.windows.bitlocker = keys;
+                                saveSysInfo();
+                            };
+                            if (ttl > 0) {
+                                // Need the previous doc to carry keys forward.
+                                db.Get(command.data._id, function (err, nodes) { updateBLKeys((nodes && nodes.length > 0) ? nodes[0].hardware?.windows?.bitlocker : null); });
+                            } else {
+                                updateBLKeys(null);   // no carry-forward, no previous-doc read needed
+                            }
+                        } else {
+                            saveSysInfo();   // non-Windows
+                        }
                     }
                     break;
                 }

--- a/meshcentral-config-schema.json
+++ b/meshcentral-config-schema.json
@@ -569,6 +569,11 @@
           "default": false,
           "description": "Enables agent-side, websocket per-message deflate compression. wscompression must also be true for this to work."
         },
+        "bitlockerKeyRetentionDays": {
+          "type": "integer",
+          "default": 0,
+          "description": "How many days to retain a BitLocker recovery key after the agent last read it, so a key stays available while a volume is locked or detached. Especially useful for Bitlocker To Go devices. 0 (default) disables carry-forward: only keys read in the latest scan are kept."
+        },
         "noAgentUpdate": {
           "type": "integer",
           "default": 0,

--- a/meshcentral.js
+++ b/meshcentral.js
@@ -164,7 +164,7 @@ function CreateMeshCentralServer(config, args) {
             'setuptelegram', 'resetaccount', 'pass', 'removesubdomain', 'adminaccount',
             'domain', 'email', 'configfile', 'maintenancemode', 'nedbtodb',
             'removetestagents', 'agentupdatetest', 'hashpassword', 'hashpass',
-            'indexmcrec', 'mpsdebug', 'dumpcores', 'dev', 'mysql', 'mariadb', 'trustedproxy'
+            'indexmcrec', 'mpsdebug', 'dumpcores', 'dev', 'mysql', 'mariadb', 'trustedproxy', 'migratevolumeinfo'
         ];
         for (var arg in obj.args) { obj.args[arg.toLocaleLowerCase()] = obj.args[arg]; if (validArguments.indexOf(arg.toLocaleLowerCase()) == -1) { console.log('Invalid argument "' + arg + '", use --help.'); return; } }
         const ENVVAR_PREFIX = "meshcentral_"
@@ -991,6 +991,7 @@ function CreateMeshCentralServer(config, args) {
                     if (obj.args.logintokenkey) { obj.showLoginTokenKey(function (r) { console.log(r); process.exit(); }); return; }
                     if (obj.args.recordencryptionrecode) { obj.db.performRecordEncryptionRecode(function (count) { console.log('Re-encoded ' + count + ' record(s).'); process.exit(); }); return; }
                     if (obj.args.dbstats) { obj.db.getDbStats(function (stats) { console.log(stats); process.exit(); }); return; }
+                    if (obj.args.migratevolumeinfo) { require('./migrate-volume-info.js').migrateVolumeInfo(obj.db, function (err, r) { if (err != null) { console.log('Volume info migration error: ' + err); } else { console.log('Volume info migration complete. Scanned ' + r.scanned + ' sysinfo document(s), migrated ' + r.migrated + ', moved ' + r.keysMoved + ' key(s).'); } process.exit(); }); return; }
                     if (obj.args.createaccount) { // Create a new user account
                         if ((typeof obj.args.createaccount != 'string') || ((obj.args.pass == null) && (obj.args.hashpass == null)) || (obj.args.pass == '') || (obj.args.hashpass == '') || (obj.args.createaccount.indexOf(' ') >= 0)) { console.log("Usage: --createaccount [userid] --pass [password] --domain (domain) --email (email) --name (name)."); process.exit(); return; }
                         var userid = 'user/' + (obj.args.domain ? obj.args.domain : '') + '/' + obj.args.createaccount.toLowerCase(), domainid = obj.args.domain ? obj.args.domain : '';

--- a/meshctrl.js
+++ b/meshctrl.js
@@ -3205,6 +3205,12 @@ function displayDeviceInfo(sysinfo, lastconnect, network, nodes) {
                 }
             }
         }
+    
+        // Windows volumes
+        if ((hardware?.windows?.volumes)) { info["Volumes"] = hardware.windows.volumes; }
+    
+        // Bitlocker cache
+        if ((hardware?.windows?.bitlocker)) { info["Bitlocker cache"] = hardware.windows.bitlocker; }
     }
 
     // Display everything

--- a/meshuser.js
+++ b/meshuser.js
@@ -13,6 +13,12 @@
 /*jshint esversion: 6 */
 "use strict";
 
+// volume & bitlocker statuses
+const encMethod = { 0: '', 1: "AES-128 with diffuser", 2: "AES-256 with diffuser", 3: 'AES-128', 4: 'AES-256', 5: "Hardware encryption", 6: 'XTS-AES-128', 7: 'XTS-AES-256' };
+const driveType = { 0: "Unknown", 1: "No Root Directory", 2: "Removable Disk", 3: "Local Disk", 4: "Network Drive", 5: "Compact Disc", 6: "RAM Disk" };
+const conversionStatus = { "-1": "Unknown", 0: "Fully Decrypted", 1: "Fully Encrypted", 2: "Encryption In Progress", 3: "Decryption In Progress", 4: "Encryption Paused", 5: "Decryption Paused" };
+const protectionStatus = { 0: "Off", 1: "On", 2: "Locked"};
+
 // Construct a MeshAgent object, called upon connection
 module.exports.CreateMeshUser = function (parent, db, ws, req, args, domain, user) {
     const fs = require('fs');
@@ -5301,7 +5307,6 @@ module.exports.CreateMeshUser = function (parent, db, ws, req, args, domain, use
                             }
 
                             var output = null;
-                            var conversionStatus = { 0: 'FullyDecrypted', 1: 'FullyEncrypted', 2: 'EncryptionInProgress', 3: 'DecryptionInProgress', 4: 'EncryptionPaused', 5: 'DecryptionPaused' };
                             if (type == 'csv') {
                                 try {
                                     // Create the CSV file
@@ -5568,9 +5573,6 @@ module.exports.CreateMeshUser = function (parent, db, ws, req, args, domain, use
                                 } catch (ex) { console.log(ex); }
                             } else {
                                 // Create the JSON file, convert codes into description
-                                var encryptionMethods = { 0: 'None', 1: 'AES_128_WITH_DIFFUSER', 2: 'AES_256_WITH_DIFFUSER', 3: 'AES_128', 4: 'AES_256', 5: 'HARDWARE_ENCRYPTION', 6: 'XTS_AES_128', 7: 'XTS_AES_256' };
-                                var protectionStatuses = { 0: 'Off', 1: 'On', 2: 'Locked'};
-                                var driveType = { 0: "Unknown", 1: "No Root Directory", 2: "Removable Disk", 3: "Local Disk", 4: "Network Drive", 5: "Compact Disc", 6: "RAM Disk" };
                                 for (var i = 0; i < results.length; i++) {
                                     const nodeinfo = results[i];
                                     if (nodeinfo.node) {
@@ -5578,16 +5580,16 @@ module.exports.CreateMeshUser = function (parent, db, ws, req, args, domain, use
                                         if (mesh) { results[i].node.groupname = mesh.name; }
                                     }
                                     // add a decoded per-volume status summary and remove the raw recovery keys
-                                    var bvols = (nodeinfo.sys && nodeinfo.sys.hardware && nodeinfo.sys.hardware.windows) ? nodeinfo.sys.hardware.windows.volumes : null;
-                                    if (bvols != null) {
+                                    var bvols = nodeinfo.sys?.hardware?.windows?.volumes;
+                                    if (bvols) {
                                         for (var a in bvols) {
                                             var bv = bvols[a];
                                             if (bv.dType) (bv.dType = driveType[bv.dType] ? driveType[bv.dType] : 'Unknown');
                                             delete bv.recoveryPassword; // never include raw recovery keys in a report
                                             if ((bv.volumeStatus == null) && (bv.protectionStatus == null)) continue;
                                             if (bv.volumeStatus != null) { bv.volumeStatus = (typeof bv.volumeStatus === 'string') ? bv.volumeStatus : (conversionStatus[bv.volumeStatus] || 'Unknown'); }
-                                            if (bv.protectionStatus != null) { bv.protectionStatus = (typeof bv.protectionStatus === 'boolean') ? (bv.protectionStatus ? 'On' : 'Off') : ((typeof bv.protectionStatus === 'string') ? bv.protectionStatus : (protectionStatuses[bv.protectionStatus] || 'Unknown')); }
-                                            if (bv.encryptionMethod != null) { bv.encryptionMethod = (typeof bv.encryptionMethod === 'string') ? bv.encryptionMethod : (encryptionMethods[bv.encryptionMethod] || 'Unknown'); }
+                                            if (bv.protectionStatus != null) { bv.protectionStatus = (typeof bv.protectionStatus === 'boolean') ? (bv.protectionStatus ? 'On' : 'Off') : ((typeof bv.protectionStatus === 'string') ? bv.protectionStatus : (protectionStatus[bv.protectionStatus] || 'Unknown')); }
+                                            if (bv.encryptionMethod != null) { bv.encryptionMethod = (typeof bv.encryptionMethod === 'string') ? bv.encryptionMethod : (encMethod[bv.encryptionMethod] || 'Unknown'); }
                                         }
                                         delete nodeinfo.sys.hardware.windows.bitlocker; // drop the recovery-key map from the export
                                     }
@@ -6712,14 +6714,39 @@ module.exports.CreateMeshUser = function (parent, db, ws, req, args, domain, use
                     delete doc.domain;
                     delete doc._id;
 
-                    // If this is not a device group admin users, don't send any BitLocker recovery info
-                    if ((rights != MESHRIGHT_ADMIN) && (doc.hardware) && (doc.hardware.windows)) {
-                        if (doc.hardware.windows.volumes) {
+                    // If this is not an admin user, don't send any BitLocker recovery info
+                    if (rights != MESHRIGHT_ADMIN && doc?.hardware?.windows) {
+                        if (doc.hardware.windows?.volumes) {
                             for (var i in doc.hardware.windows.volumes) {
                                 delete doc.hardware.windows.volumes[i].recoveryPassword;    // previous single bitlocker schema
                             }
                         }
                         delete doc.hardware.windows.bitlocker;  // new bitlocker driveletter independent cache
+                    }
+                  
+                    // deviceinfo for meshctrl.js, replace raw codes with readable strings and add recoveryPassword if possible
+                    if (command.responseid && command.responseid == 'meshctrl') {
+                        if (doc.hardware?.windows?.volumes) {
+                            for (const [drive, volumeInfo] of Object.entries(doc.hardware.windows.volumes)) {
+                                if (typeof volumeInfo.dType == 'number') { volumeInfo.dType = driveType[volumeInfo.dType] ?? 'Unknown'; }
+                                if (typeof volumeInfo.volumeStatus == 'number') {
+                                    if (volumeInfo.volumeStatus == 0) {volumeInfo.volumeStatus = conversionStatus[0]; continue; }
+                                    // only do volumes with a encryption status
+                                    volumeInfo.volumeStatus = conversionStatus[volumeInfo.volumeStatus] ?? 'Unknown';
+                                    if (volumeInfo.protectionStatus && typeof volumeInfo.protectionStatus == 'number') { volumeInfo.protectionStatus = protectionStatus[volumeInfo.protectionStatus] ?? 'Unknown'; }     
+                                    if (volumeInfo.encryptionMethod) { volumeInfo.encryptionMethod = encMethod[volumeInfo.encryptionMethod] ?? 'Unknown'; } 
+                                    if ((rights == MESHRIGHT_ADMIN) && volumeInfo.identifier && !(volumeInfo.hasOwnProperty('recoveryPassword')) && doc.hardware.windows?.bitlocker?.[volumeInfo.identifier])
+                                        { volumeInfo.recoveryPassword = doc.hardware.windows.bitlocker[volumeInfo.identifier].rp; }
+                                }
+                            }
+                        }
+                        var b;
+                        if ((rights == MESHRIGHT_ADMIN) && (b = doc.hardware?.windows?.bitlocker)) {
+                            for (const robj of Object.values(b)) {
+                                robj.recoveryPassword = robj.rp; delete robj.rp;
+                                robj.lastSeen = new Date(robj.t); delete robj.t;
+                            }
+                        }
                     }
 
                     if (command.nodeinfo === true) {

--- a/meshuser.js
+++ b/meshuser.js
@@ -5301,6 +5301,7 @@ module.exports.CreateMeshUser = function (parent, db, ws, req, args, domain, use
                             }
 
                             var output = null;
+                            var conversionStatus = { 0: 'FullyDecrypted', 1: 'FullyEncrypted', 2: 'EncryptionInProgress', 3: 'DecryptionInProgress', 4: 'EncryptionPaused', 5: 'DecryptionPaused' };
                             if (type == 'csv') {
                                 try {
                                     // Create the CSV file
@@ -5317,9 +5318,19 @@ module.exports.CreateMeshUser = function (parent, db, ws, req, args, domain, use
                                             } else if (typeof n.lsc == 'object') {
                                                 output += ',' + csvClean(n.lsc.antiVirus ? n.lsc.antiVirus : '') + ',,' + csvClean(n.lsc.firewall ? n.lsc.firewall : '')
                                             } else { output += ',,,'; }
-                                            if (typeof n.volumes == 'object') {
+                                            // BitLocker info sits in the sysinfo node
+                                            // present when the user has device-details rights (otherwise sys was deleted above).
+                                            var bitlockervolumes = (nodeinfo.sys && nodeinfo.sys.hardware && nodeinfo.sys.hardware.windows) ? nodeinfo.sys.hardware.windows.volumes : null;
+                                            if (bitlockervolumes != null) {
+                                                // Map the Win32_EncryptableVolume.ConversionStatus codes to labels (legacy string values pass through).
                                                 var bitlockerdetails = '', firstbitlocker = true;
-                                                for (var a in n.volumes) { if (typeof n.volumes[a].protectionStatus !== 'undefined') { if (firstbitlocker) { firstbitlocker = false; } else { bitlockerdetails += '|'; } bitlockerdetails += a + '/' + n.volumes[a].volumeStatus; } }
+                                                for (var a in bitlockervolumes) {
+                                                    var bv = bitlockervolumes[a];
+                                                    if ((bv.volumeStatus == null) && (bv.protectionStatus == null)) continue; // no BitLocker info for this volume
+                                                    if (firstbitlocker) { firstbitlocker = false; } else { bitlockerdetails += '|'; }
+                                                    var status = (bv.protectionStatus == 2) ? 'Locked' : ((typeof bv.volumeStatus === 'string') ? bv.volumeStatus : (conversionStatus[bv.volumeStatus] || 'Unknown'));
+                                                    bitlockerdetails += a + '/' + status;
+                                                }
                                                 output += ',' + csvClean(bitlockerdetails);
                                             } else {
                                                 output += ',';
@@ -5556,18 +5567,33 @@ module.exports.CreateMeshUser = function (parent, db, ws, req, args, domain, use
                                     }
                                 } catch (ex) { console.log(ex); }
                             } else {
-                                // Create the JSON file
-
-                                // Add the device group name to each device
+                                // Create the JSON file, convert codes into description
+                                var encryptionMethods = { 0: 'None', 1: 'AES_128_WITH_DIFFUSER', 2: 'AES_256_WITH_DIFFUSER', 3: 'AES_128', 4: 'AES_256', 5: 'HARDWARE_ENCRYPTION', 6: 'XTS_AES_128', 7: 'XTS_AES_256' };
+                                var protectionStatuses = { 0: 'Off', 1: 'On', 2: 'Locked'};
+                                var driveType = { 0: "Unknown", 1: "No Root Directory", 2: "Removable Disk", 3: "Local Disk", 4: "Network Drive", 5: "Compact Disc", 6: "RAM Disk" };
                                 for (var i = 0; i < results.length; i++) {
                                     const nodeinfo = results[i];
                                     if (nodeinfo.node) {
                                         const mesh = parent.meshes[nodeinfo.node.meshid];
                                         if (mesh) { results[i].node.groupname = mesh.name; }
                                     }
+                                    // add a decoded per-volume status summary and remove the raw recovery keys
+                                    var bvols = (nodeinfo.sys && nodeinfo.sys.hardware && nodeinfo.sys.hardware.windows) ? nodeinfo.sys.hardware.windows.volumes : null;
+                                    if (bvols != null) {
+                                        for (var a in bvols) {
+                                            var bv = bvols[a];
+                                            if (bv.dType) (bv.dType = driveType[bv.dType] ? driveType[bv.dType] : 'Unknown');
+                                            delete bv.recoveryPassword; // never include raw recovery keys in a report
+                                            if ((bv.volumeStatus == null) && (bv.protectionStatus == null)) continue;
+                                            if (bv.volumeStatus != null) { bv.volumeStatus = (typeof bv.volumeStatus === 'string') ? bv.volumeStatus : (conversionStatus[bv.volumeStatus] || 'Unknown'); }
+                                            if (bv.protectionStatus != null) { bv.protectionStatus = (typeof bv.protectionStatus === 'boolean') ? (bv.protectionStatus ? 'On' : 'Off') : ((typeof bv.protectionStatus === 'string') ? bv.protectionStatus : (protectionStatuses[bv.protectionStatus] || 'Unknown')); }
+                                            if (bv.encryptionMethod != null) { bv.encryptionMethod = (typeof bv.encryptionMethod === 'string') ? bv.encryptionMethod : (encryptionMethods[bv.encryptionMethod] || 'Unknown'); }
+                                        }
+                                        delete nodeinfo.sys.hardware.windows.bitlocker; // drop the recovery-key map from the export
+                                    }
                                 }
 
-                                output = JSON.stringify(results);
+                                output = JSON.stringify(results, null, 1);
                             }
                             try { ws.send(JSON.stringify({ action: 'getDeviceDetails', data: output, type: type })); } catch (ex) { }
                         });

--- a/meshuser.js
+++ b/meshuser.js
@@ -6686,9 +6686,14 @@ module.exports.CreateMeshUser = function (parent, db, ws, req, args, domain, use
                     delete doc.domain;
                     delete doc._id;
 
-                    // If this is not a device group admin users, don't send any BitLocker recovery passwords
-                    if ((rights != MESHRIGHT_ADMIN) && (doc.hardware) && (doc.hardware.windows) && (doc.hardware.windows.volumes)) {
-                        for (var i in doc.hardware.windows.volumes) { delete doc.hardware.windows.volumes[i].recoveryPassword; }
+                    // If this is not a device group admin users, don't send any BitLocker recovery info
+                    if ((rights != MESHRIGHT_ADMIN) && (doc.hardware) && (doc.hardware.windows)) {
+                        if (doc.hardware.windows.volumes) {
+                            for (var i in doc.hardware.windows.volumes) {
+                                delete doc.hardware.windows.volumes[i].recoveryPassword;    // previous single bitlocker schema
+                            }
+                        }
+                        delete doc.hardware.windows.bitlocker;  // new bitlocker driveletter independent cache
                     }
 
                     if (command.nodeinfo === true) {

--- a/migrate-volume-info.js
+++ b/migrate-volume-info.js
@@ -1,0 +1,67 @@
+/**
+* @description One-shot migration: convert pre-key-list BitLocker sysinfo documents to the
+*              identifier-keyed hardware.windows.bitlocker map and convert DriveType
+*
+* Run with:  node meshcentral --migrateVolumeInfo
+*
+* Old sysinfo documents stored BitLocker recovery keys per-volume (recoveryPassword).
+* The current schema keeps them in hardware.windows.bitlocker[identifier] = { rp, t }.
+* Devices whose agents have not reconnected still hold the old shape.
+* This moves the existing keys into the new map.
+* Old DriveTypes (cdrom, removable) are converted to the raw windows code
+*
+* Notes:
+*  - Idempotent: any document that already has hardware.windows.bitlocker is left untouched, so it is
+*    safe to run repeatedly and a no-op once every device has re-sent sysinfo.
+*  - Volume status strings written by the old agent are converted back to their raw codes.
+*    Any unrecognized string is left untouched and still renders via the views' typeof==='string' branch.
+*  - The timestamp (t) is taken from the document's own 'time' field (last sysinfo). With the default
+*    bitlockerKeyRetentionDays=0, migrated keys persist for non-reconnecting devices and are rebuilt
+*    from the live scan once a device reconnects.
+*
+* @license Apache-2.0
+*/
+'use strict';
+
+// db: the MeshCentral database object (obj.db). callback(err, { scanned, migrated, keysMoved }).
+module.exports.migrateVolumeInfo = function (db, callback) {
+    // Legacy string (old agent stringified values) -> raw code, to restore the schema the current views expect.
+    var conversionStatusCodes = { 'FullyDecrypted': 0, 'FullyEncrypted': 1, 'EncryptionInProgress': 2, 'DecryptionInProgress': 3, 'EncryptionPaused': 4, 'DecryptionPaused': 5 };
+    db.GetAllType('sysinfo', function (err, docs) {
+        if (err != null) { if (callback != null) { callback(err); } return; }
+        var scanned = 0, migrated = 0, keysMoved = 0, writesPending = 0, listed = false;
+        var done = function () { if (listed && (writesPending == 0) && (callback != null)) { callback(null, { scanned: scanned, migrated: migrated, keysMoved: keysMoved }); } };
+        for (var d in docs) {
+            var doc = docs[d];
+            scanned++;
+            var windows = (doc.hardware != null) ? doc.hardware.windows : null;
+            // Skip non-Windows documents and anything already on the new schema.
+            if ((windows == null) || (windows.volumes == null) || (windows.bitlocker != null)) { continue; }
+
+            var keys = {};
+            for (var letter in windows.volumes) {
+                var v = windows.volumes[letter];
+                // Live key read at the time of the last sysinfo, for the current protector.
+                if (v.identifier && v.recoveryPassword) { keys[v.identifier] = { rp: v.recoveryPassword, t: (doc.time || 0) }; }
+                // Reconstruct the raw Win32_LogicalDisk.DriveType code from the legacy boolean flags
+                if (v.dType == null) {
+                    if (v.removable) { v.dType = 2; }        // Removable Disk
+                    else if (v.cdrom) { v.dType = 5; }       // Compact Disc / CD-ROM
+                }
+                delete v.removable; delete v.cdrom;
+                // Restore raw status/method codes from the legacy stringified values. Unrecognized strings are left as is, handled in the views
+                if ((typeof v.volumeStatus === 'string') && (conversionStatusCodes[v.volumeStatus] != null)) { v.volumeStatus = conversionStatusCodes[v.volumeStatus]; }
+                // Old documents stored protectionStatus as a boolean (true = On; Off/Locked were dropped). Restore the
+                // raw code: true -> 1 (On). Locked (2) was not retained by the old agent, so it cannot be recovered.
+                if (typeof v.protectionStatus === 'boolean') { if (v.protectionStatus) { v.protectionStatus = 1; } else { delete v.protectionStatus; } }
+            }
+            windows.bitlocker = keys;
+            migrated++;
+            keysMoved += Object.keys(keys).length;
+            writesPending++;
+            db.Set(doc, function () { writesPending--; done(); });
+        }
+        listed = true;
+        done();   // handle the case where nothing needed writing
+    });
+};

--- a/views/default-mobile.handlebars
+++ b/views/default-mobile.handlebars
@@ -6879,6 +6879,9 @@
             // Volumes and Bitlocker
             if (hardware.windows && hardware.windows.volumes) {
                 var x = '';
+                const encMethod = { 0: '', 1: " / AES-128 with diffuser", 2: " / AES-256 with diffuser", 3: ' / AES-128', 4: ' / AES-256', 5: " / Hardware encryption", 6: ' / XTS-AES-128', 7: ' / XTS-AES-256' };
+                const driveType = { 0: "Unknown", 1: "No Root Directory", 2: "Removable Disk", 3: "Local Disk", 4: "Network Drive", 5: "Compact Disc", 6: "RAM Disk" };
+                const conversionStatus = { 1: "Fully Encrypted", 2: "Encryption In Progress", 3: "Decryption In Progress", 4: "Encryption Paused", 5: "Decryption Paused" };
                 for (var i in hardware.windows.volumes) {
                     var m = hardware.windows.volumes[i];
                     x += '<tr><td><div class=style10 style=border-radius:5px;padding:8px>';
@@ -6896,22 +6899,29 @@
                         x += addDetailItem("Capacity Remaining", EscapeHtml(fsize), s);
                     }
                     if (m.type) {
-                        var type = (m.removable == true ? "Removable" : (m.cdrom == true ? "CD-ROM" : (m.network == true ? "Network" : '')));
+                        var type = (m.removable == true ? "Removable" : (m.cdrom == true ? "CD-ROM" : ''));
+                        if (m.dType != null) { type = driveType.hasOwnProperty(m.dType) ? driveType[m.dType] : 'Unknown'; }
                         x += addDetailItem("File System", (type != '' ? (type + ' / ') : '') + (m.type == 'Unknown' ? "Unknown" : EscapeHtml(m.type)), s);
                     }
 
-                    if (m.protectionStatus || m.volumeStatus) {
-                        var bitlockerState = [];
-                        if (m.protectionStatus) bitlockerState.push("Enabled");
-                        if (m.volumeStatus && m.volumeStatus == 'FullyDecrypted') bitlockerState.push("Fully Decrypted");
-                        if (m.volumeStatus && m.volumeStatus == 'EncryptionInProgress') bitlockerState.push("Encryption In Progress");
-                        if (m.volumeStatus && m.volumeStatus == 'FullyEncrypted') bitlockerState.push("Fully Encrypted");
-                        if (m.volumeStatus && m.volumeStatus == 'DecryptionInProgress') bitlockerState.push("Decryption In Progress");
-                        if (m.volumeStatus && m.volumeStatus == 'EncryptionPaused') bitlockerState.push("Encryption Paused");
-                        if (m.volumeStatus && m.volumeStatus == 'DecryptionPaused') bitlockerState.push("Decryption Paused");
-                        if (m.encryptionMethod) bitlockerState.push(m.encryptionMethod);
-                        bitlockerState = bitlockerState.join(' - ');
-                        if (m.recoveryPassword) { bitlockerState += addKeyLink('', 'deviceDetailsShowBitlockerInfo(\"' + encodeURIComponentEx(i) + '\",\"' + encodeURIComponentEx(m.identifier) + '\",\"' + encodeURIComponentEx(m.recoveryPassword) + '\")'); }
+                    if (m.protectionStatus || m.volumeStatus) { // volumeStatus=conversionStatus
+                        var bitlockerState;
+                        if (typeof(m.volumeStatus) === "string") {  // string style db schema
+                            bitlockerState = m.volumeStatus;
+                        } else {    // new code db schema
+                            if (m.protectionStatus == 2) {
+                                bitlockerState = 'Locked'
+                            } else {
+                                bitlockerState = (conversionStatus.hasOwnProperty(m.volumeStatus) ? conversionStatus[m.volumeStatus] : 'Unknown');
+                            }
+                        }
+                        bitlockerState += (encMethod.hasOwnProperty(m.encryptionMethod) ? encMethod[m.encryptionMethod] : ' / Unknown');
+                        var lastrp = (m.identifier && hardware.windows.bitlocker) ? hardware.windows.bitlocker[m.identifier] : null;
+                        var legacyrp = (m.lastKnownRecoveryPassword && (m.lastKnownIdentifier === m.identifier)) ? m.lastKnownRecoveryPassword : null;   // pre key-list (un-migrated) docs
+                        var sendPW = m.recoveryPassword || (lastrp ? lastrp.rp : null) || legacyrp || 'External (PIN/Key/File)';
+                        if (m.identifier) {
+                            bitlockerState += addKeyLink('', 'deviceDetailsShowBitlockerInfo(\"' + encodeURIComponentEx(i) + '\",\"' + encodeURIComponentEx(m.identifier) + '\",\"' + encodeURIComponentEx(sendPW) + '\"' + ')');
+                        }
                         x += addDetailItem("BitLocker", bitlockerState, s);
                     }
                     x += '</div>';

--- a/views/default-mobile.handlebars
+++ b/views/default-mobile.handlebars
@@ -6896,7 +6896,7 @@
                         x += addDetailItem("Capacity Remaining", EscapeHtml(fsize), s);
                     }
                     if (m.type) {
-                        var type = (m.removable == true ? "Removable" : (m.cdrom == true ? "CD-ROM" : ''));
+                        var type = (m.removable == true ? "Removable" : (m.cdrom == true ? "CD-ROM" : (m.network == true ? "Network" : '')));
                         x += addDetailItem("File System", (type != '' ? (type + ' / ') : '') + (m.type == 'Unknown' ? "Unknown" : EscapeHtml(m.type)), s);
                     }
 
@@ -6906,6 +6906,10 @@
                         if (m.volumeStatus && m.volumeStatus == 'FullyDecrypted') bitlockerState.push("Fully Decrypted");
                         if (m.volumeStatus && m.volumeStatus == 'EncryptionInProgress') bitlockerState.push("Encryption In Progress");
                         if (m.volumeStatus && m.volumeStatus == 'FullyEncrypted') bitlockerState.push("Fully Encrypted");
+                        if (m.volumeStatus && m.volumeStatus == 'DecryptionInProgress') bitlockerState.push("Decryption In Progress");
+                        if (m.volumeStatus && m.volumeStatus == 'EncryptionPaused') bitlockerState.push("Encryption Paused");
+                        if (m.volumeStatus && m.volumeStatus == 'DecryptionPaused') bitlockerState.push("Decryption Paused");
+                        if (m.encryptionMethod) bitlockerState.push(m.encryptionMethod);
                         bitlockerState = bitlockerState.join(' - ');
                         if (m.recoveryPassword) { bitlockerState += addKeyLink('', 'deviceDetailsShowBitlockerInfo(\"' + encodeURIComponentEx(i) + '\",\"' + encodeURIComponentEx(m.identifier) + '\",\"' + encodeURIComponentEx(m.recoveryPassword) + '\")'); }
                         x += addDetailItem("BitLocker", bitlockerState, s);

--- a/views/default.handlebars
+++ b/views/default.handlebars
@@ -12811,7 +12811,7 @@
                         x += addDetailItem("Capacity Remaining", EscapeHtml(fsize), s);
                     }
                     if (m.type) {
-                        var type = (m.removable == true ? "Removable" : (m.cdrom == true ? "CD-ROM" : ''));
+                        var type = (m.removable == true ? "Removable" : (m.cdrom == true ? "CD-ROM" : (m.network == true ? "Network" : '')));
                         x += addDetailItem("File System", (type != '' ? (type + ' / ') : '') + (m.type == 'Unknown' ? "Unknown" : EscapeHtml(m.type)), s);
                     }
 
@@ -12821,6 +12821,10 @@
                         if (m.volumeStatus && m.volumeStatus == 'FullyDecrypted') bitlockerState.push("Fully Decrypted");
                         if (m.volumeStatus && m.volumeStatus == 'EncryptionInProgress') bitlockerState.push("Encryption In Progress");
                         if (m.volumeStatus && m.volumeStatus == 'FullyEncrypted') bitlockerState.push("Fully Encrypted");
+                        if (m.volumeStatus && m.volumeStatus == 'DecryptionInProgress') bitlockerState.push("Decryption In Progress");
+                        if (m.volumeStatus && m.volumeStatus == 'EncryptionPaused') bitlockerState.push("Encryption Paused");
+                        if (m.volumeStatus && m.volumeStatus == 'DecryptionPaused') bitlockerState.push("Decryption Paused");
+                        if (m.encryptionMethod) bitlockerState.push(m.encryptionMethod);
                         bitlockerState = bitlockerState.join(' - ');
                         if (m.recoveryPassword) { bitlockerState += addKeyLink('', 'deviceDetailsShowBitlockerInfo(\"' + encodeURIComponentEx(i) + '\",\"' + encodeURIComponentEx(m.identifier) + '\",\"' + encodeURIComponentEx(m.recoveryPassword) + '\")'); }
                         x += addDetailItem("BitLocker", bitlockerState, s);

--- a/views/default.handlebars
+++ b/views/default.handlebars
@@ -12794,6 +12794,9 @@
             // Volumes and Bitlocker
             if (hardware.windows && hardware.windows.volumes) {
                 var x = '';
+                const encMethod = { 0: '', 1: " / AES-128 with diffuser", 2: " / AES-256 with diffuser", 3: ' / AES-128', 4: ' / AES-256', 5: " / Hardware encryption", 6: ' / XTS-AES-128', 7: ' / XTS-AES-256' };
+                const driveType = { 0: "Unknown", 1: "No Root Directory", 2: "Removable Disk", 3: "Local Disk", 4: "Network Drive", 5: "Compact Disc", 6: "RAM Disk" };
+                const conversionStatus = { 1: "Fully Encrypted", 2: "Encryption In Progress", 3: "Decryption In Progress", 4: "Encryption Paused", 5: "Decryption Paused" };
                 for (var i in hardware.windows.volumes) {
                     var m = hardware.windows.volumes[i];
                     x += '<tr><td><div class=style10 style=border-radius:5px;padding:8px>';
@@ -12811,22 +12814,29 @@
                         x += addDetailItem("Capacity Remaining", EscapeHtml(fsize), s);
                     }
                     if (m.type) {
-                        var type = (m.removable == true ? "Removable" : (m.cdrom == true ? "CD-ROM" : (m.network == true ? "Network" : '')));
+                        var type = (m.removable == true ? "Removable" : (m.cdrom == true ? "CD-ROM" : '')); 
+                        if (m.dType != null) {type = driveType.hasOwnProperty(m.dType) ? driveType[m.dType] : 'Unknown'; };
                         x += addDetailItem("File System", (type != '' ? (type + ' / ') : '') + (m.type == 'Unknown' ? "Unknown" : EscapeHtml(m.type)), s);
                     }
 
-                    if (m.protectionStatus || m.volumeStatus) {
-                        var bitlockerState = [];
-                        if (m.protectionStatus) bitlockerState.push("Enabled");
-                        if (m.volumeStatus && m.volumeStatus == 'FullyDecrypted') bitlockerState.push("Fully Decrypted");
-                        if (m.volumeStatus && m.volumeStatus == 'EncryptionInProgress') bitlockerState.push("Encryption In Progress");
-                        if (m.volumeStatus && m.volumeStatus == 'FullyEncrypted') bitlockerState.push("Fully Encrypted");
-                        if (m.volumeStatus && m.volumeStatus == 'DecryptionInProgress') bitlockerState.push("Decryption In Progress");
-                        if (m.volumeStatus && m.volumeStatus == 'EncryptionPaused') bitlockerState.push("Encryption Paused");
-                        if (m.volumeStatus && m.volumeStatus == 'DecryptionPaused') bitlockerState.push("Decryption Paused");
-                        if (m.encryptionMethod) bitlockerState.push(m.encryptionMethod);
-                        bitlockerState = bitlockerState.join(' - ');
-                        if (m.recoveryPassword) { bitlockerState += addKeyLink('', 'deviceDetailsShowBitlockerInfo(\"' + encodeURIComponentEx(i) + '\",\"' + encodeURIComponentEx(m.identifier) + '\",\"' + encodeURIComponentEx(m.recoveryPassword) + '\")'); }
+                    if (m.protectionStatus || m.volumeStatus) { // volumeStatus=conversionStatus
+                        var bitlockerState;
+                        if (typeof(m.volumeStatus) === "string") {  // string style db schema 
+                            bitlockerState = m.volumeStatus;
+                        } else {    // new code db schema
+                            if (m.protectionStatus == 2) {
+                                bitlockerState = 'Locked'
+                            } else {
+                                bitlockerState = (conversionStatus.hasOwnProperty(m.volumeStatus) ? conversionStatus[m.volumeStatus] : 'Unknown');
+                            }
+                        }
+                        bitlockerState += (encMethod.hasOwnProperty(m.encryptionMethod) ? encMethod[m.encryptionMethod] : ' / Unknown');
+                        var lastrp = (m.identifier && hardware.windows.bitlocker) ? hardware.windows.bitlocker[m.identifier] : null;
+                        var legacyrp = (m.lastKnownRecoveryPassword && (m.lastKnownIdentifier === m.identifier)) ? m.lastKnownRecoveryPassword : null;   // pre key-list (un-migrated) docs
+                        var sendPW = m.recoveryPassword || (lastrp ? lastrp.rp : null) || legacyrp || 'External (PIN/Key/File)';
+                        if (m.identifier) { 
+                            bitlockerState += addKeyLink('', 'deviceDetailsShowBitlockerInfo(\"' + encodeURIComponentEx(i) + '\",\"' + encodeURIComponentEx(m.identifier) + '\",\"' + encodeURIComponentEx(sendPW) + '\"' + ')');
+                        }
                         x += addDetailItem("BitLocker", bitlockerState, s);
                     }
                     x += '</div>';

--- a/views/default.handlebars
+++ b/views/default.handlebars
@@ -6256,19 +6256,12 @@
                 meshserver.send({ action: 'getDeviceDetails', nodeids: chkNodeIds, tz: tz, tf: new Date().getTimezoneOffset(), l: getLang(), type: 'csv' }); // With details
             } else {
                 // Without details
-                var csv = "id,name,rname,host,icon,ip,osdesc,state,groupname,conn,pwr,av,update,firewall,bitlocker,avdetails,tags,lastbootuptime" + '\r\n', r = [];
+                var csv = "id,name,rname,host,icon,ip,osdesc,state,groupname,conn,pwr,av,update,firewall,avdetails,tags,lastbootuptime" + '\r\n', r = [];
                 for (var i in chkNodeIds) {
                     var n = getNodeFromId(chkNodeIds[i]);
                     csv += '"' + n._id.split(',').join('') + '","' + n.name.split(',').join('') + '","' + (n.rname?(n.rname.split(',').join('')):'') + '","' + (n.host?(n.host.split(',').join('')):'') + '","' + n.icon + '","' + (n.ip?n.ip:'') + '","' + (n.osdesc?(n.osdesc.split(',').join('')):'') + '","' + n.state + '","' + meshes[n.meshid].name.split(',').join('') + '","' + (n.conn?n.conn:'') + '","' + (n.pwr?n.pwr:'') + '"';
                     if (typeof n.wsc == 'object') { csv += ',"' + csvClean(n.wsc.antiVirus) + '","' + csvClean(n.wsc.autoUpdate) + '","' + csvClean(n.wsc.firewall) + '"'; }
                     else if (typeof n.lsc == 'object') { csv += ',"' + csvClean(n.lsc.antiVirus) + '",,"' + csvClean(n.lsc.firewall) + '"'; } else { csv += ',,,';  }
-                    if (typeof n.volumes == 'object') {
-                        var bitlockerdetails = '', firstbitlocker = true;
-                        for (var a in n.volumes) { if (typeof n.volumes[a].protectionStatus !== 'undefined') { if (firstbitlocker) { firstbitlocker = false; } else { bitlockerdetails += '|'; } bitlockerdetails += a + '/' + n.volumes[a].volumeStatus; } }
-                        csv += ',"' + csvClean(bitlockerdetails) + '"'; }
-                    else {
-                        csv += ',';
-                    }
                     if (typeof n.av == 'object') {
                         var avdetails = '', firstav = true;
                         for (var a in n.av) { if (typeof n.av[a].product == 'string') { if (firstav) { firstav = false; } else { avdetails += '|'; } avdetails += (n.av[a].product + '/' + ((n.av[a].enabled)?'enabled':'disabled') + '/' + ((n.av[a].updated)?'updated':'notupdated')); } }

--- a/views/default3.handlebars
+++ b/views/default3.handlebars
@@ -14687,6 +14687,9 @@
             // Volumes and Bitlocker
             if (hardware.windows && hardware.windows.volumes) {
                 var x = '';
+                const encMethod = { 0: '', 1: " / AES-128 with diffuser", 2: " / AES-256 with diffuser", 3: ' / AES-128', 4: ' / AES-256', 5: " / Hardware encryption", 6: ' / XTS-AES-128', 7: ' / XTS-AES-256' };
+                const driveType = { 0: "Unknown", 1: "No Root Directory", 2: "Removable Disk", 3: "Local Disk", 4: "Network Drive", 5: "Compact Disc", 6: "RAM Disk" };
+                const conversionStatus = { 1: "Fully Encrypted", 2: "Encryption In Progress", 3: "Decryption In Progress", 4: "Encryption Paused", 5: "Decryption Paused" };
                 for (var i in hardware.windows.volumes) {
                     var m = hardware.windows.volumes[i];
                     x += '<tr><td><div class=style10 style=border-radius:5px;padding:8px>';
@@ -14704,22 +14707,29 @@
                         x += addDetailItem("Capacity Remaining", EscapeHtml(fsize), s);
                     }
                     if (m.type) {
-                        var type = (m.removable == true ? "Removable" : (m.cdrom == true ? "CD-ROM" : (m.network == true ? "Network" : '')));
+                        var type = (m.removable == true ? "Removable" : (m.cdrom == true ? "CD-ROM" : ''));
+                        if (m.dType != null) { type = driveType.hasOwnProperty(m.dType) ? driveType[m.dType] : 'Unknown'; }
                         x += addDetailItem("File System", (type != '' ? (type + ' / ') : '') + (m.type == 'Unknown' ? "Unknown" : EscapeHtml(m.type)), s);
                     }
 
-                    if (m.protectionStatus || m.volumeStatus) {
-                        var bitlockerState = [];
-                        if (m.protectionStatus) bitlockerState.push("Enabled");
-                        if (m.volumeStatus && m.volumeStatus == 'FullyDecrypted') bitlockerState.push("Fully Decrypted");
-                        if (m.volumeStatus && m.volumeStatus == 'EncryptionInProgress') bitlockerState.push("Encryption In Progress");
-                        if (m.volumeStatus && m.volumeStatus == 'FullyEncrypted') bitlockerState.push("Fully Encrypted");
-                        if (m.volumeStatus && m.volumeStatus == 'DecryptionInProgress') bitlockerState.push("Decryption In Progress");
-                        if (m.volumeStatus && m.volumeStatus == 'EncryptionPaused') bitlockerState.push("Encryption Paused");
-                        if (m.volumeStatus && m.volumeStatus == 'DecryptionPaused') bitlockerState.push("Decryption Paused");
-                        if (m.encryptionMethod) bitlockerState.push(m.encryptionMethod);
-                        bitlockerState = bitlockerState.join(' - ');
-                        if (m.recoveryPassword) { bitlockerState += addKeyLink('', 'deviceDetailsShowBitlockerInfo(\"' + encodeURIComponentEx(i) + '\",\"' + encodeURIComponentEx(m.identifier) + '\",\"' + encodeURIComponentEx(m.recoveryPassword) + '\")'); }
+                    if (m.protectionStatus || m.volumeStatus) { // volumeStatus=conversionStatus
+                        var bitlockerState;
+                        if (typeof(m.volumeStatus) === "string") {  // string style db schema
+                            bitlockerState = m.volumeStatus;
+                        } else {    // new code db schema
+                            if (m.protectionStatus == 2) {
+                                bitlockerState = 'Locked'
+                            } else {
+                                bitlockerState = (conversionStatus.hasOwnProperty(m.volumeStatus) ? conversionStatus[m.volumeStatus] : 'Unknown');
+                            }
+                        }
+                        bitlockerState += (encMethod.hasOwnProperty(m.encryptionMethod) ? encMethod[m.encryptionMethod] : ' / Unknown');
+                        var lastrp = (m.identifier && hardware.windows.bitlocker) ? hardware.windows.bitlocker[m.identifier] : null;
+                        var legacyrp = (m.lastKnownRecoveryPassword && (m.lastKnownIdentifier === m.identifier)) ? m.lastKnownRecoveryPassword : null;   // pre key-list (un-migrated) docs
+                        var sendPW = m.recoveryPassword || (lastrp ? lastrp.rp : null) || legacyrp || 'External (PIN/Key/File)';
+                        if (m.identifier) {
+                            bitlockerState += addKeyLink('', 'deviceDetailsShowBitlockerInfo(\"' + encodeURIComponentEx(i) + '\",\"' + encodeURIComponentEx(m.identifier) + '\",\"' + encodeURIComponentEx(sendPW) + '\"' + ')');
+                        }
                         x += addDetailItem("BitLocker", bitlockerState, s);
                     }
                     x += '</div>';

--- a/views/default3.handlebars
+++ b/views/default3.handlebars
@@ -7360,20 +7360,12 @@
                 meshserver.send({ action: 'getDeviceDetails', nodeids: chkNodeIds, tz: tz, tf: new Date().getTimezoneOffset(), l: getLang(), type: 'csv' }); // With details
             } else {
                 // Without details
-                var csv = "id,name,rname,host,icon,ip,osdesc,state,groupname,conn,pwr,av,update,firewall,bitlocker,avdetails,tags,lastbootuptime" + '\r\n', r = [];
+                var csv = "id,name,rname,host,icon,ip,osdesc,state,groupname,conn,pwr,av,update,firewall,avdetails,tags,lastbootuptime" + '\r\n', r = [];
                 for (var i in chkNodeIds) {
                     var n = getNodeFromId(chkNodeIds[i]);
                     csv += '"' + n._id.split(',').join('') + '","' + n.name.split(',').join('') + '","' + (n.rname ? (n.rname.split(',').join('')) : '') + '","' + (n.host ? (n.host.split(',').join('')) : '') + '","' + n.icon + '","' + (n.ip ? n.ip : '') + '","' + (n.osdesc ? (n.osdesc.split(',').join('')) : '') + '","' + n.state + '","' + meshes[n.meshid].name.split(',').join('') + '","' + (n.conn ? n.conn : '') + '","' + (n.pwr ? n.pwr : '') + '"';
                     if (typeof n.wsc == 'object') { csv += ',"' + csvClean(n.wsc.antiVirus) + '","' + csvClean(n.wsc.autoUpdate) + '","' + csvClean(n.wsc.firewall) + '"'; }
                     else if (typeof n.lsc == 'object') { csv += ',"' + csvClean(n.lsc.antiVirus) + '",,"' + csvClean(n.lsc.firewall) + '"'; } else { csv += ',,,'; }
-                    if (typeof n.volumes == 'object') {
-                        var bitlockerdetails = '', firstbitlocker = true;
-                        for (var a in n.volumes) { if (typeof n.volumes[a].protectionStatus !== 'undefined') { if (firstbitlocker) { firstbitlocker = false; } else { bitlockerdetails += '|'; } bitlockerdetails += a + '/' + n.volumes[a].volumeStatus; } }
-                        csv += ',"' + csvClean(bitlockerdetails) + '"';
-                    }
-                    else {
-                        csv += ',';
-                    }
                     if (typeof n.av == 'object') {
                         var avdetails = '', firstav = true;
                         for (var a in n.av) { if (typeof n.av[a].product == 'string') { if (firstav) { firstav = false; } else { avdetails += '|'; } avdetails += (n.av[a].product + '/' + ((n.av[a].enabled) ? 'enabled' : 'disabled') + '/' + ((n.av[a].updated) ? 'updated' : 'notupdated')); } }

--- a/views/default3.handlebars
+++ b/views/default3.handlebars
@@ -14704,7 +14704,7 @@
                         x += addDetailItem("Capacity Remaining", EscapeHtml(fsize), s);
                     }
                     if (m.type) {
-                        var type = (m.removable == true ? "Removable" : (m.cdrom == true ? "CD-ROM" : ''));
+                        var type = (m.removable == true ? "Removable" : (m.cdrom == true ? "CD-ROM" : (m.network == true ? "Network" : '')));
                         x += addDetailItem("File System", (type != '' ? (type + ' / ') : '') + (m.type == 'Unknown' ? "Unknown" : EscapeHtml(m.type)), s);
                     }
 
@@ -14714,6 +14714,10 @@
                         if (m.volumeStatus && m.volumeStatus == 'FullyDecrypted') bitlockerState.push("Fully Decrypted");
                         if (m.volumeStatus && m.volumeStatus == 'EncryptionInProgress') bitlockerState.push("Encryption In Progress");
                         if (m.volumeStatus && m.volumeStatus == 'FullyEncrypted') bitlockerState.push("Fully Encrypted");
+                        if (m.volumeStatus && m.volumeStatus == 'DecryptionInProgress') bitlockerState.push("Decryption In Progress");
+                        if (m.volumeStatus && m.volumeStatus == 'EncryptionPaused') bitlockerState.push("Encryption Paused");
+                        if (m.volumeStatus && m.volumeStatus == 'DecryptionPaused') bitlockerState.push("Decryption Paused");
+                        if (m.encryptionMethod) bitlockerState.push(m.encryptionMethod);
                         bitlockerState = bitlockerState.join(' - ');
                         if (m.recoveryPassword) { bitlockerState += addKeyLink('', 'deviceDetailsShowBitlockerInfo(\"' + encodeURIComponentEx(i) + '\",\"' + encodeURIComponentEx(m.identifier) + '\",\"' + encodeURIComponentEx(m.recoveryPassword) + '\")'); }
                         x += addDetailItem("BitLocker", bitlockerState, s);


### PR DESCRIPTION
- Adds encryptionmethod (AES-128, XTS-AES-128 etc) to bitlocker info
- Adds all statuses (Locked, encryption paused etc) to bitlocker info
- Adds lastknown recoverypassword option. Useful for Bitlocker To Go drives. Config.json option: bitlockerKeyRetentionDays. Default 0. If enabled, remembers bitlocker keys for the days entered. If a rembered drive is inserted, gives admins the option to see the recoverykey even if the drive is still locked. Accessible through the same keylink in de device details pane at the bitlocker info of the device.
- Adds all drivetypes as defined by windows (RAM disk, Network drive(< only system mappings, no user atm, coming soon)) to volumeinfo
- Adds admin checks to bitlocker and sysinfo console command, only admins see recoverycodes
- Fixes csv/JSON devicereports to show bitlocker info
- Remove bitlocker info from report without device details
- Moves the volume data description logic from the agent to the webviews. The agent just pushes the raw wmi codes instead of translating it to full text. The codes are stored in the db and translated in the webviews. With sysinfo updates from the nodes, the data is updated to the code format in the sysinfo object. Previous data (from disconnected nodes) is preserved until updated and displayed as is now. There is an optional migrate script to convert the legacy string format to the new code format. Run with the server off: node meshcentral.js --migratevolumeinfo
- Fix sessionid and add error feedback to bitlocker console command
- Optimise windows-volumes() drive iterationloop

<img width="819" height="665" alt="image" src="https://github.com/user-attachments/assets/4ed38230-4804-48e8-8146-863a84afa858" />
