### PR TITLE
Docker: fix DYNAMIC_CONFIG writing port/redirPort as JSON strings

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -127,12 +127,12 @@ function dynamic_config() {
         echo "Setting port... $PORT"
 
         jq --arg port "$PORT" \
-            '.settings.port = $port' \
+            '.settings.port = ($port|tonumber)' \
             "$CONFIG_FILE" > temp_config.json && mv temp_config.json "$CONFIG_FILE"
     else
         echo "Invalid or no port, defaulting to '443', Value(s) given: ${PORT:-empty}"
         jq --arg port "443" \
-            '.settings.port = $port' \
+            '.settings.port = ($port|tonumber)' \
             "$CONFIG_FILE" > temp_config.json && mv temp_config.json "$CONFIG_FILE"
     fi
 
@@ -141,12 +141,12 @@ function dynamic_config() {
         echo "Setting redirport... $REDIR_PORT"
 
         jq --arg redirport "$REDIR_PORT" \
-            '.settings.redirPort = $redirport' \
+            '.settings.redirPort = ($redirport|tonumber)' \
             "$CONFIG_FILE" > temp_config.json && mv temp_config.json "$CONFIG_FILE"
     else
         echo "Invalid or no redirport, defaulting to '80', Value(s) given: ${REDIR_PORT:-empty}"
         jq --arg redirport "80" \
-            '.settings.redirPort = $redirport' \
+            '.settings.redirPort = ($redirport|tonumber)' \
             "$CONFIG_FILE" > temp_config.json && mv temp_config.json "$CONFIG_FILE"
     fi
 


### PR DESCRIPTION
Fixes #7886.

`jq --arg` always produces a JSON string, so with `DYNAMIC_CONFIG=true` the entrypoint wrote `"port": "8080"` into `config.json`. MeshCentral requires a number for `settings.port`/`settings.redirPort`:

```js
if (obj.args.port == null || typeof obj.args.port != 'number') { obj.args.port = 443; }
```

so the server silently fell back to 443/80 while the entrypoint logged the requested port.

This casts the values in the jq filter (`($port|tonumber)`), including the 443/80 default branches, matching the `--argjson` style already used for the boolean settings in the same script.

Tested on the generated config:
- `PORT=8080 REDIR_PORT=800` → `"port": 8080, "redirPort": 800` (numbers, pass the `typeof === 'number'` check);
- default branch → `"port": 443` (number);
- side effect of the cast: a non-numeric `PORT` now makes jq fail and leaves `config.json` untouched (the `&& mv` guard), instead of silently writing a string the server rejects.