### PR TITLE
Remove unused listconfigfiles queries

### DIFF
--- a/db.js
+++ b/db.js
@@ -1878,9 +1878,6 @@ module.exports.CreateDB = function (parent, func) {
             // Write a configuration file to the database
             obj.setConfigFile = function (path, data, func) { obj.Set({ _id: 'cfile/' + path, type: 'cfile', data: data.toString('base64') }, func); }
 
-            // List all configuration files
-            obj.listConfigFiles = function (func) { sqlDbQuery('SELECT doc FROM main WHERE type = "cfile" ORDER BY id', func); }
-
             // Get database information (TODO: Complete this)
             obj.getDbStats = function (func) {
                 obj.stats = { c: 4 };
@@ -2161,13 +2158,6 @@ module.exports.CreateDB = function (parent, func) {
             // Write a configuration file to the database
             obj.setConfigFile = function (path, data, func) { obj.Set({ _id: 'cfile/' + path, type: 'cfile', data: data.toString('base64') }, func); }
 
-            // List all configuration files
-            obj.listConfigFiles = function (func) {
-                obj.file.query('meshcentral').filter('type', '==', 'cfile').sort('_id').get(function (snapshots) {
-                    const docs = []; for (var i in snapshots) { docs.push(snapshots[i].val()); } func(null, docs);
-                });
-            }
-
             // Get database information
             obj.getDbStats = function (func) {
                 obj.stats = { c: 5 };
@@ -2434,9 +2424,6 @@ module.exports.CreateDB = function (parent, func) {
             // Write a configuration file to the database
             obj.setConfigFile = function (path, data, func) { obj.Set({ _id: 'cfile/' + path, type: 'cfile', data: data.toString('base64') }, func); }
 
-            // List all configuration files
-            obj.listConfigFiles = function (func) { sqlDbQuery('SELECT doc FROM main WHERE type = "cfile" ORDER BY id', func); }
-
             // Get database information (TODO: Complete this)
             obj.getDbStats = function (func) {
                 obj.stats = { c: 4 };
@@ -2686,9 +2673,6 @@ module.exports.CreateDB = function (parent, func) {
             // Write a configuration file to the database
             obj.setConfigFile = function (path, data, func) { obj.Set({ _id: 'cfile/' + path, type: 'cfile', data: data.toString('base64') }, func); }
 
-            // List all configuration files
-            obj.listConfigFiles = function (func) { sqlDbQuery('SELECT doc FROM main WHERE type = "cfile" ORDER BY id', func); }
-            
             // Get database information (TODO: Complete this)
             obj.getDbStats = function (func) {
                 obj.stats = { c: 4 };
@@ -2988,9 +2972,6 @@ module.exports.CreateDB = function (parent, func) {
             // Write a configuration file to the database
             obj.setConfigFile = function (path, data, func) { obj.Set({ _id: 'cfile/' + path, type: 'cfile', data: data.toString('base64') }, func); }
 
-            // List all configuration files
-            obj.listConfigFiles = function (func) { obj.file.find({ type: 'cfile' }).sort({ _id: 1 }).toArray(func); }
-
             // Get database information
             obj.getDbStats = function (func) {
                 obj.stats = { c: 6 };
@@ -3206,9 +3187,6 @@ module.exports.CreateDB = function (parent, func) {
 
             // Write a configuration file to the database
             obj.setConfigFile = function (path, data, func) { obj.Set({ _id: 'cfile/' + path, type: 'cfile', data: data.toString('base64') }, func); }
-
-            // List all configuration files
-            obj.listConfigFiles = function (func) { obj.file.find({ type: 'cfile' }).sort({ _id: 1 }).exec(func); }
 
             // Get database information
             obj.getDbStats = function (func) {

--- a/meshcentral.js
+++ b/meshcentral.js
@@ -1182,7 +1182,7 @@ function CreateMeshCentralServer(config, args) {
                             if (err == null) {
                                 if (docs.length == 0) { console.log("File not found."); } else {
                                     const data = obj.db.decryptData(obj.args.configkey, docs[0].data);
-                                    if (data == null) { console.log("Invalid config key."); } else { console.log(data); }
+                                    if (data == null) { console.log("Invalid config key."); } else { console.log(data.toString()); }
                                 }
                             } else { console.log("Unable to read from database."); }
                             process.exit();

--- a/meshcentral.js
+++ b/meshcentral.js
@@ -190,25 +190,31 @@ function CreateMeshCentralServer(config, args) {
             console.log('Details at: https://www.meshcentral.com\r\n');
             if ((obj.platform == 'win32') || (obj.platform == 'linux')) {
                 console.log('Run as a background service');
-                console.log('   --install/uninstall               Install MeshCentral as a background service.');
-                console.log('   --start/stop/restart              Control MeshCentral background service.');
+                console.log('   --install/uninstall\t\t\t\t\tInstall MeshCentral as a background service.');
+                console.log('   --start/stop/restart\t\t\t\t\tControl MeshCentral background service.');
                 console.log('');
                 console.log('Run standalone, console application');
             }
-            console.log('   --user [username]                 Always login as [username] if account exists.');
-            console.log('   --port [number]                   Web server port number.');
-            console.log('   --redirport [number]              Creates an additional HTTP server to redirect users to the HTTPS server.');
-            console.log('   --exactports                      Server must run with correct ports or exit.');
-            console.log('   --noagentupdate                   Server will not update mesh agent native binaries.');
-            console.log('   --nedbtodb                        Transfer all NeDB records into current database.');
-            console.log('   --listuserids                     Show a list of a user identifiers in the database.');
-            console.log('   --cert [name], (country), (org)   Create a web server certificate with [name] server name.');
-            console.log('                                     country and organization can optionally be set.');
-            console.log('');
-            console.log('Server recovery commands, use only when MeshCentral is offline.');
-            console.log('   --createaccount [userid]          Create a new user account.');
-            console.log('   --resetaccount [userid]           Unlock an account, disable 2FA and set a new account password.');
-            console.log('   --adminaccount [userid]           Promote account to site administrator.');
+            console.log('   --user [username]\t\t\t\t\tAlways login as [username] if account exists.');
+            console.log('   --port [number]\t\t\t\t\tWeb server port number.');
+            console.log('   --redirport [number]\t\t\t\t\tCreates an additional HTTP server to redirect users to the HTTPS server.');
+            console.log('   --exactports\t\t\t\t\t\tServer must run with correct ports or exit.');
+            console.log('   --noagentupdate\t\t\t\t\tServer will not update mesh agent native binaries.');
+            console.log('   --nedbtodb\t\t\t\t\t\tTransfer all NeDB records into current database.');
+            console.log('   --listuserids\t\t\t\t\tShow a list of a user identifiers in the database.');
+            console.log('   --cert [name], (country), (org)\t\t\tCreate a web server certificate with [name] server name.');
+            console.log('\t\t\t\t\t\t\tcountry and organization can optionally be set.');
+            console.log('\r\nRun stateless, config files (config.json and certificates) are stored encrypted with [password] in the database.');
+            console.log('   --dblistconfigfile (password)\t\t\tShow the files in the db and optionally check the files against the password.');
+            console.log('   --dbpushconfigfiles (path) --configkey [password]\tThis will import the current configfiles or from (path) into the database.');
+            console.log('   --dbshowconfigfile [file] --configkey [password]\tShow contents of config [file].');
+            console.log('   --dbpullconfigfiles [path] --configkey [password]\tPull configfiles out of the database into [path].');
+            console.log('   --dbdeleteconfigfiles\t\t\t\tDelete config files from the database.');
+            console.log('   --loadconfigfromdb [password]\t\t\tRun meshcentral with configfiles found in the database.')
+            console.log('\r\nServer recovery commands, use only when MeshCentral is offline.');
+            console.log('   --createaccount [userid]\t\t\t\tCreate a new user account.');
+            console.log('   --resetaccount [userid]\t\t\t\tUnlock an account, disable 2FA and set a new account password.');
+            console.log('   --adminaccount [userid]\t\t\t\tPromote account to site administrator.');
             return;
         }
 


### PR DESCRIPTION
Came across the stateless config management functions and saw this function is not used, as it was probably replaced with the default getalltype query it uses now a long time ago.
@si458 And optional help info regarding the commands to run meshcentral stateless. I placed it in a separate commit so you can decide if you want to include it or not.