### PR TITLE
Fix errormessage in checkbackupcapabilities

### DIFF
--- a/db.js
+++ b/db.js
@@ -3465,11 +3465,11 @@ module.exports.CreateDB = function (parent, func) {
                 if ((error != null) && (error != '')) {
                         func(1, "Mongodump error, backup will not be performed. Check path or use mongodumppath & mongodumpargs");
 						
-						let processedError = error;
+						let processedError = error.message;
 						if (typeof parent?.config?.settings?.postgres?.password === "string" &&	parent.config.settings.postgres.password.length > 0) {
-							processedError = encodeURIComponent(processedError.replaceAll(parent.config.settings.postgres.password, "****"));
+							processedError = processedError.replaceAll(encodeURIComponent(parent.config.settings.postgres.password), "****");
 						}
-						parent.debug('backup', 'MongoDB/MongoJS DumpTool: ' + processedError);			
+						parent.debug('backup', 'MongoDB/MongoJS DumpTool: ' + processedError);
 						
                         return;
                 } else {parent.config.settings.autobackup.backupintervalhours = backupInterval;}
@@ -3483,9 +3483,9 @@ module.exports.CreateDB = function (parent, func) {
                 if ((error != null) && (error != '')) {
                         func(1, "mysqldump error, backup will not be performed. Check path or use mysqldumppath");
 						
-						let processedError = error;
+						let processedError = error.message;
 						if (typeof parent?.config?.settings?.postgres?.password === "string" &&	parent.config.settings.postgres.password.length > 0) {
-							processedError = encodeURIComponent(processedError.replaceAll(parent.config.settings.postgres.password, "****"));
+							processedError = processedError.replaceAll(encodeURIComponent(parent.config.settings.postgres.password), "****");
 						}
 						parent.debug('backup', 'MariaDB/MySQL DumpTool: ' + processedError);
 						
@@ -3505,9 +3505,9 @@ module.exports.CreateDB = function (parent, func) {
                 if ((error != null) && (error != '')) {
                         func(1, "pg_dump error, backup will not be performed. Check path or use pgdumppath.");
 						
-						let processedError = error;
-						if (typeof parent?.config?.settings?.postgres?.password === "string" &&	parent.config.settings.postgres.password.length > 0) {
-							processedError = encodeURIComponent(processedError.replaceAll(parent.config.settings.postgres.password, "****"));
+						let processedError = error.message;
+						if (typeof parent?.config?.settings?.postgres?.password === "string" && parent.config.settings.postgres.password.length > 0) {
+							processedError = processedError.replaceAll(encodeURIComponent(parent.config.settings.postgres.password), "****");
 						}
 						parent.debug('backup', 'PostgreSQL DumpTool: ' + processedError);				
 						


### PR DESCRIPTION
While switching to postgres to check something, it would fatally error out at startup, as my pgdumppath was incorrect.
The errorfucntion for the dumptoolcheck tries to replaceAll() on the error object instead of the .message.
And the encodeURIcomponent was done on the whole processedError, but should be done on the password from the config for a proper the replace.