### PR TITLE
Prevent linux-info.js from hanging the agent

### DIFF
--- a/agents/meshcore.js
+++ b/agents/meshcore.js
@@ -7040,88 +7040,101 @@ function sendNetworkUpdate(force) {
 }
 
 // Called periodically to check if we need to send updates to the server
+var sendPeriodicServerUpdateInProgress = false;
 function sendPeriodicServerUpdate(flags, force) {
     if (meshServerConnectionState == 0) return; // Not connected to server, do nothing.
-    if (!flags) { flags = 0xFFFFFFFF; }
-    if (!force) { force = false; }
 
-    // If we have a connected MEI, get Intel ME information
-    if ((flags & 1) && (amt != null) && (amt.state == 2)) {
-        delete meshCoreObj.intelamt;
-        amt.getMeiState(9, function (meinfo) {
-            meshCoreObj.intelamt = meinfo;
-            meshCoreObj.intelamt.microlms = amt.lmsstate;
-            meshCoreObjChanged();
-        });
-    }
+    // Defensive guard against re-entrancy. The info collectors below are currently
+    // non-blocking (Linux av()/firewall() are async; Windows uses native WMI), so
+    // nothing here pumps the event loop and this guard never actually fires. It's
+    // kept as a safety net: if a future collector re-introduces a blocking
+    // child.waitExit() (which runs a nested event loop), a timer firing inside it
+    // could re-enter and throw 'waitExit() already in progress'. Skipping the
+    // overlapping run avoids that.
+    if (sendPeriodicServerUpdateInProgress) return;
+    sendPeriodicServerUpdateInProgress = true;
+    try {
+        if (!flags) { flags = 0xFFFFFFFF; }
+        if (!force) { force = false; }
 
-    // Update network information
-    if (flags & 2) { sendNetworkUpdateNagle(false); }
-
-    // Update anti-virus information
-    if ((flags & 4) && (process.platform == 'win32')) {
-        // Windows Command: "wmic /Namespace:\\root\SecurityCenter2 Path AntiVirusProduct get /FORMAT:CSV"
-        try { meshCoreObj.av = require('win-info').av(); meshCoreObjChanged(); } catch (ex) { av = null; } // Antivirus
-        //if (process.platform == 'win32') { try { meshCoreObj.pr = require('win-info').pendingReboot(); meshCoreObjChanged(); } catch (ex) { meshCoreObj.pr = null; } } // Pending reboot
-    }
-    // Update Linux AV/Firewall information. av()/firewall() are asynchronous (they
-    // spawn child processes), so they don't block this periodic update with a nested
-    // waitExit() loop. Results are applied in the callbacks and flushed via
-    // meshCoreObjChanged().
-    if ((flags & 4) && (process.platform == 'linux')) {
-        try {
-            require('linux-info').av(function (avResult) {
-                try {
-                    var lsc = {};
-                    if (avResult && avResult.length > 0) { meshCoreObj.av = avResult; lsc.antiVirus = 'OK'; }
-                    require('linux-info').firewall(function (fwResult) {
-                        try {
-                            if (fwResult && fwResult.installed) { lsc.firewall = fwResult.enabled ? 'OK' : 'BAD'; }
-                            if (Object.keys(lsc).length > 0) { meshCoreObj.lsc = lsc; meshCoreObjChanged(); }
-                        } catch (ex) { }
-                    });
-                } catch (ex) { }
+        // If we have a connected MEI, get Intel ME information
+        if ((flags & 1) && (amt != null) && (amt.state == 2)) {
+            delete meshCoreObj.intelamt;
+            amt.getMeiState(9, function (meinfo) {
+                meshCoreObj.intelamt = meinfo;
+                meshCoreObj.intelamt.microlms = amt.lmsstate;
+                meshCoreObjChanged();
             });
-        } catch (ex) { }
-    }
+        }
 
-    if (process.platform == 'win32') {
-        if (require('MeshAgent')._securitycenter == null) {
+        // Update network information
+        if (flags & 2) { sendNetworkUpdateNagle(false); }
+
+        // Update anti-virus information
+        if ((flags & 4) && (process.platform == 'win32')) {
+            // Windows Command: "wmic /Namespace:\\root\SecurityCenter2 Path AntiVirusProduct get /FORMAT:CSV"
+            try { meshCoreObj.av = require('win-info').av(); meshCoreObjChanged(); } catch (ex) { av = null; } // Antivirus
+            //if (process.platform == 'win32') { try { meshCoreObj.pr = require('win-info').pendingReboot(); meshCoreObjChanged(); } catch (ex) { meshCoreObj.pr = null; } } // Pending reboot
+        }
+        // Update Linux AV/Firewall information. av()/firewall() are asynchronous (they
+        // spawn child processes), so they don't block this periodic update with a nested
+        // waitExit() loop. Results are applied in the callbacks and flushed via
+        // meshCoreObjChanged().
+        if ((flags & 4) && (process.platform == 'linux')) {
             try {
-                require('MeshAgent')._securitycenter = require('win-securitycenter').status();
-                meshCoreObj['wsc'] = require('MeshAgent')._securitycenter; // Windows Security Central (WSC)
-                require('win-securitycenter').on('changed', function () {
-                    require('MeshAgent')._securitycenter = require('win-securitycenter').status();
-                    meshCoreObj['wsc'] = require('MeshAgent')._securitycenter; // Windows Security Central (WSC)
-                    require('MeshAgent').SendCommand({ action: 'coreinfo', wsc: require('MeshAgent')._securitycenter });
+                require('linux-info').av(function (avResult) {
+                    try {
+                        var lsc = {};
+                        if (avResult && avResult.length > 0) { meshCoreObj.av = avResult; lsc.antiVirus = 'OK'; }
+                        require('linux-info').firewall(function (fwResult) {
+                            try {
+                                if (fwResult && fwResult.installed) { lsc.firewall = fwResult.enabled ? 'OK' : 'BAD'; }
+                                if (Object.keys(lsc).length > 0) { meshCoreObj.lsc = lsc; meshCoreObjChanged(); }
+                            } catch (ex) { }
+                        });
+                    } catch (ex) { }
                 });
             } catch (ex) { }
         }
 
-        // Get Defender Information
-        try {
-            meshCoreObj.defender = require('win-info').defender();
-            meshCoreObjChanged();
-        } catch (ex) { }
+        if (process.platform == 'win32') {
+            if (require('MeshAgent')._securitycenter == null) {
+                try {
+                    require('MeshAgent')._securitycenter = require('win-securitycenter').status();
+                    meshCoreObj['wsc'] = require('MeshAgent')._securitycenter; // Windows Security Central (WSC)
+                    require('win-securitycenter').on('changed', function () {
+                        require('MeshAgent')._securitycenter = require('win-securitycenter').status();
+                        meshCoreObj['wsc'] = require('MeshAgent')._securitycenter; // Windows Security Central (WSC)
+                        require('MeshAgent').SendCommand({ action: 'coreinfo', wsc: require('MeshAgent')._securitycenter });
+                    });
+                } catch (ex) { }
+            }
 
-        // Calculate Windows Idle Time
-        try {
-            require('win-deskutils').idle.getSecondsAllSessions().then(function (seconds) {
-                meshCoreObj.idletime = seconds;
+            // Get Defender Information
+            try {
+                meshCoreObj.defender = require('win-info').defender();
                 meshCoreObjChanged();
-            });
-        } catch (ex) { sendConsoleText('Error getting idle time: ' + ex.toString());}
-    }
+            } catch (ex) { }
 
-    // Send available data right now
-    if (force) {
-        meshCoreObj = sortObjRec(meshCoreObj);
-        var x = JSON.stringify(meshCoreObj);
-        if (x != LastPeriodicServerUpdate) {
-            LastPeriodicServerUpdate = x;
-            mesh.SendCommand(meshCoreObj);
+            // Calculate Windows Idle Time
+            try {
+                require('win-deskutils').idle.getSecondsAllSessions().then(function (seconds) {
+                    meshCoreObj.idletime = seconds;
+                    meshCoreObjChanged();
+                });
+            } catch (ex) { sendConsoleText('Error getting idle time: ' + ex.toString());}
         }
-    }
+
+        // Send available data right now
+        if (force) {
+            meshCoreObj = sortObjRec(meshCoreObj);
+            var x = JSON.stringify(meshCoreObj);
+            if (x != LastPeriodicServerUpdate) {
+                LastPeriodicServerUpdate = x;
+                mesh.SendCommand(meshCoreObj);
+            }
+        }
+    } finally { sendPeriodicServerUpdateInProgress = false; }
 }
 
 // Sort the names in an object

--- a/agents/meshcore.js
+++ b/agents/meshcore.js
@@ -5421,8 +5421,9 @@ function processConsoleCommand(cmd, args, rights, sessionid) {
                 if (process.platform == 'win32') {
                     // Windows Command: "wmic /Namespace:\\root\SecurityCenter2 Path AntiVirusProduct get /FORMAT:CSV"
                     response = JSON.stringify(require('win-info').av(), null, 1);
-                } if (process.platform == 'linux') {
-                    response = JSON.stringify(require('linux-info').av(), null, 1);
+                } else if (process.platform == 'linux') {
+                    require('linux-info').av(function (r) { sendConsoleText(JSON.stringify(r, null, 1), sessionid); });
+                    response = null;
                 } else {
                     response = 'Not supported on the platform';
                 }

--- a/agents/meshcore.js
+++ b/agents/meshcore.js
@@ -7063,15 +7063,24 @@ function sendPeriodicServerUpdate(flags, force) {
         try { meshCoreObj.av = require('win-info').av(); meshCoreObjChanged(); } catch (ex) { av = null; } // Antivirus
         //if (process.platform == 'win32') { try { meshCoreObj.pr = require('win-info').pendingReboot(); meshCoreObjChanged(); } catch (ex) { meshCoreObj.pr = null; } } // Pending reboot
     }
-    // Update Linux AV/Firewall information
+    // Update Linux AV/Firewall information. av()/firewall() are asynchronous (they
+    // spawn child processes), so they don't block this periodic update with a nested
+    // waitExit() loop. Results are applied in the callbacks and flushed via
+    // meshCoreObjChanged().
     if ((flags & 4) && (process.platform == 'linux')) {
         try {
-            var lsc = {};
-            var avResult = require('linux-info').av();
-            if (avResult && avResult.length > 0) { meshCoreObj.av = avResult; lsc.antiVirus = 'OK'; }
-            var fwResult = require('linux-info').firewall();
-            if (fwResult && fwResult.installed) { lsc.firewall = fwResult.enabled ? 'OK' : 'BAD'; }
-            if (Object.keys(lsc).length > 0) { meshCoreObj.lsc = lsc; meshCoreObjChanged(); }
+            require('linux-info').av(function (avResult) {
+                try {
+                    var lsc = {};
+                    if (avResult && avResult.length > 0) { meshCoreObj.av = avResult; lsc.antiVirus = 'OK'; }
+                    require('linux-info').firewall(function (fwResult) {
+                        try {
+                            if (fwResult && fwResult.installed) { lsc.firewall = fwResult.enabled ? 'OK' : 'BAD'; }
+                            if (Object.keys(lsc).length > 0) { meshCoreObj.lsc = lsc; meshCoreObjChanged(); }
+                        } catch (ex) { }
+                    });
+                } catch (ex) { }
+            });
         } catch (ex) { }
     }
 

--- a/agents/modules_meshcore/linux-info.js
+++ b/agents/modules_meshcore/linux-info.js
@@ -3,91 +3,109 @@ var promise = require('promise');
 
 function dataHandler(data) { this.str += data.toString(); }
 
-function av()
-{
-    var result = [];
-    var child, version, dbDate, running;
+// Shell preamble that sets $TO to a 'timeout N' prefix when the 'timeout' utility
+// is present (busybox/coreutils), or empty otherwise. Killing /bin/sh does not
+// stop a reparented grandchild (e.g. a hung clamscan); 'timeout' does.
+function shellTimeout(seconds) { return 'TO=""; command -v timeout >/dev/null 2>&1 && TO="timeout ' + seconds + '"; '; }
 
-    // Check if clamscan binary exists
-    var clamBinaries = ['/usr/bin/clamscan', '/usr/local/bin/clamscan', '/bin/clamscan'];
-    var clamFound = false;
-    var fs = require('fs');
-    for (var i = 0; i < clamBinaries.length; ++i) {
-        try { if (fs.existsSync(clamBinaries[i])) { clamFound = true; break; } } catch (ex) { }
+// Run a short shell script WITHOUT blocking the event loop: cb(trimmedStdout) is
+// called when the child exits or the timeout elapses. This never calls waitExit()
+// (whose nested event loop can re-enter from another timer as 'waitExit() already
+// in progress' when a command hangs). The child is killed on overrun, and
+// shellTimeout()'s 'timeout' prefix stops a hung grandchild.
+function runShellAsync(script, timeout, cb) {
+    var done = false;
+    function finish(child, out) {
+        if (done) { return; }
+        done = true;
+        if (child) {
+            if (child._to) { try { clearTimeout(child._to); } catch (ex) { } }
+            try { child.kill(); } catch (ex) { }
+        }
+        cb((out || '').trim());
     }
-    if (!clamFound) { return ([]); }
-
-    // Get ClamAV version
     try {
-        child = require('child_process').execFile('/bin/sh', ['sh']);
+        var child = require('child_process').execFile('/bin/sh', ['sh']);
         child.stdout.str = ''; child.stdout.on('data', dataHandler);
-        child.stdin.write('clamscan --version 2>/dev/null | head -1\nexit\n');
-        child.waitExit();
-        version = child.stdout.str.trim();
-    } catch (ex) { version = ''; }
-
-    // Get virus database date from freshclam/clamd dat files
-    try {
-        child = require('child_process').execFile('/bin/sh', ['sh']);
-        child.stdout.str = ''; child.stdout.on('data', dataHandler);
-        child.stdin.write('stat -c "%y" /var/lib/clamav/main.cvd /var/lib/clamav/main.cld 2>/dev/null | sort -r | head -1 | cut -d" " -f1\nexit\n');
-        child.waitExit();
-        dbDate = child.stdout.str.trim();
-    } catch (ex) { dbDate = ''; }
-
-    // Check if clamd service is running (systemd, OpenRC, or process scan fallback)
-    try {
-        child = require('child_process').execFile('/bin/sh', ['sh']);
-        child.stdout.str = ''; child.stdout.on('data', dataHandler);
-        child.stdin.write(
-            'if command -v systemctl >/dev/null 2>&1; then ' +
-                'systemctl is-active clamav-daemon 2>/dev/null || systemctl is-active clamd 2>/dev/null || echo inactive; ' +
-            'elif command -v rc-service >/dev/null 2>&1; then ' +
-                'rc-service clamd status 2>/dev/null | grep -q started && echo active || echo inactive; ' +
-            'else ' +
-                'pgrep -x clamd >/dev/null 2>&1 && echo active || echo inactive; ' +
-            'fi\nexit\n'
-        );
-        child.waitExit();
-        running = child.stdout.str.trim() === 'active';
-    } catch (ex) { running = false; }
-
-    var status = {};
-    status.product = version || 'ClamAV';
-    status.enabled = running;
-    status.updated = dbDate !== '';
-    if (dbDate) { status.definitionDate = dbDate; }
-    result.push(status);
-
-    return (result);
+        child.stderr.on('data', function () { });
+        child.on('exit', function () { finish(this, this.stdout.str); });
+        child._to = setTimeout(function () { finish(child, child.stdout.str); }, timeout);
+        child.stdin.write(script + '\nexit\n');
+    } catch (ex) { finish(null, ''); }
 }
 
-function firewall()
+// Asynchronous so it never blocks the caller with a waitExit() nested loop. Calls
+// callback(arrayOrEmpty).
+function av(callback)
 {
-    var child, status, output;
-
-    // Check if ufw binary exists
-    var ufwBinaries = ['/usr/sbin/ufw', '/sbin/ufw', '/usr/bin/ufw'];
-    var ufwFound = false;
     var fs = require('fs');
-    for (var i = 0; i < ufwBinaries.length; ++i) {
-        try { if (fs.existsSync(ufwBinaries[i])) { ufwFound = true; break; } } catch (ex) { }
+
+    // Find the clamscan binary and use its absolute path (don't depend on PATH,
+    // the agent environment may not include the binary's directory).
+    var clamBinaries = ['/usr/bin/clamscan', '/usr/local/bin/clamscan', '/bin/clamscan'];
+    var clamPath = null;
+    for (var i = 0; i < clamBinaries.length; ++i) {
+        try { if (fs.existsSync(clamBinaries[i])) { clamPath = clamBinaries[i]; break; } } catch (ex) { }
     }
-    if (!ufwFound) { return (null); }
+    if (clamPath == null) { callback([]); return; }
 
-    // Get ufw status
+    var status = { product: 'ClamAV', enabled: false, updated: false };
+
+    // Virus database date: newest mtime of the ClamAV signature files. Pure JS, so
+    // it needs no subprocess and can't hang on busybox-vs-coreutils tool differences.
     try {
-        child = require('child_process').execFile('/bin/sh', ['sh']);
-        child.stdout.str = ''; child.stdout.on('data', dataHandler);
-        child.stdin.write('ufw status 2>/dev/null | head -1\nexit\n');
-        child.waitExit();
-        output = child.stdout.str.trim();
-    } catch (ex) { output = ''; }
+        var newest = 0;
+        var dbFiles = ['/var/lib/clamav/main.cvd', '/var/lib/clamav/main.cld'];
+        for (var k = 0; k < dbFiles.length; ++k) {
+            try { var st = fs.statSync(dbFiles[k]); var t = (st && st.mtime) ? st.mtime.getTime() : 0; if (t > newest) { newest = t; } } catch (ex) { }
+        }
+        if (newest > 0) {
+            var d = new Date(newest);
+            status.definitionDate = d.getFullYear() + '-' + ('0' + (d.getMonth() + 1)).slice(-2) + '-' + ('0' + d.getDate()).slice(-2);
+            status.updated = true;
+        }
+    } catch (ex) { }
 
-    return ({
-        product: 'UFW',
-        installed: true,
-        enabled: /^status:\s+active$/i.test(output)
+    // Get the ClamAV version, then whether clamd is running, then return. Both run as
+    // non-blocking children, so a hung command can't stall the agent or nest waitExit().
+    runShellAsync(shellTimeout(4) + '$TO "' + clamPath + '" --version 2>/dev/null', 4000, function (verOut) {
+        var v = verOut.split('\n')[0].trim();
+        if (v) { status.product = v; }
+        // systemd via 'is-active'; otherwise a direct process check (pgrep). The old
+        // 'rc-service clamd status' path could block for seconds on Alpine/OpenRC.
+        runShellAsync(
+            shellTimeout(4) +
+            'if command -v systemctl >/dev/null 2>&1; then ' +
+                'if $TO systemctl is-active --quiet clamav-daemon 2>/dev/null || $TO systemctl is-active --quiet clamd 2>/dev/null; then echo active; else echo inactive; fi; ' +
+            'else ' +
+                'pgrep -x clamd >/dev/null 2>&1 && echo active || echo inactive; ' +
+            'fi', 4000, function (svcOut) {
+                status.enabled = (svcOut.split('\n')[0].trim() === 'active');
+                callback([status]);
+            });
+    });
+}
+
+// Asynchronous so it never blocks the caller with a waitExit() nested loop. Calls
+// callback(objectOrNull).
+function firewall(callback)
+{
+    var fs = require('fs');
+
+    // Find the ufw binary and use its absolute path (don't depend on PATH).
+    var ufwBinaries = ['/usr/sbin/ufw', '/sbin/ufw', '/usr/bin/ufw'];
+    var ufwPath = null;
+    for (var i = 0; i < ufwBinaries.length; ++i) {
+        try { if (fs.existsSync(ufwBinaries[i])) { ufwPath = ufwBinaries[i]; break; } } catch (ex) { }
+    }
+    if (ufwPath == null) { callback(null); return; }
+
+    runShellAsync(shellTimeout(4) + '$TO "' + ufwPath + '" status 2>/dev/null', 4000, function (out) {
+        callback({
+            product: 'UFW',
+            installed: true,
+            enabled: /^status:\s+active$/i.test(out.split('\n')[0])
+        });
     });
 }
 
@@ -95,16 +113,8 @@ function packages() {
     var ret = new promise(function (res, rej) { this._res = res; this._rej = rej; });
     var fs = require('fs');
 
-    function runSh(script) {
-        try {
-            var child = require('child_process').execFile('/bin/sh', ['sh']);
-            child.stdout.str = '';
-            child.stdout.on('data', function (d) { child.stdout.str += d; });
-            child.stdin.write(script + '\nexit\n');
-            child.waitExit();
-            return child.stdout.str.trim();
-        } catch (ex) { return ''; }
-    }
+    // Run a shell script without blocking the event loop, capped at 30s; cb(stdout).
+    function runSh(script, cb) { runShellAsync(shellTimeout(25) + '$TO ' + script, 30000, cb); }
 
     function dirExists(path) {
         try { return fs.existsSync(path); } catch (ex) { return false; }
@@ -118,151 +128,153 @@ function packages() {
     }
 
     // ---------- dpkg (Debian/Ubuntu) ----------
-    function collectDpkg() {
-        if (!binExists(['/usr/bin/dpkg-query', '/bin/dpkg-query'])) return [];
-        if (!dirExists('/var/lib/dpkg/info')) return [];
+    function collectDpkg(cb) {
+        if (!binExists(['/usr/bin/dpkg-query', '/bin/dpkg-query']) || !dirExists('/var/lib/dpkg/info')) { cb([]); return; }
 
-        var out = runSh('dpkg-query -W -f=\'${binary:Package}\\t${Version}\\t${Architecture}\\t${db:Status-Abbrev}\\t${Maintainer}\\n\' 2>/dev/null');
-        if (!out) return [];
+        runSh('dpkg-query -W -f=\'${binary:Package}\\t${Version}\\t${Architecture}\\t${db:Status-Abbrev}\\t${Maintainer}\\n\' 2>/dev/null', function (out) {
+            if (!out) { cb([]); return; }
+            runSh('find /var/lib/dpkg/info -name \'*.list\' -printf \'%f\\t%TY-%Tm-%Td\\n\' 2>/dev/null', function (dateOut) {
+                var dateMap = {};
+                if (dateOut) {
+                    dateOut.split('\n').forEach(function (line) {
+                        var p = line.split('\t');
+                        if (p.length >= 2) { dateMap[p[0].replace(/\.list$/, '')] = p[1]; }
+                    });
+                }
 
-        var dateMap = {};
-        var dateOut = runSh('find /var/lib/dpkg/info -name \'*.list\' -printf \'%f\\t%TY-%Tm-%Td\\n\' 2>/dev/null');
-        if (dateOut) {
-            dateOut.split('\n').forEach(function (line) {
-                var p = line.split('\t');
-                if (p.length >= 2) { dateMap[p[0].replace(/\.list$/, '')] = p[1]; }
+                var results = [];
+                out.split('\n').forEach(function (line) {
+                    var p = line.split('\t');
+                    if (p.length < 4) return;
+                    if (p[3].indexOf('ii') !== 0) return;
+                    results.push({ name: p[0], version: p[1], arch: p[2], publisher: p[4] || '', date: dateMap[p[0]] || '', location: 'dpkg' });
+                });
+                cb(results);
             });
-        }
-
-        var results = [];
-        out.split('\n').forEach(function (line) {
-            var p = line.split('\t');
-            if (p.length < 4) return;
-            if (p[3].indexOf('ii') !== 0) return;
-            results.push({ name: p[0], version: p[1], arch: p[2], publisher: p[4] || '', date: dateMap[p[0]] || '', location: 'dpkg' });
         });
-        return results;
     }
 
     // ---------- rpm (RHEL/Fedora/CentOS/SUSE) ----------
-    function collectRpm() {
-        if (!binExists(['/usr/bin/rpm', '/bin/rpm'])) return [];
-        if (!dirExists('/var/lib/rpm') && !dirExists('/usr/lib/sysimage/rpm')) return [];
+    function collectRpm(cb) {
+        if (!binExists(['/usr/bin/rpm', '/bin/rpm']) || (!dirExists('/var/lib/rpm') && !dirExists('/usr/lib/sysimage/rpm'))) { cb([]); return; }
 
-        var out = runSh('rpm -qa --qf \'%{NAME}\\t%{VERSION}\\t%{RELEASE}\\t%{ARCH}\\t%{VENDOR}\\t%{INSTALLTIME:date}\\n\' 2>/dev/null');
-        if (!out) return [];
-
-        var results = [];
-        out.split('\n').forEach(function (line) {
-            var p = line.split('\t');
-            if (p.length < 5 || !p[0]) return;
-            results.push({ name: p[0], version: p[1] + (p[2] ? '-' + p[2] : ''), arch: p[3], publisher: p[4] || '', date: p[5] || '', location: 'rpm' });
+        runSh('rpm -qa --qf \'%{NAME}\\t%{VERSION}\\t%{RELEASE}\\t%{ARCH}\\t%{VENDOR}\\t%{INSTALLTIME:date}\\n\' 2>/dev/null', function (out) {
+            if (!out) { cb([]); return; }
+            var results = [];
+            out.split('\n').forEach(function (line) {
+                var p = line.split('\t');
+                if (p.length < 5 || !p[0]) return;
+                results.push({ name: p[0], version: p[1] + (p[2] ? '-' + p[2] : ''), arch: p[3], publisher: p[4] || '', date: p[5] || '', location: 'rpm' });
+            });
+            cb(results);
         });
-        return results;
     }
 
     // ---------- pacman (Arch/Manjaro) ----------
-    function collectPacman() {
-        if (!binExists(['/usr/bin/pacman', '/bin/pacman'])) return [];
-        if (!dirExists('/var/lib/pacman/local')) return [];
+    function collectPacman(cb) {
+        if (!binExists(['/usr/bin/pacman', '/bin/pacman']) || !dirExists('/var/lib/pacman/local')) { cb([]); return; }
 
-        var out = runSh('pacman -Qi 2>/dev/null');
-        if (!out) return [];
-
-        var results = [];
-        var current = {};
-        out.split('\n').forEach(function (line) {
-            var m = line.match(/^([A-Za-z ]+?)\s*:\s(.+)$/);
-            if (m) {
-                current[m[1].trim()] = m[2].trim();
-            } else if (!line.trim() && current['Name']) {
+        runSh('pacman -Qi 2>/dev/null', function (out) {
+            if (!out) { cb([]); return; }
+            var results = [];
+            var current = {};
+            out.split('\n').forEach(function (line) {
+                var m = line.match(/^([A-Za-z ]+?)\s*:\s(.+)$/);
+                if (m) {
+                    current[m[1].trim()] = m[2].trim();
+                } else if (!line.trim() && current['Name']) {
+                    results.push({ name: current['Name'], version: current['Version'] || '', arch: current['Architecture'] || '', publisher: current['Packager'] || '', date: current['Install Date'] || '', location: 'pacman' });
+                    current = {};
+                }
+            });
+            if (current['Name']) {
                 results.push({ name: current['Name'], version: current['Version'] || '', arch: current['Architecture'] || '', publisher: current['Packager'] || '', date: current['Install Date'] || '', location: 'pacman' });
-                current = {};
             }
+            cb(results);
         });
-        if (current['Name']) {
-            results.push({ name: current['Name'], version: current['Version'] || '', arch: current['Architecture'] || '', publisher: current['Packager'] || '', date: current['Install Date'] || '', location: 'pacman' });
-        }
-        return results;
     }
 
     // ---------- apk (Alpine) ----------
-    function collectApk() {
-        if (!binExists(['/sbin/apk', '/usr/bin/apk'])) return [];
-        if (!dirExists('/lib/apk/db') && !dirExists('/var/lib/apk/db')) return [];
+    function collectApk(cb) {
+        if (!binExists(['/sbin/apk', '/usr/bin/apk']) || (!dirExists('/lib/apk/db') && !dirExists('/var/lib/apk/db'))) { cb([]); return; }
 
-        var out = runSh('apk info -v 2>/dev/null');
-        if (!out) return [];
-
-        var results = [];
-        out.split('\n').forEach(function (line) {
-            line = line.trim();
-            if (!line) return;
-            var match = line.match(/^(.+)-(\d[^-]*)(-r\d+)?$/);
-            if (match) {
-                results.push({ name: match[1], version: match[2] + (match[3] || ''), arch: '', publisher: '', location: 'apk' });
-            } else {
-                results.push({ name: line, version: '', arch: '', publisher: '', location: 'apk' });
-            }
+        runSh('apk info -v 2>/dev/null', function (out) {
+            if (!out) { cb([]); return; }
+            var results = [];
+            out.split('\n').forEach(function (line) {
+                line = line.trim();
+                if (!line) return;
+                var match = line.match(/^(.+)-(\d[^-]*)(-r\d+)?$/);
+                if (match) {
+                    results.push({ name: match[1], version: match[2] + (match[3] || ''), arch: '', publisher: '', location: 'apk' });
+                } else {
+                    results.push({ name: line, version: '', arch: '', publisher: '', location: 'apk' });
+                }
+            });
+            cb(results);
         });
-        return results;
     }
 
     // ---------- flatpak ----------
-    function collectFlatpak() {
-        if (!binExists(['/usr/bin/flatpak', '/bin/flatpak'])) return [];
-        if (!dirExists('/var/lib/flatpak')) return [];
+    function collectFlatpak(cb) {
+        if (!binExists(['/usr/bin/flatpak', '/bin/flatpak']) || !dirExists('/var/lib/flatpak')) { cb([]); return; }
 
         var results = [];
 
-        var sys = runSh('flatpak list --system --columns=application,version,origin 2>/dev/null');
-        sys.split('\n').forEach(function (line) {
-            var p = line.split('\t');
-            if (!p[0] || !p[0].trim()) return;
-            results.push({ name: p[0].trim(), version: (p[1] || '').trim(), arch: '', publisher: (p[2] || '').trim(), location: 'flatpak', scope: 'system' });
-        });
+        runSh('flatpak list --system --columns=application,version,origin 2>/dev/null', function (sys) {
+            sys.split('\n').forEach(function (line) {
+                var p = line.split('\t');
+                if (!p[0] || !p[0].trim()) return;
+                results.push({ name: p[0].trim(), version: (p[1] || '').trim(), arch: '', publisher: (p[2] || '').trim(), location: 'flatpak', scope: 'system' });
+            });
 
-        var usr = runSh('flatpak list --user --columns=application,version,origin 2>/dev/null');
-        usr.split('\n').forEach(function (line) {
-            var p = line.split('\t');
-            if (!p[0] || !p[0].trim()) return;
-            results.push({ name: p[0].trim(), version: (p[1] || '').trim(), arch: '', publisher: (p[2] || '').trim(), location: 'flatpak', scope: 'user' });
-        });
+            runSh('flatpak list --user --columns=application,version,origin 2>/dev/null', function (usr) {
+                usr.split('\n').forEach(function (line) {
+                    var p = line.split('\t');
+                    if (!p[0] || !p[0].trim()) return;
+                    results.push({ name: p[0].trim(), version: (p[1] || '').trim(), arch: '', publisher: (p[2] || '').trim(), location: 'flatpak', scope: 'user' });
+                });
 
-        return results;
+                cb(results);
+            });
+        });
     }
 
     // ---------- snap ----------
-    function collectSnap() {
-        if (!binExists(['/usr/bin/snap', '/bin/snap'])) return [];
-        if (!dirExists('/var/lib/snapd/snaps')) return [];
+    function collectSnap(cb) {
+        if (!binExists(['/usr/bin/snap', '/bin/snap']) || !dirExists('/var/lib/snapd/snaps')) { cb([]); return; }
 
-        var out = runSh('snap list --all 2>/dev/null');
-        if (!out) return [];
-
-        var results = [];
-        out.split('\n').forEach(function (line) {
-            if (!line || line.indexOf('Name') === 0) return;
-            var p = line.trim().split(/\s+/);
-            if (p.length < 5 || !p[0]) return;
-            results.push({ name: p[0], version: p[1], arch: '', publisher: p[4] || '', location: 'snap' });
+        runSh('snap list --all 2>/dev/null', function (out) {
+            if (!out) { cb([]); return; }
+            var results = [];
+            out.split('\n').forEach(function (line) {
+                if (!line || line.indexOf('Name') === 0) return;
+                var p = line.trim().split(/\s+/);
+                if (p.length < 5 || !p[0]) return;
+                results.push({ name: p[0], version: p[1], arch: '', publisher: p[4] || '', location: 'snap' });
+            });
+            cb(results);
         });
-        return results;
     }
 
-    try {
-        var all = [].concat(
-            collectDpkg(),
-            collectRpm(),
-            collectPacman(),
-            collectApk(),
-            collectFlatpak(),
-            collectSnap()
-        );
-        ret._res(all);
-    } catch (e) {
-        ret._rej(e);
+    // Run every collector concurrently (non-blocking), keep results in source order,
+    // and resolve once all have reported. Each collector calls its callback exactly
+    // once; the bucket guard makes a stray double-callback harmless.
+    var collectors = [collectDpkg, collectRpm, collectPacman, collectApk, collectFlatpak, collectSnap];
+    var buckets = new Array(collectors.length);
+    var pending = collectors.length;
+    function onCollected(i, r) {
+        if (buckets[i] !== undefined) { return; }
+        buckets[i] = (r && r.length) ? r : [];
+        if (--pending === 0) {
+            try { ret._res([].concat.apply([], buckets)); } catch (e) { ret._rej(e); }
+        }
     }
+    collectors.forEach(function (collector, i) {
+        try { collector(function (r) { onCollected(i, r); }); }
+        catch (e) { onCollected(i, []); }
+    });
+
     return (ret);
 }
 


### PR DESCRIPTION
Discovered this bug after the meshagent on one of my alpine servers hung. A trace showed it stopped in linux-info.js, at the clamav check. This server happened to have a disabled clamav package installed. The clamav processcheck hung and caused a 'timers.onElapsed() callback handler on '()' => waitExit() already in progress' exception in the console, with an unresponsive/hung agent as a result.

The child_process.execFile/waitExit() structure should be avoided if possible, as explained by Claude below. Originally I just added a timeout in the waitExit(4000), but the claude check brought up the bigger issue.
waitExit() is used quite a few times throughout the meshcore modules, so I think there is a todo to at least add the timeout and review and, where possible, remove them by making it async.

All functions in the linux-info.js, including the software inventory are async now with timeouts and there is a guard added in the 'sendPeriodicServerUpdate' function in meshcore.js to prevent overlapping runs, just to be safe.

**A bit of Claude:**
## The setup: one thread, one event loop

MeshAgent's JS runtime (duktape embedded in the native ILib "chain"/microstack) is **single-threaded with a single event loop**. That loop does roughly:

```
forever:
   poll all file descriptors (sockets, child stdout/stderr pipes, timers)
   for each thing that's ready: call its JS callback
```

Child-process I/O and exit notifications are delivered *through this loop* — the child's stdout arrives because the loop polled the pipe fd, and "the child exited" is detected the same way.

## The problem `waitExit()` solves

`child.waitExit()` offers **synchronous semantics**: the next line of JS doesn't run until the child is done, and `child.stdout.str` is fully populated.

```js
child.stdin.write('...\nexit\n');
child.waitExit();                 // <-- does not return until child exits
var out = child.stdout.str;       // <-- guaranteed complete here
```

But here's the catch: it **can't** implement that by just parking the thread (a plain `sleep`/wait). If the thread stops, the event loop stops, the child's pipe never gets read, the exit never gets noticed → permanent deadlock. The very mechanism that would tell you "the child exited" is the loop you just froze.

## The trick: a *nested* event loop

So `waitExit()` doesn't freeze the loop — it **runs another copy of the loop, in place**, on top of the current call stack:

```
waitExit():
   forever:
      poll fds            <-- same polling the top-level loop does
      dispatch ready callbacks   <-- timers fire, pipe data is read, etc.
      if (child has exited) return
      if (timeout elapsed) kill + return
```

This is the "nested / recursive event loop" technique (same idea as a browser's synchronous `alert()`, or `deasync` in Node). The actual implementation is in the native agent binary, not the JS you can see.

## In what sense it "blocks"

Two senses, and they're different:

1. **It blocks the calling code's stack.** Control is parked inside the `waitExit()` frame — which is itself buried under whatever triggered the current dispatch (a timer callback, a server command, etc.). The **top-level loop iteration cannot unwind and advance** until `waitExit()` returns. Anything waiting for the stack to return to the top is stalled.

2. **It does *not* block dispatch.** The nested loop is still pumping — so timers still fire, other pipes still get serviced, callbacks still run. The loop is "blocked" at the top level but "alive" inside the nest.

That second property is the dangerous one.

## Why that produced your bug

```
top-level loop
  └─ fires timer A  →  callback collects AV info
        └─ child.waitExit()        ← nested loop starts, pumping
              └─ (8s pass; command hung)
              └─ timer B's deadline passes → nested loop dispatches it
                    └─ timer B's callback calls child.waitExit()  ← SECOND one
                          └─ guard trips: "waitExit() already in progress"  ✗
```

A timer fired *inside* the nested pump, and its callback tried to start a **second** nested `waitExit()`. MeshAgent refuses to stack them (unbounded nesting would corrupt the chain's re-entrant state / risk the C stack), so it throws — and that exception surfaces as `timers.onElapsed() callback handler on '()' => waitExit() already in progress`.

And the *other* failure mode you saw — "the agent doesn't continue" — is the degenerate case: if the child **never exits and there's no timeout**, the nested loop spins forever. The stack never unwinds, so the top-level loop never resumes. The agent is wedged inside `waitExit()`.

## Why making it async fixes it completely

The async version (`runShellAsync`) never opens a nested loop:

```js
child.on('exit', function () { cb(...); });   // delivered by the TOP-level loop
child._to = setTimeout(...);                    // also a normal top-level event
// function returns immediately — stack unwinds
```

The `exit` and timeout are just ordinary events handled by the **one** top-level loop. The call stack unwinds right away, so there's never a second loop to nest into, and a hung command merely delays a callback instead of parking the whole stack. That's why it's immune regardless of which command hangs or which timer races.