### PR TITLE
backup.js: zipExtract, reduce memory usage by using Uint8ArrayReader …

### DIFF
--- a/backup.js
+++ b/backup.js
@@ -44,14 +44,14 @@ module.exports.zipDirectory = async function (dirPath, outputZip, password = '',
 // removePath: optional path to remove from destination path
 module.exports.zipExtract = async function (zipPath, destPath, removePath = '', password = "") {
     try {
-        const { ZipReader, BlobReader } = require("@zip.js/zip.js");
+        const { ZipReader, Uint8ArrayReader } = require("@zip.js/zip.js");
         const { createWriteStream } = require("fs");
         const { readFile, mkdir } = require("fs/promises");
         const path = require("path");
         const { Readable } = require("stream");
         const { pipeline } = require("stream/promises");
 
-        const zipReader = new ZipReader(new BlobReader(new Blob([(await readFile(zipPath))])));
+        const zipReader = new ZipReader(new Uint8ArrayReader(await readFile(zipPath)));
         const entries = await zipReader.getEntries();
         const resolveDestPath = path.resolve(destPath);
 


### PR DESCRIPTION
…instead of BlobReader

Uint8ArrayReader reads directly, BlobReader makes a copy
