### PR TITLE
fix(i18n): improve Simplified Chinese (zh-chs) translations

### DIFF
--- a/translate/translate.json
+++ b/translate/translate.json
@@ -55,7 +55,7 @@
       "sv": " - Återställ om 1 dag.",
       "tr": " - 1 gün içinde sıfırlayın.",
       "uk": " - Скинути за 1 день.",
-      "zh-chs": " - 1天后重设。",
+      "zh-chs": " - 1天后重置。",
       "zh-cht": " - 1天后重設。",
       "xloc": [
         "default-mobile.handlebars->55->66",
@@ -86,7 +86,7 @@
       "sv": " - Återställ om 1 timme.",
       "tr": " - 1 saat içinde sıfırlayın.",
       "uk": " - Скинути за 1 годину.",
-      "zh-chs": " - 1小时后重设。",
+      "zh-chs": " - 1小时后重置。",
       "zh-cht": " - 1小時後重設。",
       "xloc": [
         "default-mobile.handlebars->55->64",
@@ -117,7 +117,7 @@
       "sv": " - Återställ om 1 minut.",
       "tr": " - 1 dakika içinde sıfırlayın.",
       "uk": " - Скинути за 1 хвилину.",
-      "zh-chs": " - 1分钟后重设。",
+      "zh-chs": " - 1分钟后重置。",
       "zh-cht": " - 1分鐘後重設。",
       "xloc": [
         "default-mobile.handlebars->55->62",
@@ -445,7 +445,8 @@
       "uk": "\" попросив про допомогу.",
       "xloc": [
         "device-help.html->2->3"
-      ]
+      ],
+      "zh-chs": "\" 请求了帮助。"
     },
     {
       "cs": "'",
@@ -1456,7 +1457,8 @@
         "default-mobile.handlebars->55->370",
         "default.handlebars->121->2628",
         "default3.handlebars->123->2632"
-      ]
+      ],
+      "zh-chs": "0 bps"
     },
     {
       "bs": "00:00:00",
@@ -1795,7 +1797,8 @@
       "xloc": [
         "default.handlebars->121->95",
         "default3.handlebars->123->93"
-      ]
+      ],
+      "zh-chs": "1 分钟后登出"
     },
     {
       "bs": "1 mjesec",
@@ -1975,7 +1978,8 @@
       "xloc": [
         "default.handlebars->121->91",
         "default3.handlebars->123->89"
-      ]
+      ],
+      "zh-chs": "1 秒后登出"
     },
     {
       "bs": "1 odabrani uređaj je van mreže.",
@@ -2060,7 +2064,7 @@
       "sv": "1 session",
       "tr": "1 oturum",
       "uk": "1 сесія",
-      "zh-chs": "1节",
+      "zh-chs": "1个会话",
       "zh-cht": "1節",
       "xloc": [
         "default-mobile.handlebars->55->410",
@@ -3177,7 +3181,7 @@
       "sv": "2:a faktorn",
       "tr": "2. Faktör",
       "uk": "Двофакторний",
-      "zh-chs": "第二个因素",
+      "zh-chs": "第二因素",
       "zh-cht": "第二個因素",
       "xloc": [
         "default.handlebars->121->3338",
@@ -4211,7 +4215,7 @@
       "sv": "8 timmar",
       "tr": "8 saat",
       "uk": "8 годин",
-      "zh-chs": "8小時",
+      "zh-chs": "8小时",
       "zh-cht": "8小時",
       "xloc": [
         "default.handlebars->121->1246",
@@ -4471,7 +4475,8 @@
       "xloc": [
         "default.handlebars->121->422",
         "default3.handlebars->123->414"
-      ]
+      ],
+      "zh-chs": "AMT 主机"
     },
     {
       "ca": "Estat AMT",
@@ -4482,7 +4487,8 @@
       "xloc": [
         "default.handlebars->121->423",
         "default3.handlebars->123->415"
-      ]
+      ],
+      "zh-chs": "AMT 状态"
     },
     {
       "bs": "AMT-OS",
@@ -4933,7 +4939,7 @@
       "sv": "Åtkomst till serverfiler",
       "tr": "Sunucu dosyalarına erişin",
       "uk": "Доступ до файлів серверу",
-      "zh-chs": "访问服务器档案",
+      "zh-chs": "访问服务器文件",
       "zh-cht": "存取伺服器檔案",
       "xloc": [
         "default.handlebars->121->3064",
@@ -5184,7 +5190,8 @@
       "xloc": [
         "default.handlebars->121->2813",
         "default3.handlebars->123->2817"
-      ]
+      ],
+      "zh-chs": "帐户已更改为与 LDAP 数据同步。"
     },
     {
       "bs": "Račun je promijenjen: {0}",
@@ -5655,7 +5662,7 @@
       "sv": "Åtgärd",
       "tr": "İşlem",
       "uk": "Дія",
-      "zh-chs": "指令",
+      "zh-chs": "操作",
       "zh-cht": "指令",
       "xloc": [
         "default-mobile.handlebars->55->989",
@@ -5688,7 +5695,7 @@
       "sv": "Åtgärdsfil",
       "tr": "İşlem Dosyası",
       "uk": "Файл Операцій",
-      "zh-chs": "动作档案",
+      "zh-chs": "动作文件",
       "zh-cht": "動作檔案",
       "xloc": [
         "default.handlebars->121->1371",
@@ -5720,7 +5727,7 @@
       "sv": "Åtgärder",
       "tr": "İşlemler",
       "uk": "Дії",
-      "zh-chs": "动作",
+      "zh-chs": "操作",
       "zh-cht": "動作",
       "xloc": [
         "default-mobile.handlebars->55->538",
@@ -5953,7 +5960,7 @@
       "sv": "Aktiv enhetsdelning",
       "tr": "Aktif Cihaz Paylaşımı",
       "uk": "Спільний доступ до пристрою активний",
-      "zh-chs": "主动设备共享",
+      "zh-chs": "活动设备共享",
       "zh-cht": "主動設備共享",
       "xloc": [
         "default.handlebars->121->1109",
@@ -6178,7 +6185,7 @@
       "sv": "Lägg till enhetshändelse",
       "tr": "Cihaz Etkinliği Ekle",
       "uk": "Додати Подію Пристрою",
-      "zh-chs": "添加设备日志",
+      "zh-chs": "添加设备事件",
       "zh-cht": "新增裝置日誌",
       "xloc": [
         "default.handlebars->121->1195",
@@ -7920,7 +7927,8 @@
         "default3.handlebars->container->column_l->p16->3->1->0->1->1->p16filterevents->3",
         "default3.handlebars->container->column_l->p3->3->1->0->1->1->p3filterevents->3",
         "default3.handlebars->container->column_l->p31->3->1->0->3->1->p31filterevents->3"
-      ]
+      ],
+      "zh-chs": "代理日志"
     },
     {
       "bs": "Agent Messages",
@@ -8441,7 +8449,7 @@
       "sv": "Agent körs på fjärrenhet med minskade förmåner.",
       "tr": "Agent, kısıtlı yetkili cihazda çalışıyor.",
       "uk": "Агент працює на віддаленому пристрої без прав адміністратора.",
-      "zh-chs": "代理在特权降低的远程设备上运行。",
+      "zh-chs": "代理正在远程设备上以降低的权限运行。",
       "zh-cht": "代理在特權降低的遠程設備上運行。",
       "xloc": [
         "default.handlebars->121->1082",
@@ -8525,7 +8533,8 @@
         "default.handlebars->121->807",
         "default3.handlebars->123->1221",
         "default3.handlebars->123->799"
-      ]
+      ],
+      "zh-chs": "警告框"
     },
     {
       "bs": "Sve",
@@ -8733,7 +8742,8 @@
         "default3.handlebars->container->column_l->p16->3->1->0->1->1->p16filterevents->1",
         "default3.handlebars->container->column_l->p3->3->1->0->1->1->p3filterevents->1",
         "default3.handlebars->container->column_l->p31->3->1->0->3->1->p31filterevents->1"
-      ]
+      ],
+      "zh-chs": "所有日志"
     },
     {
       "bs": "Sve teme",
@@ -9298,7 +9308,8 @@
       "xloc": [
         "default.handlebars->121->3258",
         "default3.handlebars->123->3256"
-      ]
+      ],
+      "zh-chs": "发生未知错误。"
     },
     {
       "bs": "Android",
@@ -9623,7 +9634,7 @@
       "sv": "Apple Silicon",
       "tr": "Apple Silicon",
       "uk": "Процесори Apple Silicon",
-      "zh-chs": "苹果硅",
+      "zh-chs": "Apple Silicon",
       "zh-cht": "蘋果矽",
       "xloc": [
         "default-mobile.handlebars->55->35",
@@ -10717,7 +10728,7 @@
       "sv": "Fråga Admin Shell",
       "tr": "Yönetici Kabuğuna Sor",
       "uk": "Запит на консоль від імені адміністратора",
-      "zh-chs": "询问管理员外壳",
+      "zh-chs": "询问管理员终端",
       "zh-cht": "詢問管理員外殼",
       "xloc": [
         "default.handlebars->termShellContextMenu->9",
@@ -10839,7 +10850,7 @@
       "sv": "Fråga User Shell",
       "tr": "Kullanıcı Kabuğuna Sor",
       "uk": "Запит на консоль користувача",
-      "zh-chs": "询问用户外壳",
+      "zh-chs": "询问用户终端",
       "zh-cht": "詢問用戶外殼",
       "xloc": [
         "default.handlebars->termShellContextMenu->13",
@@ -12278,7 +12289,8 @@
         "default3.handlebars->container->column_l->p16->3->1->0->1->1->p16filterevents->11",
         "default3.handlebars->container->column_l->p3->3->1->0->1->1->p3filterevents->11",
         "default3.handlebars->container->column_l->p31->3->1->0->3->1->p31filterevents->11"
-      ]
+      ],
+      "zh-chs": "批量上传日志"
     },
     {
       "bs": "Skupno kreiranje naloga",
@@ -12532,7 +12544,8 @@
         "default-mobile.handlebars->55->949",
         "default.handlebars->121->1807",
         "default3.handlebars->123->1795"
-      ]
+      ],
+      "zh-chs": "BitLocker"
     },
     {
       "ca": "Informació de BitLocker",
@@ -12544,7 +12557,8 @@
         "default-mobile.handlebars->55->970",
         "default.handlebars->121->1828",
         "default3.handlebars->123->1816"
-      ]
+      ],
+      "zh-chs": "BitLocker 信息"
     },
     {
       "bs": "Bootloader",
@@ -13098,7 +13112,8 @@
         "login-mobile.handlebars->container->page_content->column_l->1->1->0->1->createpanel->1->1->9->1",
         "login.handlebars->container->column_l->centralTable->1->0->logincell->createpanel->1->9->1",
         "login2.handlebars->centralTable->1->0->logincell->createpanel->createpanelform->9->1"
-      ]
+      ],
+      "zh-chs": "验证码图片"
     },
     {
       "bs": "CCM",
@@ -14664,7 +14679,7 @@
       "ru": "Ставка заряда",
       "sv": "Debiteringshastighet",
       "tr": "Şarj Oranı",
-      "zh-chs": "收费率",
+      "zh-chs": "充电速率",
       "zh-cht": "收費率",
       "xloc": [
         "default-mobile.handlebars->55->896",
@@ -15354,7 +15369,8 @@
       "xloc": [
         "default.handlebars->121->75",
         "default3.handlebars->123->73"
-      ]
+      ],
+      "zh-chs": "经典"
     },
     {
       "bs": "Jasno",
@@ -16759,7 +16775,7 @@
       "sv": "Komprimerar filer ...",
       "tr": "Dosyalar sıkıştırılıyor ...",
       "uk": "Стиснення файлів...",
-      "zh-chs": "压缩档案...",
+      "zh-chs": "压缩文件...",
       "zh-cht": "壓縮檔案...",
       "xloc": [
         "default.handlebars->121->1559",
@@ -16834,7 +16850,8 @@
       "nl": "Bevestig wachtwoord",
       "xloc": [
         "default3.handlebars->123->2949"
-      ]
+      ],
+      "zh-chs": "确认密码"
     },
     {
       "bs": "Potvrditi kopiju 1 unosa na ovu lokaciju?",
@@ -18735,7 +18752,8 @@
       "xloc": [
         "default.handlebars->121->235",
         "default3.handlebars->123->232"
-      ]
+      ],
+      "zh-chs": "复制密钥到剪贴板"
     },
     {
       "bs": "Kopirajte URL u međuspremnik",
@@ -18784,7 +18802,8 @@
         "default.handlebars->121->707",
         "default3.handlebars->123->652",
         "default3.handlebars->123->699"
-      ]
+      ],
+      "zh-chs": "复制 Windows ARM 64位代理 URL 到剪贴板"
     },
     {
       "ca": "Copieu l'URL de l'agent de Windows x86 de 32 bits al porta-retalls",
@@ -18799,7 +18818,8 @@
         "default.handlebars->121->699",
         "default3.handlebars->123->644",
         "default3.handlebars->123->691"
-      ]
+      ],
+      "zh-chs": "复制 Windows x86 32位代理 URL 到剪贴板"
     },
     {
       "ca": "Copieu l'URL de l'agent de Windows x86 de 64 bits al porta-retalls",
@@ -18814,7 +18834,8 @@
         "default.handlebars->121->703",
         "default3.handlebars->123->648",
         "default3.handlebars->123->695"
-      ]
+      ],
+      "zh-chs": "复制 Windows x86 64位代理 URL 到剪贴板"
     },
     {
       "bs": "Kopiraj adresu u međuspremnik",
@@ -18925,7 +18946,7 @@
       "sv": "Kopiera länk till urklipp",
       "tr": "Bağlantıyı panoya kopyala",
       "uk": "Копіювати посилання до буфера обміну",
-      "zh-chs": "复制连结到剪贴板",
+      "zh-chs": "复制链接到剪贴板",
       "zh-cht": "複製連結到剪貼板",
       "xloc": [
         "default.handlebars->121->2612",
@@ -19125,7 +19146,7 @@
       "sv": "Copyright (C) 2011 Joel Martin Detta källkodsformulär är föremål för villkoren i Mozilla Public License, v. 2.0. Om en kopia av MPL inte distribuerades med den här filen kan du få en på http://mozilla.org/MPL/2.0/.",
       "tr": "Telif Hakkı (C) 2011 Joel Martin Bu Kaynak Kodu Formu, Mozilla Public License, v. 2.0 hükümlerine tabidir. MPL'nin bir kopyası bu dosyayla birlikte dağıtılmadıysa, http://mozilla.org/MPL/2.0/ adresinden bir tane edinebilirsiniz.",
       "uk": "Copyright (C) 2011 Joel Martin Ця форма вихідного коду підпадає під дію умов Mozilla Public License, v. 2.0. Якщо копія MPL не була розповсюджена разом із цим файлом, ви можете отримати її за адресою http://mozilla.org/MPL/2.0/ .",
-      "zh-chs": "版权所有（C）2011 Joel Martin此源代码表受Mozilla公共许可证v。2.0条款的约束。如果未随该档案分发MPL的副本，则可以在http://mozilla.org/MPL/2.0/上获得一份。",
+      "zh-chs": "版权所有（C）2011 Joel Martin此源代码表受Mozilla公共许可证v。2.0条款的约束。如果未随该文件分发MPL的副本，则可以在http://mozilla.org/MPL/2.0/上获得一份。",
       "zh-cht": "版權所有（C）2011 Joel Martin此源代碼表受Mozilla Public License v。2.0條款的約束。如果未隨該檔案分發MPL的副本，則可以在http://mozilla.org/MPL/2.0/上獲得一份。",
       "xloc": [
         "terms-mobile.handlebars->container->page_content->column_l->63->1",
@@ -19497,7 +19518,7 @@
       "sv": "Skapa en länk för att dela den här enheten med en gäst",
       "tr": "Bu cihazı bir misafirle paylaşmak için bir bağlantı oluşturun",
       "uk": "Створіть посилання, щоб поділитися цим пристроєм з гостем",
-      "zh-chs": "创建连结以与访客共享此设备",
+      "zh-chs": "创建链接以与访客共享此设备",
       "zh-cht": "創建鏈結以與訪客共享此裝置",
       "xloc": [
         "default.handlebars->121->1046",
@@ -20545,7 +20566,8 @@
         "default-mobile.handlebars->55->831",
         "default.handlebars->121->1689",
         "default3.handlebars->123->1679"
-      ]
+      ],
+      "zh-chs": "DNS 服务器"
     },
     {
       "bs": "DNS sufiks",
@@ -20675,7 +20697,8 @@
       "nl": "Donker",
       "xloc": [
         "default3.handlebars->123->2195"
-      ]
+      ],
+      "zh-chs": "Darkly"
     },
     {
       "bs": "DataChannel",
@@ -20722,7 +20745,8 @@
       "xloc": [
         "default.handlebars->121->3303",
         "default3.handlebars->123->3301"
-      ]
+      ],
+      "zh-chs": "数据库记录"
     },
     {
       "bs": "Datumi i vrijeme",
@@ -21713,7 +21737,8 @@
       "xloc": [
         "default.handlebars->121->2814",
         "default3.handlebars->123->2818"
-      ]
+      ],
+      "zh-chs": "拒绝来自 {0}、{1}、{2} 的用户登录"
     },
     {
       "bs": "Deny",
@@ -23204,7 +23229,8 @@
       "xloc": [
         "default.handlebars->121->2818",
         "default3.handlebars->123->2822"
-      ]
+      ],
+      "zh-chs": "设备已开机"
     },
     {
       "bs": "Device Push",
@@ -23250,7 +23276,8 @@
       "xloc": [
         "default.handlebars->121->3392",
         "default3.handlebars->123->3390"
-      ]
+      ],
+      "zh-chs": "设备推送通知记录"
     },
     {
       "bs": "SMBIOS zapis uređaja",
@@ -23266,7 +23293,8 @@
       "xloc": [
         "default.handlebars->121->3391",
         "default3.handlebars->123->3389"
-      ]
+      ],
+      "zh-chs": "设备 SMBIOS 记录"
     },
     {
       "bs": "Veza za dijeljenje uređaja",
@@ -23645,7 +23673,8 @@
       "xloc": [
         "default.handlebars->121->3377",
         "default3.handlebars->123->3375"
-      ]
+      ],
+      "zh-chs": "设备组记录"
     },
     {
       "bs": "Poništeno brisanje grupe uređaja: {0}",
@@ -23751,7 +23780,8 @@
       "xloc": [
         "default.handlebars->121->3379",
         "default3.handlebars->123->3377"
-      ]
+      ],
+      "zh-chs": "设备信息记录"
     },
     {
       "bs": "Uređaj se napaja baterijama",
@@ -24412,7 +24442,8 @@
       "xloc": [
         "default.handlebars->121->3385",
         "default3.handlebars->123->3383"
-      ]
+      ],
+      "zh-chs": "设备电源状态转换记录"
     },
     {
       "bs": "Zapis uređaja",
@@ -24428,7 +24459,8 @@
       "xloc": [
         "default.handlebars->121->3376",
         "default3.handlebars->123->3374"
-      ]
+      ],
+      "zh-chs": "设备记录"
     },
     {
       "bs": "Uređaj je zatražio Intel(R) AMT ACM TLS aktivaciju, FQDN: {0}",
@@ -24504,7 +24536,8 @@
       "xloc": [
         "default.handlebars->121->3389",
         "default3.handlebars->123->3387"
-      ]
+      ],
+      "zh-chs": "设备共享记录"
     },
     {
       "bs": "Uređaj, korisnici, grupe i drugi zapisi",
@@ -24520,7 +24553,8 @@
       "xloc": [
         "default.handlebars->121->3393",
         "default3.handlebars->123->3391"
-      ]
+      ],
+      "zh-chs": "设备、用户、组和其他记录"
     },
     {
       "bs": "Uređaji",
@@ -24839,7 +24873,8 @@
       "xloc": [
         "default.handlebars->121->2820",
         "default3.handlebars->123->2824"
-      ]
+      ],
+      "zh-chs": "已禁用 Duo 双因素认证"
     },
     {
       "bs": "Onemogućena dvofaktorska autentikacija e-pošte",
@@ -24891,7 +24926,7 @@
       "ru": "Скорость разряда",
       "sv": "Urladdningshastighet",
       "tr": "Deşarj Hızı",
-      "zh-chs": "出院率",
+      "zh-chs": "放电率",
       "zh-cht": "出院率",
       "xloc": [
         "default-mobile.handlebars->55->901",
@@ -24919,7 +24954,7 @@
       "ru": "Разгрузка",
       "sv": "Urladdning",
       "tr": "Boşaltma",
-      "zh-chs": "出院",
+      "zh-chs": "放电中",
       "zh-cht": "出院",
       "xloc": [
         "default-mobile.handlebars->55->903",
@@ -25424,7 +25459,7 @@
       "sv": "Visa allmän länk",
       "tr": "Herkese açık bağlantıyı görüntüle",
       "uk": "Показати публічне посилання",
-      "zh-chs": "显示公共连结",
+      "zh-chs": "显示公共链接",
       "zh-cht": "顯示公共鏈結",
       "xloc": [
         "default.handlebars->121->2611",
@@ -26071,7 +26106,7 @@
       "sv": "Ladda ner \\\"meshcmd \\\" med en åtgärdsfil för att dirigera trafik genom denna server till den här enheten. Se till att du redigerar meshaction.txt och lägger till ditt kontolösenord eller gör eventuella ändringar.",
       "tr": "Bu sunucu üzerinden trafiği bu cihaza yönlendirmek için bir eylem dosyasıyla \\\"meshcmd\\\" dosyasını indirin. Meshaction.txt dosyasını düzenlediğinizden ve hesap şifrenizi eklediğinizden veya gerekli değişiklikleri yaptığınızdan emin olun.",
       "uk": "Завантажте \\\"meshcmd\\\" із файлом операцій, щоб спрямувати трафік через сервер на цей пристрій. Обов’язково відредагуйте meshaction.txt і додайте пароль від свого акаунту, та внесіть інші зміни за потребою.",
-      "zh-chs": "下载带有指令档案的“ meshcmd”，以通过此服务器将网络讯息发送到该设备。紧记编辑meshaction.txt并添加您的帐户密码或进行任何必要的更改。",
+      "zh-chs": "下载带有指令文件的“ meshcmd”，以通过此服务器将网络讯息发送到该设备。紧记编辑meshaction.txt并添加您的帐户密码或进行任何必要的更改。",
       "zh-cht": "下載帶有指令檔案的“ meshcmd”，以通過此服務器將網絡讯息發送到該裝置。緊記編輯meshaction.txt並新增你的帳戶密碼或進行任何必要的更改。",
       "xloc": [
         "default.handlebars->121->1368",
@@ -26373,7 +26408,7 @@
       "sv": "Ladda ner listan över enheter med ett av filformaten nedan.",
       "tr": "Aşağıdaki dosya biçimlerinden birine sahip cihazların listesini indirin.",
       "uk": "Завантажте файл переліку пристроїв в одному із наведених нижче форматів.",
-      "zh-chs": "使用以下一种档案格式下载设备列表。",
+      "zh-chs": "使用以下一种文件格式下载设备列表。",
       "zh-cht": "使用以下一種檔案格式下載裝置列表。",
       "xloc": [
         "default.handlebars->121->828",
@@ -26403,7 +26438,7 @@
       "sv": "Ladda ner listan över händelser med ett av filformaten nedan.",
       "tr": "Aşağıdaki dosya biçimlerinden birine sahip olayların listesini indirin.",
       "uk": "Завантажте файл переліку подій в одному з наведених нижче форматів.",
-      "zh-chs": "使用以下一种档案格式下载事件列表。",
+      "zh-chs": "使用以下一种文件格式下载事件列表。",
       "zh-cht": "使用以下一種檔案格式下載事件列表。",
       "xloc": [
         "default.handlebars->121->2848",
@@ -26433,7 +26468,7 @@
       "sv": "Ladda ner listan över användare med ett av filformaten nedan.",
       "tr": "Aşağıdaki dosya biçimlerinden birine sahip kullanıcıların listesini indirin.",
       "uk": "Завантажити файл із переліком користувачів в одному з наведених нижче форматів.",
-      "zh-chs": "使用以下一种档案格式下载用户列表。",
+      "zh-chs": "使用以下一种文件格式下载用户列表。",
       "zh-cht": "使用以下一種檔案格式下載用戶列表。",
       "xloc": [
         "default.handlebars->121->2925",
@@ -26494,7 +26529,7 @@
       "sv": "Ladda ner spårning (.csv)",
       "tr": "İndir (.csv)",
       "uk": "Завантажити трасування (.csv)",
-      "zh-chs": "下载跟踪（.csv）",
+      "zh-chs": "下载追踪（.csv）",
       "zh-cht": "下載追蹤（.csv）",
       "xloc": [
         "default.handlebars->container->column_l->p41->3->1",
@@ -26629,7 +26664,8 @@
         "default3.handlebars->123->3130",
         "login.handlebars->container->column_l->centralTable->1->0->logincell->resettokenpanel->1->5->1->2->1->3",
         "login.handlebars->container->column_l->centralTable->1->0->logincell->tokenpanel->1->7->1->4->1->3"
-      ]
+      ],
+      "zh-chs": "Duo"
     },
     {
       "en": "Duo Authentication",
@@ -26641,7 +26677,8 @@
         "default3.handlebars->123->1925",
         "login2.handlebars->centralTable->1->0->logincell->resettokenpanel->resettokenpanelform->5->1->2farow2->1->3",
         "login2.handlebars->centralTable->1->0->logincell->tokenpanel->tokenpanelform->7->1->2farow->1->3"
-      ]
+      ],
+      "zh-chs": "Duo 认证"
     },
     {
       "bs": "Duplirani agent",
@@ -27078,7 +27115,7 @@
       "sv": "FEL: Ogiltig e-post \\\"{0}\\\" för användaren \\\"{1} \\\".",
       "tr": "HATA: \\\"{1}\\\" kullanıcısı için \\\"{0}\\\" geçersiz e-posta.",
       "uk": "ПОМИЛКА: Хибна е-пошта \\\"{0}\\\" для користувача \\\"{1}\\\".",
-      "zh-chs": "错误：用户“ {1} ”的电邮“ {0} ”无效。",
+      "zh-chs": "错误：用户“ {1} ”的电子邮件“ {0} ”无效。",
       "zh-cht": "錯誤：用戶“ {1} ”的電郵“ {0} ”無效。",
       "xloc": [
         "message.handlebars->9->7",
@@ -27616,7 +27653,8 @@
       "nl": "Bewerk Tags",
       "xloc": [
         "default3.handlebars->123->1393"
-      ]
+      ],
+      "zh-chs": "编辑标签"
     },
     {
       "bs": "Uredite pristanak korisnika",
@@ -27971,7 +28009,7 @@
       "sv": "E-post",
       "tr": "E-posta",
       "uk": "е-пошта",
-      "zh-chs": "电邮",
+      "zh-chs": "电子邮件",
       "zh-cht": "電郵",
       "xloc": [
         "default-mobile.handlebars->55->332",
@@ -28016,7 +28054,8 @@
         "default.handlebars->121->2334",
         "default3.handlebars->123->2337",
         "default3.handlebars->123->995"
-      ]
+      ],
+      "zh-chs": "电子邮件 ({0})"
     },
     {
       "bs": "Promjena adrese e-pošte",
@@ -28445,7 +28484,7 @@
       "sv": "E-postverifierad och tvingad återställning av lösenord krävs.",
       "tr": "E-posta doğrulandı ve zorunlu şifre sıfırlama gerekli.",
       "uk": "Потрібно верифікувати е-пошту та примусово скинути пароль.",
-      "zh-chs": "已通过电邮验证，并且需要重置密码。",
+      "zh-chs": "已通过电子邮件验证，并且需要重置密码。",
       "zh-cht": "已通過電郵驗證，並且需要重置密碼。",
       "xloc": [
         "default.handlebars->121->2950",
@@ -28505,7 +28544,7 @@
       "sv": "E-post:",
       "tr": "E-posta:",
       "uk": "е-пошта:",
-      "zh-chs": "电邮：",
+      "zh-chs": "电子邮件：",
       "zh-cht": "電郵：",
       "xloc": [
         "login-mobile.handlebars->23->24",
@@ -28717,7 +28756,7 @@
       "sv": "Aktivera e-post tvåfaktors autentisering.",
       "tr": "E-posta iki faktörlü kimlik doğrulamasını etkinleştirin.",
       "uk": "Увімкнути двофакторну автентифікацію е-поштою.",
-      "zh-chs": "启用电邮两因素验证。",
+      "zh-chs": "启用电子邮件两因素验证。",
       "zh-cht": "啟用電郵二因子鑑別。",
       "xloc": [
         "default-mobile.handlebars->55->119",
@@ -28799,7 +28838,8 @@
       "xloc": [
         "default.handlebars->121->2819",
         "default3.handlebars->123->2823"
-      ]
+      ],
+      "zh-chs": "已启用 Duo 双因素认证"
     },
     {
       "bs": "Omogućena dvofaktorska autentifikacija e-pošte",
@@ -28965,7 +29005,8 @@
         "default-mobile.handlebars->55->947",
         "default.handlebars->121->1805",
         "default3.handlebars->123->1793"
-      ]
+      ],
+      "zh-chs": "加密进行中"
     },
     {
       "bs": "Kraj",
@@ -30402,7 +30443,8 @@
       "xloc": [
         "default.handlebars->121->3386",
         "default3.handlebars->123->3384"
-      ]
+      ],
+      "zh-chs": "事件记录"
     },
     {
       "bs": "Događaji",
@@ -30472,7 +30514,7 @@
       "sv": "Befintligt konto med den här e-postadressen.",
       "tr": "Bu e-posta adresine sahip mevcut hesap.",
       "uk": "Існуючий акаунт із цією е-поштою.",
-      "zh-chs": "使用此电邮地址的现有帐户。",
+      "zh-chs": "使用此电子邮件地址的现有帐户。",
       "zh-cht": "使用此電郵地址的現有帳戶。",
       "xloc": [
         "login-mobile.handlebars->23->7",
@@ -30896,7 +30938,8 @@
         "default.handlebars->121->3174",
         "default3.handlebars->123->1908",
         "default3.handlebars->123->3176"
-      ]
+      ],
+      "zh-chs": "Facebook"
     },
     {
       "bs": "Faeroese",
@@ -31363,7 +31406,7 @@
       "sv": "Filhantering",
       "tr": "Dosya İşlemi",
       "uk": "Файлова Операція",
-      "zh-chs": "档案操作",
+      "zh-chs": "文件操作",
       "zh-cht": "檔案操作",
       "xloc": [
         "default.handlebars->121->1558",
@@ -31401,7 +31444,7 @@
       "sv": "Filval",
       "tr": "Dosya Seçimi",
       "uk": "Вибір файлу",
-      "zh-chs": "档案选择",
+      "zh-chs": "文件选择",
       "zh-cht": "檔案選擇",
       "xloc": [
         "default-mobile.handlebars->dialog->3->dialog4->d3upload->1",
@@ -31426,7 +31469,8 @@
         "default3.handlebars->123->1789",
         "default3.handlebars->123->1801",
         "default3.handlebars->123->1808"
-      ]
+      ],
+      "zh-chs": "文件系统"
     },
     {
       "bs": "File Transfer",
@@ -31511,7 +31555,7 @@
       "sv": "Filer",
       "tr": "Dosyalar",
       "uk": "Файли",
-      "zh-chs": "档案",
+      "zh-chs": "文件",
       "zh-cht": "檔案",
       "xloc": [
         "default-mobile.handlebars->55->423",
@@ -31567,7 +31611,7 @@
       "sv": "Filer meddelas",
       "tr": "Dosyalar Bildir",
       "uk": "Файли: сповістити",
-      "zh-chs": "档案通知",
+      "zh-chs": "文件通知",
       "zh-cht": "檔案通知",
       "xloc": [
         "default.handlebars->121->2326",
@@ -31603,7 +31647,7 @@
       "sv": "Filer uppmanas",
       "tr": "Dosya İstemi",
       "uk": "Файли: запит",
-      "zh-chs": "档案提示",
+      "zh-chs": "文件提示",
       "zh-cht": "檔案提示",
       "xloc": [
         "default.handlebars->121->2325",
@@ -31853,7 +31897,8 @@
       "xloc": [
         "default.handlebars->121->125",
         "default3.handlebars->123->123"
-      ]
+      ],
+      "zh-chs": "Firebase 现在需要服务帐户 JSON 文件，Firebase 已禁用。"
     },
     {
       "bs": "Firewall",
@@ -31937,7 +31982,8 @@
       "xloc": [
         "default.handlebars->121->1498",
         "default3.handlebars->123->1489"
-      ]
+      ],
+      "zh-chs": "首次失败"
     },
     {
       "ar": "اتصال الوكيل الأول",
@@ -32115,7 +32161,8 @@
       "nl": "Plat",
       "xloc": [
         "default3.handlebars->123->2196"
-      ]
+      ],
+      "zh-chs": "Flatly"
     },
     {
       "bs": "Focus All",
@@ -32231,7 +32278,7 @@
       "sv": "För Apple OSX, nagivera till följande länk för att slutföra processen:",
       "tr": "Apple OSX için, işlemi tamamlamak için aşağıdaki bağlantıya gidin:",
       "uk": "Для Apple OSX перейдіть за цим посиланням, щоб завершити процес:",
-      "zh-chs": "对于Apple OSX，请导航至以下连结以完成该过程：",
+      "zh-chs": "对于Apple OSX，请导航至以下链接以完成该过程：",
       "zh-cht": "對於Apple OSX，請導航至以下鏈結以完成該過程：",
       "xloc": [
         "mesh-invite.txt"
@@ -32318,7 +32365,7 @@
       "ru": "Для Windows откройте следующую ссылку, чтобы завершить процесс:",
       "sv": "För Windows, nagivera till följande länk för att slutföra processen:",
       "tr": "Windows için, işlemi tamamlamak için aşağıdaki bağlantıya gidin:",
-      "zh-chs": "对于Windows，请导航至以下连结以完成该过程：",
+      "zh-chs": "对于Windows，请导航至以下链接以完成该过程：",
       "zh-cht": "對於Windows，請導航至以下鏈結以完成該過程：",
       "xloc": [
         "mesh-invite.txt"
@@ -32684,7 +32731,7 @@
       "sv": "Bildhastighet",
       "tr": "Kare hızı",
       "uk": "Частота кадрів",
-      "zh-chs": "贞速率",
+      "zh-chs": "帧速率",
       "zh-cht": "框速率",
       "xloc": [
         "default.handlebars->container->dialog->dialogBody->dialog7->d7meshkvm->7->1",
@@ -32739,7 +32786,8 @@
         "default.handlebars->121->3177",
         "default3.handlebars->123->1911",
         "default3.handlebars->123->3179"
-      ]
+      ],
+      "zh-chs": "ntfy.sh 的免费服务"
     },
     {
       "bs": "FreeBSD x86-64",
@@ -33354,7 +33402,8 @@
         "default-mobile.handlebars->55->946",
         "default.handlebars->121->1804",
         "default3.handlebars->123->1792"
-      ]
+      ],
+      "zh-chs": "完全解密"
     },
     {
       "ca": "Totalment encriptat",
@@ -33366,7 +33415,8 @@
         "default-mobile.handlebars->55->948",
         "default.handlebars->121->1806",
         "default3.handlebars->123->1794"
-      ]
+      ],
+      "zh-chs": "完全加密"
     },
     {
       "bs": "GB",
@@ -33607,7 +33657,7 @@
       "sv": "Allmänt",
       "tr": "Genel",
       "uk": "Загальні",
-      "zh-chs": "一般",
+      "zh-chs": "常规",
       "zh-cht": "一般",
       "xloc": [
         "default-mobile.handlebars->55->563",
@@ -33655,7 +33705,7 @@
       "sv": "Allmän information",
       "tr": "Genel bilgi",
       "uk": "Загальні відомості",
-      "zh-chs": "一般信息",
+      "zh-chs": "基本信息",
       "zh-cht": "一般訊息",
       "xloc": [
         "default.handlebars->121->872",
@@ -34106,7 +34156,8 @@
       "xloc": [
         "default.handlebars->container->column_l->p13->p13toolbar->1->4->1->1->p13sizedropdown->9",
         "default3.handlebars->container->column_l->p13->p13toolbar->1->4->1->1->p13sizedropdown->9"
-      ]
+      ],
+      "zh-chs": "吉字节"
     },
     {
       "bs": "Globalno",
@@ -34147,7 +34198,8 @@
       "xloc": [
         "default.handlebars->121->1568",
         "default3.handlebars->123->1558"
-      ]
+      ],
+      "zh-chs": "转到文件夹"
     },
     {
       "bs": "Idi na prvu stranicu",
@@ -34163,7 +34215,8 @@
       "xloc": [
         "default.handlebars->container->column_l->p1->p1title->devListToolbarViewIcons",
         "default3.handlebars->container->column_l->p1->p1title->devListToolbarViewIcons"
-      ]
+      ],
+      "zh-chs": "转到第一页"
     },
     {
       "bs": "Idi na posljednju stranicu",
@@ -34179,7 +34232,8 @@
       "xloc": [
         "default.handlebars->container->column_l->p1->p1title->devListToolbarViewIcons",
         "default3.handlebars->container->column_l->p1->p1title->devListToolbarViewIcons"
-      ]
+      ],
+      "zh-chs": "转到最后一页"
     },
     {
       "bs": "Idite na stranicu za prijavu",
@@ -34255,7 +34309,8 @@
       "xloc": [
         "default.handlebars->container->column_l->p1->p1title->devListToolbarViewIcons",
         "default3.handlebars->container->column_l->p1->p1title->devListToolbarViewIcons"
-      ]
+      ],
+      "zh-chs": "转到下一页"
     },
     {
       "bs": "Idi na prethodnu stranicu",
@@ -34271,7 +34326,8 @@
       "xloc": [
         "default.handlebars->container->column_l->p1->p1title->devListToolbarViewIcons",
         "default3.handlebars->container->column_l->p1->p1title->devListToolbarViewIcons"
-      ]
+      ],
+      "zh-chs": "转到上一页"
     },
     {
       "ca": "Anar a",
@@ -34776,7 +34832,8 @@
       "xloc": [
         "default.handlebars->121->3002",
         "default3.handlebars->123->3004"
-      ]
+      ],
+      "zh-chs": "组类型"
     },
     {
       "bs": "Grupirajte po",
@@ -35074,7 +35131,7 @@
       "sv": "Gästdelning",
       "tr": "Misafir Paylaşımı",
       "uk": "Поширити гостю",
-      "zh-chs": "嘉宾分享",
+      "zh-chs": "访客共享",
       "zh-cht": "嘉賓分享",
       "xloc": [
         "default.handlebars->121->1155",
@@ -35106,7 +35163,7 @@
       "sv": "Gästdelning",
       "tr": "Misafir Paylaşımı",
       "uk": "Можливість ділитись з гостями",
-      "zh-chs": "嘉宾分享",
+      "zh-chs": "访客共享",
       "zh-cht": "嘉賓分享",
       "xloc": [
         "default.handlebars->121->2486",
@@ -35518,7 +35575,8 @@
         "default.handlebars->121->3170",
         "default3.handlebars->123->1904",
         "default3.handlebars->123->3172"
-      ]
+      ],
+      "zh-chs": "Handle"
     },
     {
       "bs": "Handle Count",
@@ -35693,7 +35751,7 @@
       "sv": "Hälsa",
       "tr": "Sağlık",
       "uk": "Здоров'я",
-      "zh-chs": "健康",
+      "zh-chs": "运行状况",
       "zh-cht": "健康",
       "xloc": [
         "default-mobile.handlebars->55->910",
@@ -35846,7 +35904,7 @@
       "sv": "Hjälp",
       "tr": "Yardım",
       "uk": "Допомога",
-      "zh-chs": "救命",
+      "zh-chs": "帮助",
       "zh-cht": "救命",
       "xloc": [
         "default.handlebars->container->column_l->p1->devListToolbarSpan->1->0->devListToolbar->DevFilterSelect->13",
@@ -35993,7 +36051,8 @@
         "default3.handlebars->123->1136",
         "default3.handlebars->123->2583",
         "default3.handlebars->123->2587"
-      ]
+      ],
+      "zh-chs": "帮助请求"
     },
     {
       "bs": "Pomozite prevesti MeshCentral",
@@ -36108,7 +36167,7 @@
       "sv": "Hej [[[USERNAME]]], [[[SERVERNAME]]] ([[[SERVERURL]]] [[[URLARGS1]]) begär återställning av kontolösenord. Ta bort till följande länk för att slutföra processen:",
       "tr": "Merhaba [[[USERNAME]]], [[[SERVERNAME]]] ([[[SERVERURL]]][[[URLARGS1]]]) bir hesap şifresi sıfırlama istiyor. İşlemi tamamlamak için aşağıdaki bağlantıya gidin:",
       "uk": "Вітаємо, [[[USERNAME]]], [[[SERVERNAME]]] ([[[SERVERURL]]][[[URLARGS1]]]) запитує скидання пароля акаунту. Перейдіть за наступним посиланням, щоб завершити процес:",
-      "zh-chs": "[[[USERNAME]]，您好：[[[SERVERNAME]]] ([[[SERVERURL]]][[[URLARGS1]]]) 正在请求重置帐户密码。导航至以下连结以完成该过程：",
+      "zh-chs": "[[[USERNAME]]，您好：[[[SERVERNAME]]] ([[[SERVERURL]]][[[URLARGS1]]]) 正在请求重置帐户密码。导航至以下链接以完成该过程：",
       "zh-cht": "[[[USERNAME]]，你好，[[[SERVERNAME]]] ([[[SERVERURL]]][[[URLARGS1]]]) 正在請求重設帳戶密碼。導航至以下鏈結以完成該過程：",
       "xloc": [
         "account-reset.txt"
@@ -36366,7 +36425,7 @@
       "sv": "Hem",
       "tr": "Ev",
       "uk": "Домівка",
-      "zh-chs": "家",
+      "zh-chs": "主页",
       "zh-cht": "家",
       "xloc": [
         "default-mobile.handlebars->55->648",
@@ -36463,7 +36522,8 @@
       "xloc": [
         "default.handlebars->container->column_l->p13->p13toolbar->1->4->1->1->p13sizedropdown->1",
         "default3.handlebars->container->column_l->p13->p13toolbar->1->4->1->1->p13sizedropdown->1"
-      ]
+      ],
+      "zh-chs": "人类可读"
     },
     {
       "bs": "Mađarski",
@@ -36503,7 +36563,8 @@
         "default-mobile.handlebars->55->55",
         "default.handlebars->121->65",
         "default3.handlebars->123->65"
-      ]
+      ],
+      "zh-chs": "混合 AD"
     },
     {
       "bs": "Potreban hibrid za server",
@@ -36622,7 +36683,7 @@
       "sv": "IP-adress blockerad, försök igen senare.",
       "tr": "IP adresi engellendi, daha sonra tekrar deneyin.",
       "uk": "IP-адресу заблоковано, повторіть спробу пізніше.",
-      "zh-chs": "IP位址已被封锁，请稍后再试。",
+      "zh-chs": "IP地址已被封锁，请稍后再试。",
       "zh-cht": "IP位址已被封鎖，請稍後再試。",
       "xloc": [
         "login-mobile.handlebars->23->19",
@@ -36644,7 +36705,8 @@
       "xloc": [
         "default.handlebars->121->3380",
         "default3.handlebars->123->3378"
-      ]
+      ],
+      "zh-chs": "IP 位置信息记录"
     },
     {
       "bs": "IP-KVM",
@@ -37549,7 +37611,8 @@
       "xloc": [
         "default.handlebars->121->2353",
         "default3.handlebars->123->2356"
-      ]
+      ],
+      "zh-chs": "导入"
     },
     {
       "bs": "Uvezite Intel&reg; AMT uređaje",
@@ -37670,7 +37733,8 @@
       "xloc": [
         "default.handlebars->121->469",
         "default3.handlebars->123->461"
-      ]
+      ],
+      "zh-chs": "输入"
     },
     {
       "bs": "Da biste koristili autentifikaciju push obavijesti, na vašem računu mora biti postavljen mobilni uređaj s punim pravima.",
@@ -38291,7 +38355,8 @@
       "xloc": [
         "default.handlebars->121->1495",
         "default3.handlebars->123->1486"
-      ]
+      ],
+      "zh-chs": "安装者"
     },
     {
       "ca": "Data d'instal·lació",
@@ -38302,7 +38367,8 @@
       "xloc": [
         "default.handlebars->121->1496",
         "default3.handlebars->123->1487"
-      ]
+      ],
+      "zh-chs": "安装日期"
     },
     {
       "en": "Installed for all users",
@@ -38433,7 +38499,8 @@
       "xloc": [
         "default.handlebars->121->3513",
         "default3.handlebars->123->3511"
-      ]
+      ],
+      "zh-chs": "Intel AMT CIRA"
     },
     {
       "bs": "Intel AMT CIRA povezan",
@@ -38578,7 +38645,7 @@
       "sv": "Intel AMT-chef",
       "tr": "Intel AMT yöneticisi",
       "uk": "Менеджер Intel AMT",
-      "zh-chs": "英特尔 AMT 经理",
+      "zh-chs": "英特尔 AMT 管理器",
       "zh-cht": "英特爾 AMT 經理",
       "xloc": [
         "default.handlebars->121->3543",
@@ -38814,7 +38881,8 @@
         "default3.handlebars->123->545",
         "default3.handlebars->123->546",
         "default3.handlebars->123->548"
-      ]
+      ],
+      "zh-chs": "Intel&reg; AMT 设备导入"
     },
     {
       "bs": "Intel&reg; AMT JSON",
@@ -39056,7 +39124,8 @@
       "xloc": [
         "default.handlebars->121->1289",
         "default3.handlebars->123->1296"
-      ]
+      ],
+      "zh-chs": "Intel&reg; AMT 开机到 BIOS"
     },
     {
       "en": "Intel&reg; AMT Power on to PXE",
@@ -39064,7 +39133,8 @@
       "xloc": [
         "default.handlebars->121->1290",
         "default3.handlebars->123->1297"
-      ]
+      ],
+      "zh-chs": "Intel&reg; AMT 开机到 PXE"
     },
     {
       "bs": "Intel&reg; AMT preusmjeravanje",
@@ -39122,7 +39192,7 @@
       "sv": "Intel&reg; AMT-återställning",
       "tr": "Intel&reg; AMT Sıfırlama",
       "uk": "Скинути Intel&reg; AMT",
-      "zh-chs": "英特尔&reg; AMT 重置",
+      "zh-chs": "英特尔&reg; AMT 重启",
       "zh-cht": "英特爾&reg; AMT 重置",
       "xloc": [
         "default-mobile.handlebars->55->580",
@@ -39144,7 +39214,8 @@
       "xloc": [
         "default.handlebars->121->1288",
         "default3.handlebars->123->1295"
-      ]
+      ],
+      "zh-chs": "Intel&reg; AMT 重启到 BIOS"
     },
     {
       "en": "Intel&reg; AMT Reset to PXE",
@@ -39152,7 +39223,8 @@
       "xloc": [
         "default.handlebars->121->1291",
         "default3.handlebars->123->1298"
-      ]
+      ],
+      "zh-chs": "Intel&reg; AMT 重启到 PXE"
     },
     {
       "bs": "Intel&reg; AMT oznaka",
@@ -39326,7 +39398,8 @@
       "xloc": [
         "default.handlebars->121->373",
         "default3.handlebars->123->371"
-      ]
+      ],
+      "zh-chs": "Intel&reg; AMT 主机名"
     },
     {
       "bs": "Intel&reg; AMT je aktiviran u Admin Control Modu",
@@ -39401,7 +39474,8 @@
       "xloc": [
         "default.handlebars->121->468",
         "default3.handlebars->123->460"
-      ]
+      ],
+      "zh-chs": "Intel&reg; AMT 处于激活模式"
     },
     {
       "ca": "Intel&reg; AMT no està activat",
@@ -39412,7 +39486,8 @@
       "xloc": [
         "default.handlebars->121->466",
         "default3.handlebars->123->458"
-      ]
+      ],
+      "zh-chs": "Intel&reg; AMT 未激活"
     },
     {
       "bs": "Intel&reg; AMT je rutabilan i spreman za upotrebu.",
@@ -39607,7 +39682,8 @@
       "xloc": [
         "default.handlebars->121->374",
         "default3.handlebars->123->372"
-      ]
+      ],
+      "zh-chs": "Intel&reg; AMT 状态"
     },
     {
       "bs": "Intel&reg; Active Management Technology",
@@ -40276,7 +40352,8 @@
         "default.handlebars->121->2918",
         "default3.handlebars->123->2920",
         "default3.handlebars->123->2922"
-      ]
+      ],
+      "zh-chs": "无效的 CSV 文件格式。"
     },
     {
       "bs": "Nevažeći vjerodajnici",
@@ -40392,7 +40469,7 @@
       "sv": "Ogiltigt JSON-filformat.",
       "tr": "Geçersiz JSON dosya biçimi.",
       "uk": "Хибний формат файлу JSON.",
-      "zh-chs": "无效的JSON档案格式。",
+      "zh-chs": "无效的JSON文件格式。",
       "zh-cht": "無效的JSON檔案格式。",
       "xloc": [
         "default.handlebars->121->2401",
@@ -40427,7 +40504,7 @@
       "sv": "Ogiltig JSON-fil: {0}.",
       "tr": "Geçersiz JSON dosyası: {0}.",
       "uk": "Хибний файл JSON: {0}.",
-      "zh-chs": "无效的JSON档案：{0}。",
+      "zh-chs": "无效的JSON文件：{0}。",
       "zh-cht": "無效的JSON檔案：{0}。",
       "xloc": [
         "default.handlebars->121->2397",
@@ -40764,7 +40841,7 @@
       "sv": "Ogiltig e-postadress",
       "tr": "Geçersiz e-posta",
       "uk": "Хибна е-пошта",
-      "zh-chs": "不合规电邮",
+      "zh-chs": "不合规电子邮件",
       "zh-cht": "不合規電郵",
       "xloc": [
         "default-mobile.handlebars->55->1089",
@@ -40795,7 +40872,7 @@
       "sv": "Ogiltig e-postadress.",
       "tr": "Geçersiz e-posta.",
       "uk": "Хибна адреса е-пошти.",
-      "zh-chs": "不合规格电邮。",
+      "zh-chs": "不合规格电子邮件。",
       "zh-cht": "不合規格電郵。",
       "xloc": [
         "login-mobile.handlebars->23->11",
@@ -40907,7 +40984,8 @@
       "xloc": [
         "default.handlebars->121->3454",
         "default3.handlebars->123->3452"
-      ]
+      ],
+      "zh-chs": "无效的消息"
     },
     {
       "ca": "Origen no vàlid a la sol·licitud HTTP",
@@ -40918,7 +40996,8 @@
       "xloc": [
         "default.handlebars->121->79",
         "default3.handlebars->123->77"
-      ]
+      ],
+      "zh-chs": "HTTP 请求中的无效来源"
     },
     {
       "bs": "Nevažeća lozinka",
@@ -40969,7 +41048,8 @@
         "login-mobile.handlebars->23->22",
         "login.handlebars->13->24",
         "login2.handlebars->17->222"
-      ]
+      ],
+      "zh-chs": "无效的安全检查。"
     },
     {
       "bs": "Nevažeće dozvole za web lokaciju",
@@ -41117,7 +41197,7 @@
       "sv": "Ogiltig e-post",
       "tr": "E-postayı Geçersiz Kıl",
       "uk": "Хибна е-пошта",
-      "zh-chs": "使电邮无效",
+      "zh-chs": "使电子邮件无效",
       "zh-cht": "使電郵無效",
       "xloc": [
         "default.handlebars->121->2888",
@@ -41433,7 +41513,7 @@
       "sv": "Bjud in någon att installera Mesh-agenten. Ett e-postmeddelande skickas med en länk till Mesh-agentens installation, för enhetsgruppen \\\"{0}\\\".",
       "tr": "Mesh aracısını kurması için birini davet edin. \\\"{0}\\\" cihaz grubu için örgü aracı kurulumuna bağlantı içeren bir e-posta gönderilecek.",
       "uk": "Запросіть встановити MeshAgent. Буде надіслана е-пошта із посиланням для інсталяції MeshAgent до групи пристроїв \\\"{0}\\\".",
-      "zh-chs": "邀请某人安装网状代理。将发送一封电邮，其中包含指向“ {0} ”设备组的网状代理安装的连结。",
+      "zh-chs": "邀请某人安装Mesh Agent。将发送一封电子邮件，其中包含指向“ {0} ”设备组的Mesh Agent安装的链接。",
       "zh-cht": "邀請某人安裝mesh agent。將發送一封電郵，其中包含指向“ {0} ”裝置群的mesh agent安裝的鏈結。",
       "xloc": [
         "default.handlebars->121->582",
@@ -44147,7 +44227,7 @@
       "sv": "Begränsning av 10 filuppladdningar samtidigt.",
       "tr": "Aynı anda 10 dosya gönderilebilir.",
       "uk": "Обмеження завантаження є 10 файлів одночасно.",
-      "zh-chs": "一次最多可上传10个档案。",
+      "zh-chs": "一次最多可上传10个文件。",
       "zh-cht": "一次最多可上傳10個檔案。",
       "xloc": [
         "messenger.handlebars->remoteImage->3->8",
@@ -44336,7 +44416,7 @@
       "sv": "Länk",
       "tr": "Bağlantı",
       "uk": "Лінк",
-      "zh-chs": "连结",
+      "zh-chs": "链接",
       "zh-cht": "鏈結",
       "xloc": [
         "default-mobile.handlebars->55->364",
@@ -44367,7 +44447,7 @@
       "sv": "Länk utgång",
       "tr": "Bağlantının Sona Ermesi",
       "uk": "Термін дії лінку",
-      "zh-chs": "连结过期",
+      "zh-chs": "链接过期",
       "zh-cht": "鏈結過期",
       "xloc": [
         "default.handlebars->121->593",
@@ -44399,7 +44479,7 @@
       "sv": "Länkinbjudan",
       "tr": "Bağlantı daveti",
       "uk": "Запрошення за посиланням",
-      "zh-chs": "连结邀请",
+      "zh-chs": "链接邀请",
       "zh-cht": "鏈結邀請",
       "xloc": [
         "default.handlebars->121->580",
@@ -45115,7 +45195,7 @@
       "sv": "Linux / BSD / macOS Command Shell",
       "tr": "Linux / BSD / macOS Komut Kabuğu",
       "uk": "Командна Оболонка Linux/BSD/macOS",
-      "zh-chs": "Linux / BSD / macOS命令外壳",
+      "zh-chs": "Linux / BSD / macOS命令命令行",
       "zh-cht": "Linux / BSD / macOS命令外殼",
       "xloc": [
         "default-mobile.handlebars->55->601",
@@ -45536,7 +45616,7 @@
       "sv": "Lokal filöverföring",
       "tr": "Yerel dosya gönderme",
       "uk": "Локальне завантаження файлу",
-      "zh-chs": "本地档案上传",
+      "zh-chs": "本地文件上传",
       "zh-cht": "本地檔案上傳",
       "xloc": [
         "default-mobile.handlebars->dialog->3->dialog4->d3upload->d3uploadMode->1",
@@ -47599,7 +47679,7 @@
       "sv": "Hantera inspelningar",
       "tr": "Kayıtları Yönetin",
       "uk": "Керувати записами",
-      "zh-chs": "管理录音",
+      "zh-chs": "管理录制记录",
       "zh-cht": "管理錄音",
       "xloc": [
         "default.handlebars->121->2966",
@@ -47783,7 +47863,7 @@
       "sv": "Hantera e-postautentisering",
       "tr": "E-posta kimlik doğrulamasını yönetin",
       "uk": "Керувати автентифікацією через е-пошту",
-      "zh-chs": "管理电邮身份验证",
+      "zh-chs": "管理电子邮件身份验证",
       "zh-cht": "管理電郵身份驗證",
       "xloc": [
         "default-mobile.handlebars->container->page_content->column_l->p3->p3info->3->p3AccountActions->p2AccountSecurity->3->manageEmail2FA->0",
@@ -47986,7 +48066,7 @@
       "sv": "Chef",
       "tr": "Yönetici",
       "uk": "Менеджер",
-      "zh-chs": "经理",
+      "zh-chs": "管理器",
       "zh-cht": "經理",
       "xloc": [
         "default.handlebars->121->2876",
@@ -48403,7 +48483,7 @@
       "sv": "Megabyte",
       "tr": "Megabayt",
       "uk": "Мегабайти",
-      "zh-chs": "Megabyte",
+      "zh-chs": "兆字节",
       "zh-cht": "Megabyte",
       "xloc": [
         "default.handlebars->121->3514",
@@ -48574,7 +48654,7 @@
       "sv": "Mesh Relay",
       "tr": "Mesh Yayını",
       "uk": "Mesh Ретрансляція",
-      "zh-chs": "网格中继",
+      "zh-chs": "Mesh 中继",
       "zh-cht": "Mesh Relay",
       "xloc": [
         "default.handlebars->121->1014",
@@ -48764,7 +48844,7 @@
       "sv": "MeshCentral",
       "tr": "MeshCentral",
       "uk": "MeshCentral",
-      "zh-chs": "网格中心",
+      "zh-chs": "MeshCentral",
       "zh-cht": "網格中心",
       "xloc": [
         "default.handlebars->121->1208",
@@ -48955,7 +49035,7 @@
       "sv": "MeshCentral Router",
       "tr": "MeshCentral Yönlendirici",
       "uk": "MeshCentral Router",
-      "zh-chs": "MeshCentral路由器",
+      "zh-chs": "MeshCentral Router",
       "zh-cht": "MeshCentral Router",
       "xloc": [
         "default.handlebars->121->1357",
@@ -49075,7 +49155,7 @@
       "sv": "MeshCentral Server Peering",
       "tr": "MeshCentral Sunucu Eşlemesi",
       "uk": "Піринг сервера MeshCentral",
-      "zh-chs": "MeshCentral服务器同级化",
+      "zh-chs": "MeshCentral 服务器对等连接",
       "zh-cht": "MeshCentral伺服器同級化",
       "xloc": [
         "default.handlebars->121->3530",
@@ -49421,7 +49501,7 @@
       "sv": "MeshCmd är ett kommandoradsverktyg som utför många olika operationer. Handlingsfilen kan valfritt laddas ner och redigeras för att tillhandahålla serverinformation och referenser.",
       "tr": "MeshCmd, birçok farklı işlemi gerçekleştiren bir komut satırı aracıdır. Eylem dosyası isteğe bağlı olarak indirilebilir ve sunucu bilgileri ve kimlik bilgileri sağlamak için düzenlenebilir.",
       "uk": "MeshCmd — це утиліта командного рядка, яка дозволяє виконати багато різних операцій. Ви також можете завантажити та відредагувати файл дій у якому міститиметься інформація про сервер та облікові дані.",
-      "zh-chs": "MeshCmd是一个可以执行许多不同操作的命令行工具。可以选择下载和编辑操作档案以提供服务器信息和凭据。",
+      "zh-chs": "MeshCmd是一个可以执行许多不同操作的命令行工具。可以选择下载和编辑操作文件以提供服务器信息和凭据。",
       "zh-cht": "MeshCmd是一個可以執行許多不同操作的命令行工具。可以選擇下載和編輯操作檔案以提供伺服器訊息和憑據。",
       "xloc": [
         "default.handlebars->121->1367",
@@ -49601,7 +49681,8 @@
       "xloc": [
         "default.handlebars->121->3456",
         "default3.handlebars->123->3454"
-      ]
+      ],
+      "zh-chs": "消息错误"
     },
     {
       "ca": "Error de missatge: {0}",
@@ -49616,7 +49697,8 @@
       "xloc": [
         "default.handlebars->121->3457",
         "default3.handlebars->123->3455"
-      ]
+      ],
+      "zh-chs": "消息错误：{0}"
     },
     {
       "ca": "Missatge enviat.",
@@ -49631,7 +49713,8 @@
       "xloc": [
         "login.handlebars->13->6",
         "login2.handlebars->17->204"
-      ]
+      ],
+      "zh-chs": "消息已发送。"
     },
     {
       "ca": "Missatge enviat correctament.",
@@ -49854,7 +49937,8 @@
         "default-mobile.handlebars->55->56",
         "default.handlebars->121->66",
         "default3.handlebars->123->66"
-      ]
+      ],
+      "zh-chs": "微软帐户"
     },
     {
       "en": "Microsoft Store Apps",
@@ -50121,7 +50205,8 @@
         "default-mobile.handlebars->55->856",
         "default.handlebars->121->1714",
         "default3.handlebars->123->1702"
-      ]
+      ],
+      "zh-chs": "模式"
     },
     {
       "bs": "Model",
@@ -50919,7 +51004,7 @@
       "sv": "Min serverspårning",
       "tr": "Sunucu İzlemem",
       "uk": "Трасування Мого Сервера",
-      "zh-chs": "我的服务器跟踪",
+      "zh-chs": "我的服务器追踪",
       "zh-cht": "我的伺服器追蹤",
       "xloc": [
         "default.handlebars->container->column_l->p41->p41title->0",
@@ -51540,7 +51625,8 @@
       "xloc": [
         "default.handlebars->121->3382",
         "default3.handlebars->123->3380"
-      ]
+      ],
+      "zh-chs": "网络接口信息记录"
     },
     {
       "bs": "Umrežavanje",
@@ -52046,7 +52132,8 @@
         "default3.handlebars->123->1728",
         "default3.handlebars->123->1746",
         "default3.handlebars->123->1751"
-      ]
+      ],
+      "zh-chs": "否"
     },
     {
       "bs": "Nema AMT",
@@ -52340,7 +52427,7 @@
       "sv": "Ingen filåtkomst",
       "tr": "Dosya Erişimi Yok",
       "uk": "Відключити доступ до файлів",
-      "zh-chs": "不能存取档案",
+      "zh-chs": "不能存取文件",
       "zh-cht": "不能存取檔案",
       "xloc": [
         "default-mobile.handlebars->55->1037",
@@ -52722,7 +52809,7 @@
       "sv": "Ingen fjärrkontroll",
       "tr": "Uzaktan Kumanda Yok",
       "uk": "Відключити віддалене керування",
-      "zh-chs": "没有遥控器",
+      "zh-chs": "无远程控制",
       "zh-cht": "沒有遙控器",
       "xloc": [
         "default.handlebars->121->3087",
@@ -52754,7 +52841,7 @@
       "sv": "Ingen återställning/av",
       "tr": "Sıfırlama/Kapatma Yok",
       "uk": "Без доступу до перезапуску/вимкнення",
-      "zh-chs": "无重置/关闭",
+      "zh-chs": "禁止重启/关机",
       "zh-cht": "無重置/關閉",
       "xloc": [
         "default.handlebars->121->3096",
@@ -53953,7 +54040,7 @@
       "sv": "Inga inspelningar.",
       "tr": "Kayıt yok.",
       "uk": "Немає записів.",
-      "zh-chs": "没有录音。",
+      "zh-chs": "没有录制记录。",
       "zh-cht": "沒有錄音。",
       "xloc": [
         "default.handlebars->121->3259",
@@ -55603,7 +55690,8 @@
         "default.handlebars->121->965",
         "default3.handlebars->123->953",
         "default3.handlebars->123->957"
-      ]
+      ],
+      "zh-chs": "开"
     },
     {
       "en": "On-Premises AD",
@@ -55934,7 +56022,8 @@
         "default.handlebars->container->column_l->p13->p13toolbar->1->2->1->3",
         "default3.handlebars->container->column_l->p13->p13toolbar->1->2->1->3",
         "default3.handlebars->container->column_l->p13->p13toolbar->1->2->1->3->37->3->p13MobileOpenButton"
-      ]
+      ],
+      "zh-chs": "打开"
     },
     {
       "bs": "Otvori datoteku...",
@@ -55975,7 +56064,8 @@
       "xloc": [
         "default.handlebars->121->1566",
         "default3.handlebars->123->1556"
-      ]
+      ],
+      "zh-chs": "打开文件/文件夹"
     },
     {
       "bs": "Otvorite stranicu na uređaju",
@@ -57798,7 +57888,7 @@
       "sv": "Utföra Intel&reg; AMT-återställning?",
       "tr": "Intel&reg; AMT sıfırlaması gerçekleştirilsin mi?",
       "uk": "Виконати скидання Intel&reg; AMT?",
-      "zh-chs": "执行英特尔&reg; AMT 重置？",
+      "zh-chs": "执行英特尔&reg; AMT 重启？",
       "zh-cht": "執行英特爾&reg; AMT 重置？",
       "xloc": [
         "default-mobile.handlebars->55->591",
@@ -58816,7 +58906,8 @@
         "default.handlebars->121->1271",
         "default3.handlebars->123->1277",
         "default3.handlebars->123->1278"
-      ]
+      ],
+      "zh-chs": "端口"
     },
     {
       "bs": "Sinhronizacija naziva porta",
@@ -60182,7 +60273,7 @@
       "sv": "Allmän länk",
       "tr": "Genel Bağlantı",
       "uk": "Публічне Посилання",
-      "zh-chs": "公开连结",
+      "zh-chs": "公开链接",
       "zh-cht": "公開鏈結",
       "xloc": [
         "default-mobile.handlebars->55->375",
@@ -60897,7 +60988,7 @@
       "sv": "Slumpmässigt lösenord",
       "tr": "Parolayı rastgele seç",
       "uk": "Випадковий пароль",
-      "zh-chs": "随机密码",
+      "zh-chs": "随机生成密码",
       "zh-cht": "隨機密碼",
       "xloc": [
         "default.handlebars->121->2411",
@@ -60927,7 +61018,7 @@
       "sv": "Slumpmässigt lösenordet.",
       "tr": "Parolayı rastgele hale getirin.",
       "uk": "Випадковий пароль.",
-      "zh-chs": "随机密码。",
+      "zh-chs": "随机生成密码。",
       "zh-cht": "隨機密碼。",
       "xloc": [
         "default.handlebars->121->2946",
@@ -60987,7 +61078,7 @@
       "sv": "Betygsätta",
       "tr": "Oranı",
       "uk": "Швидкість",
-      "zh-chs": "率",
+      "zh-chs": "速率",
       "zh-cht": "率",
       "xloc": [
         "default-mobile.handlebars->dialog->3->dialog7->d7meshkvm->3->1->4->1",
@@ -61017,7 +61108,7 @@
       "sv": "Rå",
       "tr": "Çiğ",
       "uk": "Необроблене",
-      "zh-chs": "生的",
+      "zh-chs": "原始",
       "zh-cht": "生的",
       "xloc": [
         "default.handlebars->container->dialog->dialogBody->dialog4",
@@ -61048,7 +61139,7 @@
       "sv": "Riktiga namn",
       "tr": "Gerçek ad",
       "uk": "Справжнє Ім'я",
-      "zh-chs": "真正的名字",
+      "zh-chs": "真实姓名",
       "zh-cht": "真正的名字",
       "xloc": [
         "default.handlebars->121->3078",
@@ -61185,7 +61276,7 @@
       "sv": "Spela in sessioner",
       "tr": "Oturumları Kaydet",
       "uk": "Запис Сеансів",
-      "zh-chs": "记录会议",
+      "zh-chs": "录制会话",
       "zh-cht": "記錄會議",
       "xloc": [
         "default.handlebars->121->2315",
@@ -61249,7 +61340,7 @@
       "sv": "Spela in sessioner",
       "tr": "Kayıt oturumları",
       "uk": "Запис сеансу",
-      "zh-chs": "记录会议",
+      "zh-chs": "录制会话",
       "zh-cht": "記錄會議",
       "xloc": [
         "default.handlebars->121->2456",
@@ -61283,7 +61374,7 @@
       "sv": "Inspelningsdetaljer",
       "tr": "Kayıt Ayrıntıları",
       "uk": "Деталі запису",
-      "zh-chs": "记录细节",
+      "zh-chs": "录制详情",
       "zh-cht": "記錄細節",
       "xloc": [
         "default.handlebars->121->3299",
@@ -61313,7 +61404,7 @@
       "sv": "Inspelningar",
       "tr": "Kayıtlar",
       "uk": "Записи",
-      "zh-chs": "录音",
+      "zh-chs": "录制记录",
       "zh-cht": "錄音",
       "xloc": [
         "default.handlebars->container->topbar->1->1->UsersSubMenuSpan->UsersSubMenu->1->0->UsersRecordings",
@@ -61355,7 +61446,7 @@
       "sv": "Återkommande",
       "tr": "yinelenen",
       "uk": "Повторити",
-      "zh-chs": "再次发生的",
+      "zh-chs": "定期",
       "zh-cht": "再次發生的",
       "xloc": [
         "default.handlebars->121->315",
@@ -62297,7 +62388,7 @@
       "sv": "Fjärrkontroll",
       "tr": "Uzaktan kumanda",
       "uk": "Дистанційне керування",
-      "zh-chs": "遥控",
+      "zh-chs": "远程控制",
       "zh-cht": "遙控",
       "xloc": [
         "default-mobile.handlebars->55->1033",
@@ -62325,7 +62416,8 @@
       "xloc": [
         "default.handlebars->121->2483",
         "default3.handlebars->123->2487"
-      ]
+      ],
+      "zh-chs": "远程控制与中继"
     },
     {
       "bs": "Remote Desktop",
@@ -62600,7 +62692,7 @@
       "sv": "Fjärrskrivbordslänk",
       "tr": "Uzak Masaüstü Bağlantısı",
       "uk": "Підключення до Віддаленої Стільниці",
-      "zh-chs": "远程桌面连结",
+      "zh-chs": "远程桌面链接",
       "zh-cht": "遠程桌面鏈結",
       "xloc": [
         "default.handlebars->121->325",
@@ -64385,7 +64477,7 @@
       "sv": "Döp om",
       "tr": "Yeniden adlandır",
       "uk": "Перейменувати",
-      "zh-chs": "改名",
+      "zh-chs": "重命名",
       "zh-cht": "改名",
       "xloc": [
         "default-mobile.handlebars->55->385",
@@ -64879,7 +64971,7 @@
       "sv": "Återställa",
       "tr": "Sıfırla",
       "uk": "Перезапустити",
-      "zh-chs": "重设",
+      "zh-chs": "重启",
       "zh-cht": "重設",
       "xloc": [
         "default-mobile.handlebars->55->578",
@@ -64912,7 +65004,7 @@
       "sv": "Återställ / stäng av",
       "tr": "Sıfırla / Kapat",
       "uk": "Перезапустити / Вимкнути",
-      "zh-chs": "重置/关闭电源",
+      "zh-chs": "重启/关机",
       "zh-cht": "重置/關閉電源",
       "xloc": [
         "default-mobile.handlebars->55->1047",
@@ -64943,7 +65035,7 @@
       "sv": "Återställ konto",
       "tr": "Hesabı Sıfırla",
       "uk": "Скинути Акаунт",
-      "zh-chs": "重设帐户",
+      "zh-chs": "重置帐户",
       "zh-cht": "重設帳戶",
       "xloc": [
         "login-mobile.handlebars->container->page_content->column_l->1->1->0->1->resetpanel->1->7->1->2->1->1",
@@ -64974,7 +65066,7 @@
       "sv": "Återställ lösenord",
       "tr": "Şifreyi yenile",
       "uk": "Відновити Пароль",
-      "zh-chs": "重设密码",
+      "zh-chs": "重置密码",
       "zh-cht": "重設密碼",
       "xloc": [
         "login-mobile.handlebars->container->page_content->column_l->1->1->0->1->resetpasswordpanel->1->7->1->6->1->1",
@@ -65005,7 +65097,7 @@
       "sv": "Återställ konto",
       "tr": "Hesabı sıfırla",
       "uk": "Відновити акаунт",
-      "zh-chs": "重设帐户",
+      "zh-chs": "重置帐户",
       "zh-cht": "重設帳戶",
       "xloc": [
         "login-mobile.handlebars->container->page_content->column_l->1->1->0->1->loginpanel->1->resetAccountDiv->3",
@@ -65096,7 +65188,7 @@
       "sv": "Återställ / Av",
       "tr": "Sıfırla / Kapat",
       "uk": "Перезапустити/Вимкнути",
-      "zh-chs": "重置/关闭",
+      "zh-chs": "重启/关机",
       "zh-cht": "重置/關閉",
       "xloc": [
         "default-mobile.handlebars->55->1067",
@@ -65131,7 +65223,7 @@
       "sv": "Omstart",
       "tr": "Tekrar başlat",
       "uk": "Перезапустити",
-      "zh-chs": "重新启动",
+      "zh-chs": "重启",
       "zh-cht": "重新啟動",
       "xloc": [
         "default.handlebars->121->1504",
@@ -65157,7 +65249,8 @@
         "default-mobile.handlebars->55->986",
         "default.handlebars->121->1892",
         "default3.handlebars->123->1878"
-      ]
+      ],
+      "zh-chs": "重启代理服务"
     },
     {
       "ca": "Restaura les dreceres de teclat predeterminades",
@@ -65662,7 +65755,8 @@
       "xloc": [
         "default.handlebars->121->1039",
         "default3.handlebars->123->1031"
-      ]
+      ],
+      "zh-chs": "运行"
     },
     {
       "ca": "Executeu registres d'ordres",
@@ -67795,7 +67889,8 @@
       "xloc": [
         "default.handlebars->121->1499",
         "default3.handlebars->123->1490"
-      ]
+      ],
+      "zh-chs": "第二次失败"
     },
     {
       "bs": "Sigurna prijava",
@@ -68644,7 +68739,7 @@
       "sv": "Skicka epost",
       "tr": "Eposta gönder",
       "uk": "Надіслати е-пошту",
-      "zh-chs": "发电邮",
+      "zh-chs": "发电子邮件",
       "zh-cht": "發電郵",
       "xloc": [
         "default.handlebars->121->2901",
@@ -68726,7 +68821,8 @@
       "xloc": [
         "default.handlebars->121->2899",
         "default3.handlebars->123->2903"
-      ]
+      ],
+      "zh-chs": "发送消息"
     },
     {
       "bs": "Pošalji obavijest",
@@ -68840,7 +68936,7 @@
       "sv": "Skicka ett e-postmeddelande till den här användaren",
       "tr": "Bu kullanıcıya bir e-posta mesajı gönder",
       "uk": "Надіслати електронного листа цьому користувачеві",
-      "zh-chs": "发送电邮给该用户",
+      "zh-chs": "发送电子邮件给该用户",
       "zh-cht": "發送電郵給該用戶",
       "xloc": [
         "default.handlebars->121->3142",
@@ -68860,7 +68956,8 @@
       "xloc": [
         "default.handlebars->121->3140",
         "default3.handlebars->123->3142"
-      ]
+      ],
+      "zh-chs": "向此用户发送消息"
     },
     {
       "bs": "Pošaljite obavještenje svim korisnicima u ovoj grupi.",
@@ -68945,7 +69042,7 @@
       "sv": "Skicka e-post till användaren",
       "tr": "Kullanıcıya e-posta gönder",
       "uk": "Надіслати електронний лист користувачеві",
-      "zh-chs": "发送电邮给用户",
+      "zh-chs": "发送电子邮件给用户",
       "zh-cht": "發送電郵給用戶",
       "xloc": [
         "default.handlebars->121->2880",
@@ -68975,7 +69072,7 @@
       "sv": "Skicka installationslänk",
       "tr": "Kurulum bağlantısını gönder",
       "uk": "Надіслати лінк для інсталювання",
-      "zh-chs": "发送安装连结",
+      "zh-chs": "发送安装链接",
       "zh-cht": "發送安裝鏈結",
       "xloc": [
         "default.handlebars->121->587",
@@ -69465,7 +69562,8 @@
         "default.handlebars->121->2285",
         "default3.handlebars->123->220",
         "default3.handlebars->123->221"
-      ]
+      ],
+      "zh-chs": "服务器配置"
     },
     {
       "bs": "Povezivanje servera",
@@ -69564,7 +69662,7 @@
       "sv": "Serverfiler",
       "tr": "Sunucu Dosyaları",
       "uk": "Файли Сервера",
-      "zh-chs": "服务器档案",
+      "zh-chs": "服务器文件",
       "zh-cht": "伺服器檔案",
       "xloc": [
         "default-mobile.handlebars->55->1040",
@@ -69875,7 +69973,7 @@
       "sv": "Serverspårning",
       "tr": "Sunucu İzleme",
       "uk": "Моніторинг сервера",
-      "zh-chs": "服务器跟踪",
+      "zh-chs": "服务器追踪",
       "zh-cht": "伺服器追蹤",
       "xloc": [
         "default.handlebars->121->3547",
@@ -69905,7 +70003,7 @@
       "sv": "Serverspårningshändelse",
       "tr": "Sunucu İzleme Etkinliği",
       "uk": "Подія трасування сервера",
-      "zh-chs": "服务器跟踪事件",
+      "zh-chs": "服务器追踪事件",
       "zh-cht": "服務器跟踪事件",
       "xloc": [
         "default.handlebars->121->3525",
@@ -70116,7 +70214,7 @@
       "sv": "Val av serverfil",
       "tr": "Sunucu dosyası seçimi",
       "uk": "Вибір файлів сервера",
-      "zh-chs": "服务器档案选择",
+      "zh-chs": "服务器文件选择",
       "zh-cht": "伺服器檔案選擇",
       "xloc": [
         "default-mobile.handlebars->dialog->3->dialog4->d3upload->d3uploadMode->3",
@@ -70249,7 +70347,8 @@
       "xloc": [
         "default.handlebars->121->3387",
         "default3.handlebars->123->3385"
-      ]
+      ],
+      "zh-chs": "服务器统计记录"
     },
     {
       "bs": "Server na održavanju.",
@@ -70890,7 +70989,7 @@
       "sv": "Inställningsfil",
       "tr": "Ayarlar Dosyası",
       "uk": "Файл налаштувань",
-      "zh-chs": "设定档案",
+      "zh-chs": "设定文件",
       "zh-cht": "設定檔案",
       "xloc": [
         "default.handlebars->121->661",
@@ -71116,7 +71215,7 @@
       "sv": "Dela en fil",
       "tr": "Dosya paylaşın",
       "uk": "Поширити файлом",
-      "zh-chs": "共享档案",
+      "zh-chs": "共享文件",
       "zh-cht": "共享檔案",
       "xloc": [
         "messenger.handlebars->xtop->3"
@@ -71979,7 +72078,8 @@
       "xloc": [
         "default.handlebars->container->column_l->p6->p6info->p2ServerActions->3->p2ServerActionsConfig->1",
         "default3.handlebars->container->column_l->p6->p6info->p2ServerActions->3->p2ServerActionsConfig->2"
-      ]
+      ],
+      "zh-chs": "显示服务器配置"
     },
     {
       "bs": "Prikaži dnevnik grešaka servera",
@@ -72294,7 +72394,8 @@
         "default.handlebars->121->3172",
         "default3.handlebars->123->1906",
         "default3.handlebars->123->3174"
-      ]
+      ],
+      "zh-chs": "Signal"
     },
     {
       "bs": "Verzija potpisa",
@@ -72727,7 +72828,8 @@
         "default.handlebars->121->3168",
         "default3.handlebars->123->1902",
         "default3.handlebars->123->3170"
-      ]
+      ],
+      "zh-chs": "Slack"
     },
     {
       "ca": "Configuració de Slack Webhook",
@@ -75488,7 +75590,8 @@
       "xloc": [
         "default.handlebars->121->1500",
         "default3.handlebars->123->1491"
-      ]
+      ],
+      "zh-chs": "后续失败"
     },
     {
       "bs": "Uspješna prijava",
@@ -76744,7 +76847,8 @@
         "default3.handlebars->123->1909",
         "default3.handlebars->123->3163",
         "default3.handlebars->123->3177"
-      ]
+      ],
+      "zh-chs": "Telegram"
     },
     {
       "bs": "Teluga",
@@ -77443,7 +77547,7 @@
       "sv": "Dessa filer delas offentligt, klicka på \"länk\" för att få offentlig webbadress.",
       "tr": "Bu dosyalar herkese açık olarak paylaşılır, genel url almak için \"bağlantı\" yı tıklayın.",
       "uk": "Ці файли доступні для всіх, клікніть \"посилання\", щоб отримати публічну URL-адресу.",
-      "zh-chs": "这些档案是公开共享的，请单击“连结”以获取公用URL。",
+      "zh-chs": "这些文件是公开共享的，请单击“链接”以获取公用URL。",
       "zh-cht": "這些檔案是公開共享的，請單擊“鏈結”以獲取公用URL。",
       "xloc": [
         "default.handlebars->container->column_l->p5->p5filetable->p5PublicShare->0",
@@ -77653,7 +77757,7 @@
       "sv": "Detta är en gästdelningssession",
       "tr": "Bu bir misafir paylaşım oturumu",
       "uk": "Це гостьовий сеанс спільного доступу",
-      "zh-chs": "这是嘉宾分享环节",
+      "zh-chs": "这是一个访客共享会话",
       "zh-cht": "這是一個嘉賓分享會",
       "xloc": [
         "default.handlebars->121->1620",
@@ -78348,7 +78452,7 @@
       "sv": "För att lägga till en ny dator i enhetsgruppen \\\"{0}\\\", ladda ner nätagenten och installera den för hantering av datorn. Den här agenten har server- och enhetsgruppinformation inbäddad.",
       "tr": "\\\"{0}\\\" cihaz grubuna yeni bir bilgisayar eklemek için Mesh Agent indirin ve yönetilecek bilgisayara kurun. Bu agent, içinde gömülü sunucu ve cihaz grubu bilgilerine sahiptir.",
       "uk": "Щоб додати новий комп'ютер до групи пристроїв \\\"{0}\\\", завантажте MeshAgent й інсталюйте його на комп'ютері, яким хочете керувати. Завантажений агент міститиме у собі інформацію про цільовий сервер та групу пристроїв.",
-      "zh-chs": "要将新计算机添加到设备组“ {0} ”，请下载网状代理并安装该计算机以进行管理。这代理中已嵌入了服务器和设备组信息。",
+      "zh-chs": "要将新计算机添加到设备组“ {0} ”，请下载Mesh Agent并安装该计算机以进行管理。这代理中已嵌入了服务器和设备组信息。",
       "zh-cht": "要將新電腦新增到裝置群“ {0} ”，請下載mesh agent並安裝該電腦以進行管理。這agent中已嵌入了伺服器和裝置群訊息。",
       "xloc": [
         "default.handlebars->121->648",
@@ -78378,7 +78482,7 @@
       "sv": "För att lägga till en ny dator i enhetsgruppen \\\"{0}\\\", ladda ner nätagenten och installera den för hantering av datorn. Det här agentinstallatören har server- och enhetsgruppinformation inbäddad.",
       "tr": "\\\"{0}\\\" cihaz grubuna yeni bir bilgisayar eklemek için Mesh Agent indirin ve yönetilecek bilgisayara kurun. Bu agent yükleyicinin içinde gömülü sunucu ve cihaz grubu bilgileri vardır.",
       "uk": "Щоб додати новий комп'ютер до групи пристроїв \\\"{0}\\\", завантажте MeshAgent й інсталюйте його на комп'ютері, яким ви хочете керувати. Цей інсталяційний агент містить інформацію про сервер та групу пристроїв.",
-      "zh-chs": "要将新计算机添加到设备组“ {0} ”，请下载网状代理并安装该计算机以进行管理。该代理安装程序中已嵌入了服务器和设备组讯息。",
+      "zh-chs": "要将新计算机添加到设备组“ {0} ”，请下载Mesh Agent并安装该计算机以进行管理。该代理安装程序中已嵌入了服务器和设备组讯息。",
       "zh-cht": "要將新電腦新增到裝置群“ {0} ”，請下載mesh agent並安裝該電腦以進行管理。該代理安裝程序中已嵌入了伺服器和裝置群訊息。",
       "xloc": [
         "default.handlebars->121->667",
@@ -78762,7 +78866,7 @@
       "sv": "Toastmeddelande",
       "tr": "Tost Bildirimi",
       "uk": "Висувне Сповіщення",
-      "zh-chs": "吐司通知",
+      "zh-chs": "弹出通知",
       "zh-cht": "吐司通知",
       "xloc": [
         "default.handlebars->121->1212",
@@ -79333,7 +79437,7 @@
       "sv": "Tecken",
       "tr": "Anahtar",
       "uk": "Токен",
-      "zh-chs": "代币",
+      "zh-chs": "令牌",
       "zh-cht": "代幣",
       "xloc": [
         "login2.handlebars->centralTable->1->0->logincell->resettokenpanel->resettokenpanelform->5->1->0->1",
@@ -80347,7 +80451,7 @@
       "sv": "Det går inte att komma åt enheten förrän e-postadressen har verifierats. Detta krävs för återställning av lösenord. Gå till \\\"Mitt konto \\\" för att ändra och verifiera e-postadressen.",
       "tr": "Bir e-posta adresi doğrulanana kadar bir cihaza erişilemiyor. Bu, şifre kurtarma için gereklidir. Bir e-posta adresini değiştirmek ve doğrulamak için \\\"Hesabım\\\" a gidin.",
       "uk": "До пристрою неможливо отримати доступ, доки не буде підтверджено адресу е-пошти. Це потрібно для відновлення пароля. Перейдіть до \\\"Мій акаунт\\\", щоб змінити та підтвердити адресу е-пошти.",
-      "zh-chs": "在验证电邮地址之前，无法访问设备。这是密码恢复所必需的。转到“我的帐户”以更改并验证电邮地址。",
+      "zh-chs": "在验证电子邮件地址之前，无法访问设备。这是密码恢复所必需的。转到“我的帐户”以更改并验证电子邮件地址。",
       "zh-cht": "在驗證電郵地址之前，無法訪問裝置。這是密碼恢復所必需的。轉到“我的帳戶”以更改並驗證電郵地址。",
       "xloc": [
         "default-mobile.handlebars->55->348",
@@ -82146,7 +82250,7 @@
       "sv": "Ladda upp en kärnfil",
       "tr": "Çekirdek dosya gönder",
       "uk": "Відправити файл ядра",
-      "zh-chs": "上载核心档案",
+      "zh-chs": "上载核心文件",
       "zh-cht": "上載核心檔案",
       "xloc": [
         "default-mobile.handlebars->55->981",
@@ -82908,7 +83012,7 @@
       "sv": "Begagnade",
       "tr": "Kullanılmış",
       "uk": "Використаний",
-      "zh-chs": "用过的",
+      "zh-chs": "已使用",
       "zh-cht": "用過的",
       "xloc": [
         "default.handlebars->121->3458",
@@ -82996,7 +83100,7 @@
       "sv": "Användare + filer",
       "tr": "Kullanıcı + Dosyalar",
       "uk": "Користувач + Файли",
-      "zh-chs": "用户+档案",
+      "zh-chs": "用户+文件",
       "zh-cht": "用戶+檔案",
       "xloc": [
         "default.handlebars->121->2874",
@@ -83089,7 +83193,8 @@
       "xloc": [
         "default.handlebars->121->3541",
         "default3.handlebars->123->3539"
-      ]
+      ],
+      "zh-chs": "用户认证日志"
     },
     {
       "bs": "Autorizacije korisnika",
@@ -84100,7 +84205,8 @@
       "xloc": [
         "default.handlebars->121->3378",
         "default3.handlebars->123->3376"
-      ]
+      ],
+      "zh-chs": "用户记录"
     },
     {
       "bs": "Korisnik {0} nije pronađen.",
@@ -84685,7 +84791,7 @@
       "sv": "Validera email",
       "tr": "E-postayı Doğrula",
       "uk": "Перевірка електронної пошти",
-      "zh-chs": "验证电邮",
+      "zh-chs": "验证电子邮件",
       "zh-cht": "驗證電郵",
       "xloc": [
         "default.handlebars->121->2887",
@@ -84776,7 +84882,7 @@
       "sv": "Värde",
       "tr": "Değer",
       "uk": "Значення",
-      "zh-chs": "价值",
+      "zh-chs": "值",
       "zh-cht": "價值",
       "xloc": [
         "default.handlebars->121->1466",
@@ -84941,7 +85047,7 @@
       "sv": "Verifierad e-post {0} för användarkonto {1}.",
       "tr": "{1} kullanıcı hesabı için {0} doğrulanmış e-posta.",
       "uk": "Верифікована е-пошта {0} для акаунту користувача {1}.",
-      "zh-chs": "用户帐户{1}的已验证电邮{0}。",
+      "zh-chs": "用户帐户{1}的已验证电子邮件{0}。",
       "zh-cht": "用戶帳戶{1}的已驗證電郵{0}。",
       "xloc": [
         "message.handlebars->9->10",
@@ -85079,7 +85185,7 @@
       "sv": "Verifiera Email",
       "tr": "E-mail'i doğrula",
       "uk": "Підтвердити е-пошту",
-      "zh-chs": "验证电邮",
+      "zh-chs": "验证电子邮件",
       "zh-cht": "驗證電郵",
       "xloc": [
         "default.handlebars->container->footer->3->verifyEmailId2",
@@ -85109,7 +85215,7 @@
       "sv": "Verifiera Email",
       "tr": "E-mail'i doğrula",
       "uk": "Підтвердити е-пошту",
-      "zh-chs": "验证电邮",
+      "zh-chs": "验证电子邮件",
       "zh-cht": "驗證電郵",
       "xloc": [
         "default-mobile.handlebars->container->page_content->column_l->p3->p3info->3->p3AccountActions->p2AccountActions->3->5->verifyEmailId->0",
@@ -85253,7 +85359,7 @@
       "sv": "Vibrera",
       "tr": "Titreşim",
       "uk": "Вібрувати",
-      "zh-chs": "颤动",
+      "zh-chs": "振动",
       "zh-cht": "顫動",
       "xloc": [
         "default-mobile.handlebars->55->571",
@@ -85316,7 +85422,7 @@
       "sv": "Se",
       "tr": "Görünüm",
       "uk": "Вигляд",
-      "zh-chs": "检视",
+      "zh-chs": "查看",
       "zh-cht": "檢視",
       "xloc": [
         "default.handlebars->container->column_l->p1->devListToolbarSpan->1->0->9->devListToolbarView",
@@ -86570,7 +86676,7 @@
       "sv": "När det är aktiverat kan inbjudningskoder användas av vem som helst för att ansluta enheter till den här enhetsgruppen med följande offentliga länk:",
       "tr": "Etkinleştirildiğinde, davet kodları herkes tarafından aşağıdaki genel bağlantı kullanılarak bu cihaz grubuna cihazlara katılmak için kullanılabilir:",
       "uk": "Коли ввімкнено, будь-хто може використовувати коди виклику, щоб приєднати пристрій до цієї групи пристроїв за допомогою такого публічного посилання:",
-      "zh-chs": "启用后，任何人都可以使用邀请代码通过以下公共连结将设备加入该设备组：",
+      "zh-chs": "启用后，任何人都可以使用邀请代码通过以下公共链接将设备加入该设备组：",
       "zh-cht": "啟用後，任何人都可以使用邀請代碼通過以下公共鏈結將裝置加入該裝置群：",
       "xloc": [
         "default.handlebars->121->2551",
@@ -86600,7 +86706,7 @@
       "sv": "När det är aktiverat får du vid varje inloggning möjlighet att få en inloggningstoken till ditt e-postkonto för ökad säkerhet.",
       "tr": "Etkinleştirildiğinde, her girişte, ek güvenlik için e-posta hesabınıza bir giriş anahtarı alma seçeneği verilecektir.",
       "uk": "Якщо увімкнено, то під час кожного входу ви матимете можливість отримати токен входу для вашого акаунту електронною поштою для додаткової безпеки.",
-      "zh-chs": "启用后，每次登录时，您都可以选择向电邮帐户接收登录保安编码，以提高安全性。",
+      "zh-chs": "启用后，每次登录时，您都可以选择向电子邮件帐户接收登录保安编码，以提高安全性。",
       "zh-cht": "啟用後，每次登入時，你都可以選擇向電郵帳戶接收登入保安編碼，以提高安全性。",
       "xloc": [
         "default-mobile.handlebars->55->118",
@@ -87408,7 +87514,8 @@
         "default-mobile.handlebars->55->779",
         "default.handlebars->121->969",
         "default3.handlebars->123->961"
-      ]
+      ],
+      "zh-chs": "Windows Defender"
     },
     {
       "ca": "Firewall de Windows",
@@ -87420,7 +87527,8 @@
         "default.handlebars->121->413",
         "default3.handlebars->123->364",
         "default3.handlebars->123->405"
-      ]
+      ],
+      "zh-chs": "Windows 防火墙"
     },
     {
       "bs": "Windows MeshAgent",
@@ -87619,7 +87727,8 @@
         "default.handlebars->121->412",
         "default3.handlebars->123->363",
         "default3.handlebars->123->404"
-      ]
+      ],
+      "zh-chs": "Windows 更新"
     },
     {
       "bs": "Samo Windows",
@@ -88092,7 +88201,8 @@
         "default3.handlebars->123->1727",
         "default3.handlebars->123->1745",
         "default3.handlebars->123->1750"
-      ]
+      ],
+      "zh-chs": "是"
     },
     {
       "en": "Yeti",
@@ -88500,7 +88610,8 @@
         "default.handlebars->121->3167",
         "default3.handlebars->123->1901",
         "default3.handlebars->123->3169"
-      ]
+      ],
+      "zh-chs": "Zulip"
     },
     {
       "bs": "Zulu",
@@ -89689,7 +89800,7 @@
       "sv": "data: image / png; base64,",
       "tr": "veri: resim / png; base64,",
       "uk": "дані:зображення/png;base64,",
-      "zh-chs": "data：image / png; base64，",
+      "zh-chs": "data:image/png;base64,",
       "zh-cht": "data：image / png; base64，",
       "xloc": [
         "player.handlebars->31->48"
@@ -90298,7 +90409,7 @@
       "sv": "begär återställning av kontolösenord, klicka på följande länk för att slutföra processen.",
       "tr": "bir hesap şifresi sıfırlama talep ediyor, işlemi tamamlamak için aşağıdaki bağlantıya tıklayın.",
       "uk": "надсилаючи запит на скидання пароля акаунту, клікніть на це посилання, щоб завершити процес.",
-      "zh-chs": "正在要求重置帐户密码，请单击以下连结以完成该过程。",
+      "zh-chs": "正在要求重置帐户密码，请单击以下链接以完成该过程。",
       "zh-cht": "正在要求重置帳戶密碼，請單擊以下鏈結以完成該過程。",
       "xloc": [
         "account-reset.html->2->3"
@@ -90327,7 +90438,7 @@
       "sv": "begär e-postverifiering, klicka på följande länk för att slutföra processen.",
       "tr": "e-posta doğrulaması istiyorsa, işlemi tamamlamak için aşağıdaki bağlantıya tıklayın.",
       "uk": "потребує підтвердження електронної пошти, натисність на посилання нижче, щоб завершити процес.",
-      "zh-chs": "正在请求电邮验证，请单击以下连结以完成该过程。",
+      "zh-chs": "正在请求电子邮件验证，请单击以下链接以完成该过程。",
       "zh-cht": "正在請求電郵驗證，請單擊以下鏈結以完成該過程。",
       "xloc": [
         "account-check.html->2->3"
@@ -90721,7 +90832,7 @@
       "sv": "opera",
       "tr": "opera",
       "uk": "Опера",
-      "zh-chs": "歌剧",
+      "zh-chs": "Opera",
       "zh-cht": "歌劇",
       "xloc": [
         "player.handlebars->31->6"
@@ -90809,7 +90920,7 @@
       "sv": "eller ett kompatibelt program och skanna streckkoden, använd <a href=\\\"{0}\\\" rel=\\\"noreferrer noopener\\\" target=_blank> den här länken </a> eller skriv hemligheten. Ange sedan den aktuella 6-siffriga token nedan för att aktivera 2-stegsinloggning.",
       "tr": "veya uyumlu bir uygulama ve barkodu tarayın, <a href=\\\"{0}\\\" rel=\\\"noreferrer noopener\\\" target=_blank> bu bağlantıyı </a> kullanın veya şifreyi girin. Ardından, 2 Adımlı girişi etkinleştirmek için mevcut 6 haneli anahtarı girin.",
       "uk": "або сумісну програму та відскануйте QR-код, скориставшись <a href=\\\"{0}\\\" rel=\\\"noreferrer noopener\\\" target=_blank>цим посилання</a> або введіть цей секретний код вручну. Потім введіть поточний 6-значний токен, щоб активувати двофакторний вхід.",
-      "zh-chs": "或兼容的应用软件并扫描条码，使用<a href=\\\"{0}\\\" rel=\\\"noreferrer noopener\\\" target=_blank>此连结</a>或输入密码。然后，在下面输入当前的6位数保安编码以激活两步登录。",
+      "zh-chs": "或兼容的应用软件并扫描条码，使用<a href=\\\"{0}\\\" rel=\\\"noreferrer noopener\\\" target=_blank>此链接</a>或输入密码。然后，在下面输入当前的6位数保安编码以激活两步登录。",
       "zh-cht": "或兼容的應用軟體並掃描條碼，使用<a href=\\\"{0}\\\" rel=\\\"noreferrer noopener\\\" target=_blank>此鏈結</a>或輸入密碼。然後，在下面輸入當前的6位數保安編碼以啟動兩步登入。",
       "xloc": [
         "default.handlebars->121->234",
@@ -90839,7 +90950,7 @@
       "sv": "eller ett kompatibelt program, använd <a href=\\\"{0}\\\" rel=\\\"noreferrer noopener\\\" target=_blank> den här länken </a> eller skriv hemligheten nedan. Ange sedan den aktuella 6-siffriga token för att aktivera 2-stegsinloggning.",
       "tr": "veya uyumlu bir uygulama için <a href=\\\"{0}\\\" rel=\\\"noreferrer noopener\\\" target=_blank> bu bağlantıyı </a> kullanın veya aşağıdaki şifreyi girin. Ardından, 2 Adımlı oturum açma özelliğini etkinleştirmek için mevcut 6 basamaklı anahtarı girin.",
       "uk": "або сумісну програму, та використайте <a href=\\\"{0}\\\" rel=\\\"noreferrer noopener\\\" target=_blank> це посилання</a> або введіть секрет нижче. Потім введіть поточний 6-значний токен, щоб активувати двофакторний вхід.",
-      "zh-chs": "或兼容的应用软件，请使用<a href=\\\"{0}\\\" rel=\\\"noreferrer noopener\\\" target=_blank>此连结</a>或在下面输入密码。然后，输入当前的6位数保安编码以激活两步登录。",
+      "zh-chs": "或兼容的应用软件，请使用<a href=\\\"{0}\\\" rel=\\\"noreferrer noopener\\\" target=_blank>此链接</a>或在下面输入密码。然后，输入当前的6位数保安编码以激活两步登录。",
       "zh-cht": "或兼容的應用軟體，請使用<a href=\\\"{0}\\\" rel=\\\"noreferrer noopener\\\" target=_blank>此鏈結</a>或在下面輸入密碼。然後，輸入當前的6位數保安編碼以啟動兩步登入。",
       "xloc": [
         "default-mobile.handlebars->55->79"
@@ -91003,7 +91114,8 @@
         "default.handlebars->121->1509",
         "default3.handlebars->123->1496",
         "default3.handlebars->123->1498"
-      ]
+      ],
+      "zh-chs": "service_"
     },
     {
       "bs": "ovo će izbrisati postojeće serverske podatke.",
@@ -91165,7 +91277,7 @@
       "sv": "treudd",
       "tr": "trident",
       "uk": "тризуб",
-      "zh-chs": "三叉戟",
+      "zh-chs": "Trident",
       "zh-cht": "三叉戟",
       "xloc": [
         "player.handlebars->31->9"
@@ -91899,7 +92011,7 @@
       "sv": "{0} timmar",
       "tr": "{0} saat",
       "uk": "{0} годин",
-      "zh-chs": "{0}小時",
+      "zh-chs": "{0}小时",
       "zh-cht": "{0}小時",
       "xloc": [
         "default.handlebars->121->297",
@@ -92550,7 +92662,7 @@
       "sv": "{0} sessioner",
       "tr": "{0} oturum",
       "uk": "{0} сеанс",
-      "zh-chs": "{0}节",
+      "zh-chs": "{0}个会话",
       "zh-cht": "{0}節",
       "xloc": [
         "default-mobile.handlebars->55->411",
@@ -92996,7 +93108,7 @@
       "sv": "{0} k i en fil. {1} k maximalt",
       "tr": "1 dosyada {0} k. {1} k maksimum",
       "uk": "{0}кБ у 1 файлу. {1}кБ максимум",
-      "zh-chs": "{0}k在1档案内。最多{1}k",
+      "zh-chs": "{0}k在1文件内。最多{1}k",
       "zh-cht": "{0}k在1檔案內。最多{1}k",
       "xloc": [
         "default.handlebars->121->2634",


### PR DESCRIPTION
## Summary

Comprehensive improvement of Simplified Chinese (zh-chs) translations in `translate/translate.json`.

**Stats:** 145 existing translations fixed + 112 missing translations added = 257 total changes (365 insertions / 253 deletions).

## ⚠️ AI-Generated Content Disclaimer

**This translation was generated using [QwenPaw](https://github.com/agentscope-ai/QwenPaw) + MiMo-v2.5-pro AI assistant. It was not written by a human.** Translations were programmatically validated against the MeshCentral source code for consistency, but may contain errors. Please review carefully before merging.

## Changes

### 1. Critical mistranslations fixed (20 items)

These were severely wrong translations that could confuse users or break functionality:

| English | Before | After |
|---------|--------|-------|
| Help | 救命 (SOS!) | 帮助 |
| Home | 家 (family home) | 主页 |
| Token | 代币 (crypto token) | 令牌 |
| Toast Notification | 吐司通知 (🍞 bread) | 弹出通知 |
| Manager | 经理 (job title) | 管理器 |
| Remote Control | 遥控 (TV remote) | 远程控制 |
| Raw | 生的 (uncooked food) | 原始 |
| Real Name | 真正的名字 | 真实姓名 |
| Discharging | 出院 (hospital) | 放电中 |
| Discharge Rate | 出院率 | 放电率 |
| Charge Rate | 收费率 | 充电速率 |
| Value | 价值 (monetary worth) | 值 |
| Used | 用过的 (second-hand) | 已使用 |
| Vibrate | 颤动 | 振动 |
| View | 检视 | 查看 |
| Rate | 率 | 速率 |
| No Remote Control | 没有遥控器 | 无远程控制 |
| Frame rate | 贞速率 (wrong char) | 帧速率 |
| Health | 健康 | 运行状况 |
| Megabytes | Megabyte (untranslated) | 兆字节 |

### 2. Browser UA detection strings — must not be translated (2 items)

| English | Before | After |
|---------|--------|-------|
| opera | 歌剧 | Opera |
| trident | 三叉戟 | Trident |

### 3. Product name corrections (3 items)

| English | Before | After |
|---------|--------|-------|
| MeshCentral | 网格中心 | MeshCentral |
| Mesh Relay | 网格中继 | Mesh 中继 |
| MeshCentral Router | MeshCentral路由器 | MeshCentral Router |

### 4. Device power commands (7 items)

| English | Before | After |
|---------|--------|-------|
| Reset | 重设 | 重启 |
| Reset / Power Off | 重置/关闭电源 | 重启/关机 |
| Reset/Off | 重置/关闭 | 重启/关机 |
| No Reset/Off | 无重置/关闭 | 禁止重启/关机 |
| Restart | 重新启动 | 重启 |
| Intel® AMT Reset to BIOS/PXE | AMT 重置... | AMT 重启... |
| Perform Intel® AMT reset? | 执行...重置？ | 执行...重启？ |

### 5. Semantic errors fixed (12 items)

| English | Before | After | Reason |
|---------|--------|-------|--------|
| Record Sessions | 记录会议 | 录制会话 | sessions ≠ 会议 |
| Recordings | 录音 | 录制记录 | screen recording, not audio |
| Guest Share/Sharing | 嘉宾分享 | 访客共享 | Guest = 访客 |
| Active Device Sharing | 主动设备共享 | 活动设备共享 | active ≠ 主动 |
| Add Device Event | 添加设备日志 | 添加设备事件 | event = 事件 |
| 1 session / {0} sessions | 1节 / {0}节 | 1个会话 | session = 会话 |
| General (tab) | 一般 | 常规 | standard UI term |
| Rename | 改名 | 重命名 | standard UI term |

### 6. Shell mistranslated as 外壳 (4 items)

| English | Before | After |
|---------|--------|-------|
| Ask Admin Shell | 询问管理员外壳 | 请求管理员终端 |
| Ask User Shell | 询问用户外壳 | 请求用户终端 |
| Linux/BSD/macOS Command Shell | 命令外壳 | 命令行 |

### 7. Traditional Chinese mixed into Simplified (~50 items)

| Traditional | Unified | Count |
|-------------|---------|-------|
| 档案 | 文件 | ~25 |
| 连结 | 链接 | ~12 |
| 小時 | 小时 | ~3 |
| 位址 | 地址 | ~2 |
| 电邮 | 电子邮件 | ~21 |
| 重设 | 重置 | ~6 |
| 网状代理 | Mesh Agent | ~3 |

### 8. Data URI incorrectly translated (1 item)

| Before | After |
|--------|-------|
| data：image / png; base64， | data:image/png;base64, |

### 9. Missing translations added (112 items)

Including: Server Configuration, Event Log, Security, Notifications, Device Events, Intel AMT controls, Message Services (Discord/Slack/Telegram/WhatsApp/Signal), File sorting, Windows components, and more.

## Testing

Verified on a live MeshCentral v1.2.0 Docker deployment (ghcr.io/ylianst/meshcentral:latest). All modified strings checked for:
- Correct `zh-chs` language tag (not `zh-cht`)
- Preserved `{0}`, `[[[PLACEHOLDER]]]` variables
- Preserved HTML entities (`&reg;`, `&amp;` etc.)
- Valid JSON structure