### PR TITLE
Fix push 2FA: replace 2fa:// scheme before URL parsing (Node 22)

### DIFF
--- a/meshagent.js
+++ b/meshagent.js
@@ -1669,8 +1669,9 @@ module.exports.CreateMeshAgent = function (parent, db, ws, req, args, domain) {
                     if ((typeof command.url != 'string') || (typeof command.approved != 'boolean') || (command.url.startsWith('2fa://') == false)) return;
 
                     // parse the URL
+                    // Node 22's WHATWG URL parser rejects custom schemes like 2fa://, so swap to https:// for parsing only.
                     var url = null;
-                    try { url = new URL(command.url); } catch (ex) { }
+                    try { url = new URL(command.url.replace(/^2fa:\/\//, 'https://')); } catch (ex) { }
                     if (url == null) return;
 
                     // Decode the cookie


### PR DESCRIPTION
## Problem

On Node 22, the push 2FA flow ("Login Verification" notification sent to the mobile MeshCentral Agent app) fails silently. The notification arrives at the phone, the user taps ACCEPT, but the web session never completes the login. No error appears in `mesherrors.txt` or the systemd journal.

The same symptom shows up during initial enrollment of a mobile device via *My Account → Manage authentication push*.

## Root cause

`meshagent.js` line 1673, inside `case '2faauth'`, calls:

```js
try { url = new URL(command.url); } catch (ex) { }
if (url == null) return;
```

…where `command.url` is `2fa://auth?code=<base64>&c=<encoded-cookie>`.

Node 22's WHATWG URL parser is stricter than v18/v20 and rejects custom (non-special) schemes such as `2fa://`, throwing `TypeError: Invalid URL`. The empty `catch` swallows the exception, `url` stays `null`, and the handler returns silently. The accept response from the mobile agent is therefore never validated.

```
> new URL("2fa://auth?code=abc&c=test")
Uncaught TypeError: Invalid URL
```

## Fix

Swap the `2fa://` scheme for `https://` only for the purpose of parsing. The original `command.url` is still validated with `startsWith('2fa://')` on the line above, and the only downstream consumer is `url.search.slice(1).split('&c=')`, which is unaffected by the scheme.

```js
try { url = new URL(command.url.replace(/^2fa:\/\//, 'https://')); } catch (ex) { }
```

One-line change plus an inline comment.

## Reproduce

1. MeshCentral 1.2.1 on Node v22.x.
2. Enable `PublicPushNotifications: true` and register a mobile device under My Account → Push 2FA.
3. Log out, log in, click the phone icon on the Token screen.
4. **Before the patch:** the notification arrives at the phone, ACCEPT does nothing, the browser stays on "Solicitud enviada / Request sent" forever and eventually times out.
5. **After the patch:** ACCEPT immediately completes the login.

Verified end-to-end for both `action: 'addAuth'` (enrollment) and `action: 'checkAuth'` (login) flows.

## Tested on

- Node v22.11.0
- Ubuntu 22.04.5 LTS
- MeshCentral 1.2.1
- Android MeshCentral Agent v1.0.21