### PR TITLE
Fix crash on SMTP/SendGrid failure due to circular JSON.stringify

### DIFF
--- a/meshmail.js
+++ b/meshmail.js
@@ -31,6 +31,10 @@ module.exports.CreateMeshMail = function (parent, domain) {
     const sortCollator = new Intl.Collator(undefined, { numeric: true, sensitivity: 'base' })
     const constants = (obj.parent.crypto.constants ? obj.parent.crypto.constants : require('constants')); // require('constants') is deprecated in Node 11.10, use require('crypto').constants instead.
 
+    // Safe JSON stringify resistant to circular references.
+    // Node TLS errors (e.g. SMTP cert mismatch) include the certificate chain, where each X509 cert has an 'issuerCertificate' field pointing back at its issuer, closing the cycle. Plain JSON.stringify throws "Converting circular structure to JSON" and crashes the server. This helper drops cert-related fields and tracks seen objects via a WeakSet.
+    function safeStringify(o) { try { const seen = new WeakSet(); return JSON.stringify(o, function (k, v) { if (typeof v === 'object' && v !== null) { if (seen.has(v)) return '[Circular]'; seen.add(v); } if (k === 'issuerCertificate' || k === 'cert' || k === 'raw') return '[Cert]'; return v; }); } catch (ex) { return '[stringify-error: ' + ex.message + ']'; } }
+
     function EscapeHtml(x) { if (typeof x == 'string') return x.replace(/&/g, '&amp;').replace(/>/g, '&gt;').replace(/</g, '&lt;').replace(/"/g, '&quot;').replace(/'/g, '&apos;'); if (typeof x == "boolean") return x; if (typeof x == "number") return x; }
     //function EscapeHtmlBreaks(x) { if (typeof x == "string") return x.replace(/&/g, '&amp;').replace(/>/g, '&gt;').replace(/</g, '&lt;').replace(/"/g, '&quot;').replace(/'/g, '&apos;').replace(/\r/g, '<br />').replace(/\n/g, '').replace(/\t/g, '&nbsp;&nbsp;'); if (typeof x == "boolean") return x; if (typeof x == "number") return x; }
 
@@ -488,15 +492,15 @@ module.exports.CreateMeshMail = function (parent, domain) {
                     sendNextMail();
                 }, function (error) {
                     obj.sendingMail = false;
-                    parent.debug('email', 'SendGrid sending error: ' + JSON.stringify(error));
+                    parent.debug('email', 'SendGrid sending error: ' + safeStringify(error));
                     obj.retry++;
                     // Wait and try again
                     if (obj.retry < 3) {
                         setTimeout(sendNextMail, 10000);
                     } else {
                         // Failed, send the next mail
-                        parent.debug('email', 'SendGrid server failed (Skipping): ' + JSON.stringify(err));
-                        console.log('SendGrid server failed (Skipping): ' + JSON.stringify(err));
+                        parent.debug('email', 'SendGrid server failed (Skipping): ' + safeStringify(err));
+                        console.log('SendGrid server failed (Skipping): ' + safeStringify(err));
                         obj.pendingMails.shift();
                         obj.retry = 0;
                         sendNextMail();
@@ -516,7 +520,7 @@ module.exports.CreateMeshMail = function (parent, domain) {
             } else {
                 // SMTP send
                 obj.smtpServer.sendMail(mailToSend, function (err, info) {
-                    parent.debug('email', 'SMTP response: ' + JSON.stringify(err) + ', ' + JSON.stringify(info));
+                    parent.debug('email', 'SMTP response: ' + safeStringify(err) + ', ' + JSON.stringify(info));
                     obj.sendingMail = false;
                     if (err == null) {
                         // Send the next mail
@@ -525,15 +529,15 @@ module.exports.CreateMeshMail = function (parent, domain) {
                         sendNextMail();
                     } else {
                         obj.retry++;
-                        parent.debug('email', 'SMTP server failed (Retry:' + obj.retry + '): ' + JSON.stringify(err));
-                        console.log('SMTP server failed (Retry:' + obj.retry + '/3): ' + JSON.stringify(err));
+                        parent.debug('email', 'SMTP server failed (Retry:' + obj.retry + '): ' + safeStringify(err));
+                        console.log('SMTP server failed (Retry:' + obj.retry + '/3): ' + safeStringify(err));
                         // Wait and try again
                         if (obj.retry < 3) {
                             setTimeout(sendNextMail, 10000);
                         } else {
                             // Failed, send the next mail
-                            parent.debug('email', 'SMTP server failed (Skipping): ' + JSON.stringify(err));
-                            console.log('SMTP server failed (Skipping): ' + JSON.stringify(err));
+                            parent.debug('email', 'SMTP server failed (Skipping): ' + safeStringify(err));
+                            console.log('SMTP server failed (Skipping): ' + safeStringify(err));
                             obj.pendingMails.shift();
                             obj.retry = 0;
                             sendNextMail();
@@ -558,8 +562,8 @@ module.exports.CreateMeshMail = function (parent, domain) {
                 // Remove all non-object types from error to avoid a JSON stringify error.
                 var err2 = {};
                 for (var i in err) { if (typeof (err[i]) != 'object') { err2[i] = err[i]; } }
-                parent.debug('email', 'SMTP mail server ' + obj.config.smtp.host + ' failed: ' + JSON.stringify(err2));
-                console.log('SMTP mail server ' + obj.config.smtp.host + ' failed: ' + JSON.stringify(err2));
+                parent.debug('email', 'SMTP mail server ' + obj.config.smtp.host + ' failed: ' + safeStringify(err2));
+                console.log('SMTP mail server ' + obj.config.smtp.host + ' failed: ' + safeStringify(err2));
             }
         });
     };


### PR DESCRIPTION
## Problem

When SMTP delivery fails with a TLS error (typical cause: the host in `config.smtp.host` doesn't match the cert presented by the SMTP server), the whole MeshCentral process crashes with:

```
TypeError: Converting circular structure to JSON
    --- property 'issuerCertificate' closes the circle
    at JSON.stringify (<anonymous>)
    at /home/.../meshmail.js:519:68
```

systemd restarts the server 5 seconds later, but any in-flight request (a user clicking the "email me a token" 2FA option, for example) is lost, the browser shows an empty page or a "request expired" error, and the root cause is mysterious because the log message is gigantic.

## Root cause

`meshmail.js` calls `JSON.stringify(err)` on the error object returned by `nodemailer`. Recent Node releases attach the full Node TLS error to the SMTP failure, which carries the certificate chain. Each parsed X509 cert exposes an `issuerCertificate` field pointing at its parent cert, and the root cert's `issuerCertificate` is itself, closing the cycle. `JSON.stringify` cannot serialize that and throws.

The behaviour is harder to spot in older Node versions because the error shape was different.

## Fix

Add a small `safeStringify(o)` helper at the top of the module that:

- Uses a `WeakSet` to detect already-seen objects and replace them with `'[Circular]'`.
- Drops the heavy `issuerCertificate`, `cert` and `raw` fields with `'[Cert]'` (they're not useful for diagnostics here and make the log enormous).
- Wraps everything in a `try/catch` so a failure here can never bring down the server, returning `'[stringify-error: …]'` instead.

All nine `JSON.stringify(err...)` / `JSON.stringify(err2)` / `JSON.stringify(error)` call sites in `meshmail.js` are routed through it. Behaviour on the success path is unchanged (no errors are serialized).

## Reproduce

1. Configure SMTP with `host` pointing at a server whose certificate altnames do not include that host (typical case: an alias/CNAME setup). For example, `host: "automatyco.com"` while the actual server presents a cert for `indatcom.mx`.
2. Trigger an email send (e.g. ask for an email 2FA token).
3. **Before the patch:** the process crashes with the circular-JSON `TypeError` and is restarted by systemd.
4. **After the patch:** the error is logged with `[Cert]` placeholders, MeshCentral keeps running, and the user just gets a "could not send email" response.

## Tested on

- Node v22.11.0
- Ubuntu 20.04 (LTS) and 22.04.5
- MeshCentral 1.2.1
- nodemailer 6.x (the version pinned by MeshCentral)