### PR TITLE
Continued implementation of probableMainLanIP

### DIFF
--- a/agents/meshcore.js
+++ b/agents/meshcore.js
@@ -7283,7 +7283,7 @@ function sendNetworkUpdate(force) {
 			try {
                 var probableMainLanIp = getProbableMainLanIp();
                 if (probableMainLanIp != null) {
-                    netInfo.probable_main_lan_ip = probableMainLanIp;
+                    netInfo.probableMainLanIp = probableMainLanIp;
                 }
             } catch (ex) { }
         } else if (process.platform == 'linux') {

--- a/meshagent.js
+++ b/meshagent.js
@@ -1304,6 +1304,10 @@ module.exports.CreateMeshAgent = function (parent, db, ws, req, args, domain) {
                         command.type = 'ifinfo';
                         db.Set(command);
 
+						if (typeof command.probableMainLanIP == 'string') {
+							ChangeAgentProbableMainLanIp(command.probableMainLanIP);
+						}
+
                         // Event the node interface information change
                         parent.parent.DispatchEvent(parent.CreateMeshDispatchTargets(obj.meshid, [obj.dbNodeKey]), obj, { action: 'ifchange', nodeid: obj.dbNodeKey, domain: domain.id, nolog: 1 });
 
@@ -2027,6 +2031,70 @@ module.exports.CreateMeshAgent = function (parent, db, ws, req, args, domain) {
             }
         });
     }
+
+	function ChangeAgentProbableMainLanIp(ip) {
+		if ((obj.agentInfo == null) || (obj.agentInfo.capabilities & 0x40)) return;
+		if ((typeof ip != 'string') || (ip.length > 64)) return;
+
+		// Very light sanity check. Keep this IPv4-only because the agent field is IPv4-only.
+		if (/^\d{1,3}(\.\d{1,3}){3}$/.test(ip) == false) return;
+
+		// Check that the mesh exists.
+		const mesh = parent.meshes[obj.dbMeshKey];
+		if (mesh == null) return;
+
+		// If the device is pending a change, hold.
+		if (obj.deviceChanging === true) {
+			setTimeout(function () { ChangeAgentProbableMainLanIp(ip); }, 100);
+			return;
+		}
+
+		obj.deviceChanging = true;
+
+		db.Get(obj.dbNodeKey, function (err, nodes) {
+			if ((nodes == null) || (nodes.length != 1)) {
+				delete obj.deviceChanging;
+				return;
+			}
+
+			const device = nodes[0];
+
+			if (device.agent) {
+				var change = 0;
+
+				if (device.probableMainLanIP != ip) {
+					device.probableMainLanIP = ip;
+					change = 1;
+				}
+
+				if (change == 1) {
+					// These should not be saved into the node document.
+					if (device.conn != null) { delete device.conn; }
+					if (device.pwr != null) { delete device.pwr; }
+					if (device.agct != null) { delete device.agct; }
+					if (device.cict != null) { delete device.cict; }
+
+					db.Set(device);
+
+					var event = {
+						etype: 'node',
+						action: 'changenode',
+						nodeid: obj.dbNodeKey,
+						domain: domain.id,
+						node: parent.CloneSafeNode(device),
+						msg: 'Changed device ' + device.name + ' from group ' + mesh.name + ': probable main LAN IP',
+						nolog: 1
+					};
+
+					if (db.changeStream) { event.noact = 1; }
+
+					parent.parent.DispatchEvent(parent.CreateMeshDispatchTargets(device.meshid, [obj.dbNodeKey]), obj, event);
+				}
+			}
+
+			delete obj.deviceChanging;
+		});
+	}
 
     // Change the current core information string and event it
     function ChangeAgentLocationInfo(command) {

--- a/views/default.handlebars
+++ b/views/default.handlebars
@@ -5098,9 +5098,9 @@
 						ip = node.ip; 
 					}
 					if ((node.probableMainLanIP != null) && (node.probableMainLanIP != '') && (node.probableMainLanIP != ip)) {
-						r += '<td style=text-align:center;white-space:nowrap;overflow:hidden;text-overflow:ellipsis title="' + EscapeHtml(node.probableMainLanIP) + '">LAN ' + EscapeHtml(node.probableMainLanIP) + '<br />WAN <a href="http://ip-api.com/#' + EscapeHtml(node.ip) + '" target="_blank">' + EscapeHtml(ip) + '</a>';
+						r += '<td style=text-align:center;white-space:nowrap;overflow:hidden;text-overflow:ellipsis title="' + EscapeHtml(node.probableMainLanIP) + '">' + "LAN" + ' ' + EscapeHtml(node.probableMainLanIP) + '<br />' + "WAN" + ' <a href="https://iplocation.com/?ip=' + EscapeHtml(node.ip) + '" target="_blank">' + EscapeHtml(ip) + '</a>';
 					} else {
-						r += '<td style=text-align:center;white-space:nowrap;overflow:hidden;text-overflow:ellipsis title="' + EscapeHtml(node.ip) + '"><a href="http://ip-api.com/#' + EscapeHtml(node.ip) + '" target="_blank">' + EscapeHtml(node.ip) + '</a>';
+						r += '<td style=text-align:center;white-space:nowrap;overflow:hidden;text-overflow:ellipsis title="' + EscapeHtml(node.ip) + '"><a href="https://iplocation.com/?ip=' + EscapeHtml(node.ip) + '" target="_blank">' + EscapeHtml(node.ip) + '</a>';
 					}
 				}
                 if (deviceViewSettings.devsCols.indexOf('conn') >= 0) { r += '<td style=text-align:center>' + states.join('&nbsp;+&nbsp;'); } // Connectivity

--- a/views/default.handlebars
+++ b/views/default.handlebars
@@ -5090,7 +5090,19 @@
                 }
                 if (deviceViewSettings.devsCols.indexOf('links') >= 0) { r += '<td style=text-align:center;font-size:x-small>' + getShortRouterLinks(node); } // Links
                 if (deviceViewSettings.devsCols.indexOf('user') >= 0) { r += '<td style=text-align:center>' + getUserShortStr(node); } // User
-                if (deviceViewSettings.devsCols.indexOf('ip') >= 0) { var ip = ''; if (node.mtype == 3) { ip = node.host; } else if (node.ip) { ip = node.ip; } r += '<td style=text-align:center;white-space:nowrap;overflow:hidden;text-overflow:ellipsis title="' + EscapeHtml(ip) + '">' + EscapeHtml(ip); } // IP address
+                if (deviceViewSettings.devsCols.indexOf('ip') >= 0) { 
+					var ip = ''; 
+					if (node.mtype == 3) {
+						ip = node.host; 
+					} else if (node.ip) { 
+						ip = node.ip; 
+					}
+					if ((node.probableMainLanIP != null) && (node.probableMainLanIP != '') && (node.probableMainLanIP != ip)) {
+						r += '<td style=text-align:center;white-space:nowrap;overflow:hidden;text-overflow:ellipsis title="' + EscapeHtml(node.probableMainLanIP) + '">LAN ' + EscapeHtml(node.probableMainLanIP) + '<br />WAN <a href="http://ip-api.com/#' + EscapeHtml(node.ip) + '" target="_blank">' + EscapeHtml(ip) + '</a>';
+					} else {
+						r += '<td style=text-align:center;white-space:nowrap;overflow:hidden;text-overflow:ellipsis title="' + EscapeHtml(node.ip) + '"><a href="http://ip-api.com/#' + EscapeHtml(node.ip) + '" target="_blank">' + EscapeHtml(node.ip) + '</a>';
+					}
+				}
                 if (deviceViewSettings.devsCols.indexOf('conn') >= 0) { r += '<td style=text-align:center>' + states.join('&nbsp;+&nbsp;'); } // Connectivity
                 if (deviceViewSettings.devsCols.indexOf('amthost') >= 0) { r += '<td style=text-align:center>' + (((node.intelamt == null) || (node.intelamt.host == null)) ? '' : EscapeHtml(node.intelamt.host)); }
                 if (deviceViewSettings.devsCols.indexOf('amtstate') >= 0) {

--- a/views/default3.handlebars
+++ b/views/default3.handlebars
@@ -6031,7 +6031,19 @@
                 }
                 if (deviceViewSettings.devsCols.indexOf('links') >= 0) { r += '<td style=text-align:center;font-size:x-small>' + getShortRouterLinks(node); } // Links
                 if (deviceViewSettings.devsCols.indexOf('user') >= 0) { r += '<td style=text-align:center>' + getUserShortStr(node); } // User
-                if (deviceViewSettings.devsCols.indexOf('ip') >= 0) { var ip = ''; if (node.mtype == 3) { ip = node.host; } else if (node.ip) { ip = node.ip; } r += '<td style=text-align:center;white-space:nowrap;overflow:hidden;text-overflow:ellipsis title="' + EscapeHtml(ip) + '">' + EscapeHtml(ip); } // IP address
+                if (deviceViewSettings.devsCols.indexOf('ip') >= 0) { 
+					var ip = ''; 
+					if (node.mtype == 3) { 
+						ip = node.host; 
+					} else if (node.ip) { 
+						ip = node.ip; 
+					}
+					if ((node.probableMainLanIP != null) && (node.probableMainLanIP != '') && (node.probableMainLanIP != ip)) {
+						r += '<td style=text-align:center;white-space:nowrap;overflow:hidden;text-overflow:ellipsis title="' + EscapeHtml(node.probableMainLanIP) + '">LAN ' + EscapeHtml(node.probableMainLanIP) + '<br />WAN <a href="http://ip-api.com/#' + EscapeHtml(node.ip) + '" target="_blank">' + EscapeHtml(ip) + '</a>';
+					} else {
+						r += '<td style=text-align:center;white-space:nowrap;overflow:hidden;text-overflow:ellipsis title="' + EscapeHtml(node.ip) + '"><a href="http://ip-api.com/#' + EscapeHtml(node.ip) + '" target="_blank">' + EscapeHtml(node.ip) + '</a>';
+					}
+				} // IP address
                 if (deviceViewSettings.devsCols.indexOf('conn') >= 0) { r += '<td style=text-align:center>' + states.join('&nbsp;+&nbsp;'); } // Connectivity
                 if (deviceViewSettings.devsCols.indexOf('amthost') >= 0) { r += '<td style=text-align:center>' + (((node.intelamt == null) || (node.intelamt.host == null)) ? '' : EscapeHtml(node.intelamt.host)); }
                 if (deviceViewSettings.devsCols.indexOf('amtstate') >= 0) {

--- a/views/default3.handlebars
+++ b/views/default3.handlebars
@@ -6039,9 +6039,9 @@
 						ip = node.ip; 
 					}
 					if ((node.probableMainLanIP != null) && (node.probableMainLanIP != '') && (node.probableMainLanIP != ip)) {
-						r += '<td style=text-align:center;white-space:nowrap;overflow:hidden;text-overflow:ellipsis title="' + EscapeHtml(node.probableMainLanIP) + '">LAN ' + EscapeHtml(node.probableMainLanIP) + '<br />WAN <a href="http://ip-api.com/#' + EscapeHtml(node.ip) + '" target="_blank">' + EscapeHtml(ip) + '</a>';
+						r += '<td style=text-align:center;white-space:nowrap;overflow:hidden;text-overflow:ellipsis title="' + EscapeHtml(node.probableMainLanIP) + '">' + "LAN" + ' ' + EscapeHtml(node.probableMainLanIP) + '<br />' + "WAN" +' <a href="https://iplocation.com/?ip=' + EscapeHtml(node.ip) + '" target="_blank">' + EscapeHtml(ip) + '</a>';
 					} else {
-						r += '<td style=text-align:center;white-space:nowrap;overflow:hidden;text-overflow:ellipsis title="' + EscapeHtml(node.ip) + '"><a href="http://ip-api.com/#' + EscapeHtml(node.ip) + '" target="_blank">' + EscapeHtml(node.ip) + '</a>';
+						r += '<td style=text-align:center;white-space:nowrap;overflow:hidden;text-overflow:ellipsis title="' + EscapeHtml(node.ip) + '"><a href="https://iplocation.com/?ip=' + EscapeHtml(node.ip) + '" target="_blank">' + EscapeHtml(node.ip) + '</a>';
 					}
 				} // IP address
                 if (deviceViewSettings.devsCols.indexOf('conn') >= 0) { r += '<td style=text-align:center>' + states.join('&nbsp;+&nbsp;'); } // Connectivity


### PR DESCRIPTION
# Summary

This PR includes changes related to:
- Fixed the variable name (probableMainLanIP instead of probable_main_lan_ip)
- It will be added to the node instead of only to the ifconfig
- It's now shown in the devices list

Related to these:
https://github.com/Ylianst/MeshCentral/issues/7436
https://github.com/Ylianst/MeshCentral/pull/7927
https://github.com/Ylianst/MeshCentral/pull/7898

- [X] 🧠 I used LLMs/AI in this contribution and reviewed all generated content.
      I understand that I am responsible for and able to explain every line of code I submit.
- [X] 🔍 Any UI changes adhere to visual style of this project.
- [X] 🛠️ I have self-reviewed and self-tested my code to ensure it works as expected.
- [ ] 🤖 I added or updated automated tests where appropriate.
- [ ] 📄 Documentation updates are included (if applicable).
- [ ] 🧰 Dependency updates are listed and explained.
- [X] ⚠️ CI passes and is green.

## Screenshots for Visual Changes

Before: (or when the public IP matches the LAN IP)
<img width="136" height="52" alt="image" src="https://github.com/user-attachments/assets/a23044a7-a01e-4b56-9703-dc5a070fcfd6" />

Now: (if the public IP related to the device doesn't match the LAN IP)
<img width="132" height="86" alt="image" src="https://github.com/user-attachments/assets/44c3e6e3-bb9d-49cd-9ef1-eed38d0872ab" />