### PR TITLE
Add file existence check before reading battery data in Linux

### DIFF
--- a/agents/modules_meshcore/computer-identifiers.js
+++ b/agents/modules_meshcore/computer-identifiers.js
@@ -441,9 +441,12 @@ function linux_identifiers()
                 ];
                 const thedata = {};
                 for (var x in filesToRead) {
-                    try {   
-                        const content = require('fs').readFileSync('/sys/class/power_supply/' + batteries[i] + '/' + filesToRead[x]).toString().trim();
-                        thedata[filesToRead[x]] = /^\d+$/.test(content) ? parseInt(content, 10) : content;
+                    try {
+						const filePath = '/sys/class/power_supply/' + batteries[i] + '/' + filesToRead[x];
+						if(require('fs').existsSync(filePath)) {
+                        	const content = require('fs').readFileSync(filePath).toString().trim();
+                        	thedata[filesToRead[x]] = /^\d+$/.test(content) ? parseInt(content, 10) : content;
+						}
                     } catch (err) { }
                 }
                 if (Object.keys(thedata).length === 0) continue; // No data read, skip


### PR DESCRIPTION
# Summary

Certain Linux devices might expose that they have a battery (like Nintendo Joy-Cons), but they might not have the expected files to retrieve the capacity, for example.

This small fix in the agent's code just checks that the file exists before trying to read it.

Fixes this: 
https://discord.com/channels/891895284005752893/891895284005752896/1519506362441273436

- [ ] 🧠 I used LLMs/AI in this contribution and reviewed all generated content.
      I understand that I am responsible for and able to explain every line of code I submit.
- [ ] 🔍 Any UI changes adhere to visual style of this project.
- [X] 🛠️ I have self-reviewed and self-tested my code to ensure it works as expected.
- [ ] 🤖 I added or updated automated tests where appropriate.
- [ ] 📄 Documentation updates are included (if applicable).
- [ ] 🧰 Dependency updates are listed and explained.
- [ ] ⚠️ CI passes and is green.