### PR TITLE
fix(docker): make Docker build debian images again

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,10 @@
+FROM alpine:3.24 AS node-base
+
+RUN apk add --no-cache --update \
+        nodejs npm jq tzdata
+
 ### STAGE 1 BUILDING.
-FROM alpine:3.23 AS builder
+FROM node-base AS mesh-compiler
 
 # Any value inside one of the disable ARGs will be accepted.
 ARG DISABLE_EXTRACT="yes"
@@ -8,9 +13,7 @@ ARG DISABLE_TRANSLATE="yes"
 #    NODE_OPTIONS="--max_old_space_size=4096"
 # If your process gets OOM killed, perhaps the above will help.
 
-RUN apk add --no-cache --update \
-        nodejs npm; \
-    mkdir -p /opt/meshcentral/meshcentral
+RUN mkdir -p /opt/meshcentral/meshcentral
 WORKDIR /opt/meshcentral
 COPY ./ /opt/meshcentral/meshcentral/
 
@@ -49,13 +52,13 @@ RUN rm -rf /opt/meshcentral/meshcentral/docker /opt/meshcentral/meshcentral/node
 
 ### STAGE 2 PRECOMPILE DEPS MODULE
 
-FROM alpine:3.23 AS dep-compiler
+FROM node-base AS dep-compiler
 
 RUN echo -e "----------\nINSTALLING ALPINE PACKAGES...\n----------"; \
     apk add --no-cache --update \
-        bash gcc g++ jq make nodejs npm python3 tzdata
+        bash gcc g++ make python3
 
-COPY --from=builder /opt/meshcentral/meshcentral /opt/meshcentral/meshcentral
+COPY --from=mesh-compiler /opt/meshcentral/meshcentral /opt/meshcentral/meshcentral
 WORKDIR /opt/meshcentral/meshcentral
 
 RUN jq '.dependencies += {"modern-syslog": "1.2.0", "telegram": "2.26.22"}' package.json > temp.json && mv temp.json package.json \
@@ -65,7 +68,7 @@ RUN jq '.dependencies += {"modern-syslog": "1.2.0", "telegram": "2.26.22"}' pack
 
 ### STAGE 3 BUILDING.
 
-FROM alpine:3.23 AS finalizer
+FROM node-base AS finalizer
 
 # copy files from previous layer
 COPY --from=dep-compiler /opt/meshcentral/meshcentral /opt/meshcentral/meshcentral
@@ -131,15 +134,14 @@ ENV MARIADB_HOST="" \
 RUN echo -e "----------\nINSTALLING ALPINE PACKAGES...\n----------"; \
     mkdir -p /opt/meshcentral/meshcentral; \
     apk add --no-cache --update \
-        bash curl jq nodejs npm tzdata && \
+        bash curl && \
     rm -rf /var/cache/* \
         /tmp/* \
         /usr/share/man/ \
         /usr/share/doc/ \
         /var/log/* \
         /var/spool/* \
-        /usr/lib/debug/ && \
-    npm install -g npm@latest
+        /usr/lib/debug/
 
 WORKDIR /opt/meshcentral
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,10 +1,5 @@
-FROM alpine:3.24 AS node-base
-
-RUN apk add --no-cache --update \
-        nodejs npm jq tzdata
-
 ### STAGE 1 BUILDING.
-FROM node-base AS mesh-compiler
+FROM alpine:3.23 AS builder
 
 # Any value inside one of the disable ARGs will be accepted.
 ARG DISABLE_EXTRACT="yes"
@@ -13,7 +8,9 @@ ARG DISABLE_TRANSLATE="yes"
 #    NODE_OPTIONS="--max_old_space_size=4096"
 # If your process gets OOM killed, perhaps the above will help.
 
-RUN mkdir -p /opt/meshcentral/meshcentral
+RUN apk add --no-cache --update \
+        nodejs npm; \
+    mkdir -p /opt/meshcentral/meshcentral
 WORKDIR /opt/meshcentral
 COPY ./ /opt/meshcentral/meshcentral/
 
@@ -52,13 +49,13 @@ RUN rm -rf /opt/meshcentral/meshcentral/docker /opt/meshcentral/meshcentral/node
 
 ### STAGE 2 PRECOMPILE DEPS MODULE
 
-FROM node-base AS dep-compiler
+FROM alpine:3.23 AS dep-compiler
 
 RUN echo -e "----------\nINSTALLING ALPINE PACKAGES...\n----------"; \
     apk add --no-cache --update \
-        bash gcc g++ make python3
+        bash gcc g++ jq make nodejs npm python3 tzdata
 
-COPY --from=mesh-compiler /opt/meshcentral/meshcentral /opt/meshcentral/meshcentral
+COPY --from=builder /opt/meshcentral/meshcentral /opt/meshcentral/meshcentral
 WORKDIR /opt/meshcentral/meshcentral
 
 RUN jq '.dependencies += {"modern-syslog": "1.2.0", "telegram": "2.26.22"}' package.json > temp.json && mv temp.json package.json \
@@ -68,7 +65,7 @@ RUN jq '.dependencies += {"modern-syslog": "1.2.0", "telegram": "2.26.22"}' pack
 
 ### STAGE 3 BUILDING.
 
-FROM node-base AS finalizer
+FROM alpine:3.23 AS finalizer
 
 # copy files from previous layer
 COPY --from=dep-compiler /opt/meshcentral/meshcentral /opt/meshcentral/meshcentral
@@ -134,14 +131,15 @@ ENV MARIADB_HOST="" \
 RUN echo -e "----------\nINSTALLING ALPINE PACKAGES...\n----------"; \
     mkdir -p /opt/meshcentral/meshcentral; \
     apk add --no-cache --update \
-        bash curl && \
+        bash curl jq nodejs npm tzdata && \
     rm -rf /var/cache/* \
         /tmp/* \
         /usr/share/man/ \
         /usr/share/doc/ \
         /var/log/* \
         /var/spool/* \
-        /usr/lib/debug/
+        /usr/lib/debug/ && \
+    npm install -g npm@latest
 
 WORKDIR /opt/meshcentral
 

--- a/docker/Dockerfile-debian
+++ b/docker/Dockerfile-debian
@@ -1,5 +1,22 @@
-### STAGE 1 BUILDING.
-FROM debian:trixie-slim AS builder
+### STAGE 1 NODEJS BASE IMAGE
+
+FROM debian:trixie-slim AS node-base
+
+ARG NODE_MAJOR=24
+
+# Install general dependencies and nodesource's NodeJS
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends --no-install-suggests \
+        ca-certificates curl gnupg2 jq tzdata wget && \
+    mkdir -p /etc/apt/keyrings/ && \
+    curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /etc/apt/keyrings/nodesource.gpg && \
+    echo "Types: deb \nURIs: https://deb.nodesource.com/node_${NODE_MAJOR}.x/ \nSuites: nodistro \nComponents: main \nSigned-By: /etc/apt/keyrings/nodesource.gpg" > /etc/apt/sources.list.d/nodesource.sources && cat /etc/apt/sources.list.d/nodesource.sources && \
+    apt-get update && \
+    apt-get install -y --no-install-recommends --no-install-suggests \
+        nodejs
+
+### STAGE 2 BUILDING MESHCENTRAL BASICS
+FROM node-base AS mesh-compiler
 
 # Any value inside one of the disable ARGs will be accepted.
 ARG DISABLE_EXTRACT="yes"
@@ -8,39 +25,34 @@ ARG DISABLE_TRANSLATE="yes"
 #    NODE_OPTIONS="--max_old_space_size=4096"
 # If your process gets OOM killed, perhaps the above will help.
 
-# Install nodesource's NodeJS
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends --no-install-suggests \
-        nodejs npm && \
-    npm install -g npm@latest && \
-    mkdir -p /opt/meshcentral/meshcentral
+RUN mkdir -p /opt/meshcentral/meshcentral
 
 WORKDIR /opt/meshcentral
 COPY ./ /opt/meshcentral/meshcentral/
 
 # Check the Docker build arguments and if they are empty do the task.
 RUN if [ -n "$DISABLE_EXTRACT" ] || [ -n "$DISABLE_MINIFY" ] || [ -n "$DISABLE_TRANSLATE" ]; then \
-        echo -e "----------\nPREPARING ENVIRONMENT...\n----------"; \
+        echo "----------\nPREPARING ENVIRONMENT...\n----------"; \
         cd meshcentral && \
         npm install html-minifier-terser@7.2.0 jsdom@26.0.0 esprima@4.0.1 && \
         cd translate && \
         case "$DISABLE_EXTRACT" in \
             false|no|FALSE|NO) \
-                echo -e "----------\nSTARTING THE EXTRACTING PROCESS...\n----------"; \
+                echo "----------\nSTARTING THE EXTRACTING PROCESS...\n----------"; \
                 node translate.js extractall;; \
             *) \
                 echo "Setting EXTRACT as disabled.";; \
         esac && \
         case "$DISABLE_MINIFY" in \
             false|no|FALSE|NO) \
-                echo -e "----------\nSTARTING THE MINIFYING PROCESS...\n----------"; \
+                echo "----------\nSTARTING THE MINIFYING PROCESS...\n----------"; \
                 node translate.js minifyall;; \
             *) \
                 echo "Setting MINIFY as disabled.";; \
         esac && \
         case "$DISABLE_TRANSLATE" in \
             false|no|FALSE|NO) \
-                echo -e "----------\nSTARTING THE TRANSLATING PROCESS...\n----------"; \
+                echo "----------\nSTARTING THE TRANSLATING PROCESS...\n----------"; \
                 node translate.js translateall;; \
             *) \
                 echo "Setting TRANSLATE as disabled.";; \
@@ -51,30 +63,27 @@ RUN if [ -n "$DISABLE_EXTRACT" ] || [ -n "$DISABLE_MINIFY" ] || [ -n "$DISABLE_T
 
 RUN rm -rf /opt/meshcentral/meshcentral/docker /opt/meshcentral/meshcentral/node_modules /opt/meshcentral/meshcentral/docs
 
-### STAGE 2 PRECOMPILE DEPS MODULE
+### STAGE 3 PRECOMPILE NODEJS DEPENDENCIES
 
-FROM debian:trixie-slim AS dep-compiler
+FROM node-base AS dep-compiler
 
 ENV NODE_ENV="production"
 
-# Install general dependencies and nodesource's NodeJS
 RUN apt-get update && \
-    echo -e "----------\nINSTALLING DEBIAN PACKAGES...\n----------"; \
     apt-get install -y --no-install-recommends --no-install-suggests \
-        bash gcc g++ jq make nodejs npm python3 tzdata && \
-    npm install -g npm@latest
+        gcc g++ make python3
 
-COPY --from=builder /opt/meshcentral/meshcentral /opt/meshcentral/meshcentral
+COPY --from=mesh-compiler /opt/meshcentral/meshcentral /opt/meshcentral/meshcentral
 WORKDIR /opt/meshcentral/meshcentral
 
 RUN jq '.dependencies += {"modern-syslog": "1.2.0", "telegram": "2.26.22"}' package.json > temp.json && mv temp.json package.json \
-    && npm i --package-lock-only \
+    && npm install --package-lock-only \
     && npm ci --omit=dev \
     && npm cache clean --force
 
-### STAGE 3 fun. building from source...
+### STAGE 4 COMPILING MONGODB TOOLS AND DEPENDENCIES
 
-FROM golang:trixie AS mongo-tools-compiler
+FROM golang:trixie AS mongo-compiler
 
 ARG INCLUDE_MONGODB_TOOLS="false"
 
@@ -95,15 +104,13 @@ RUN case "$INCLUDE_MONGODB_TOOLS" in \
             exit 1;; \
     esac
 
-### STAGE 4 BUILDING.
+### STAGE 5 COMPILING LAYERS AND FORGING MESHCENTRAL STATE
 
-FROM debian:trixie-slim AS finalizer
-
-ARG NODEJS_DOWNLOAD="https://nodejs.org/dist/v24.12.0/node-v24.12.0-linux-x64.tar.xz"
+FROM node-base AS finalizer
 
 # Copy files from previous layers
 COPY --from=dep-compiler /opt/meshcentral/meshcentral /opt/meshcentral/meshcentral
-COPY --from=mongo-tools-compiler /mongo-tools/bin/ /tmp/bin/
+COPY --from=mongo-compiler /mongo-tools/bin/ /tmp/bin/
 
 # environment variables
 ENV NODE_ENV="production" \
@@ -165,12 +172,7 @@ ENV MARIADB_HOST="" \
 
 WORKDIR /opt/meshcentral
 
-RUN apt-get update && \
-    echo -e "----------\nINSTALLING DEBIAN PACKAGES...\n----------"; \
-    apt-get install -y --no-install-recommends --no-install-suggests \
-        bash ca-certificates curl jq nodejs npm tzdata wget && \
-    npm install -g npm@latest && \    
-    rm -rfv \
+RUN rm -rfv \
         /var/cache/* \
         /usr/share/man/ \
         /usr/share/doc/ \
@@ -182,12 +184,12 @@ RUN apt-get update && \
 RUN case "$PREINSTALL_LIBS" in \
         true|yes|TRUE|YES) \
             cd meshcentral && \
-            echo -e "----------\nPREINSTALLING LIBRARIES...\n----------"; \
+            echo "----------\nPREINSTALLING LIBRARIES...\n----------"; \
             npm install ssh2@1.17.0 nodemailer@6.10.1 image-size@2.0.2 wildleek@2.0.0 yub@0.11.1;; \
         false|no|FALSE|NO) \
             echo "Not pre-installing libraries.";; \
         *) \
-            echo -e "Invalid value for build argument INCLUDE_POSTGRESQL_TOOLS, possible values: 'yes', 'true', 'no' or 'false'"; \
+            echo "Invalid value for build argument INCLUDE_POSTGRESQL_TOOLS, possible values: 'yes', 'true', 'no' or 'false'"; \
             exit 1;; \
     esac
 
@@ -196,7 +198,7 @@ RUN case "$INCLUDE_MONGODB_TOOLS" in \
         true|yes|TRUE|YES) \
             mv /tmp/bin/* /usr/bin; \
             cd meshcentral && \
-            echo -e "----------\nPREINSTALLING MONGODB LIBRARIES...\n----------"; \
+            echo "----------\nPREINSTALLING MONGODB LIBRARIES...\n----------"; \
             npm install mongodb@4.17.2 @mongodb-js/saslprep@1.3.1;; \
         false|no|FALSE|NO) \
             echo "Not including MongoDB Tools.";; \
@@ -209,12 +211,12 @@ RUN case "$INCLUDE_POSTGRESQL_TOOLS" in \
         true|yes|TRUE|YES) \
             apt-get install -y --no-install-recommends --no-install-suggests postgresql-client-17; \
             cd meshcentral && \
-            echo -e "----------\nPREINSTALLING POSTGRESQL LIBRARIES...\n----------"; \
+            echo "----------\nPREINSTALLING POSTGRESQL LIBRARIES...\n----------"; \
             npm install pg@8.16.3;; \
         false|no|FALSE|NO) \
             echo "Not including PostgreSQL Tools.";; \
         *) \
-            echo -e "Invalid value for build argument INCLUDE_POSTGRESQL_TOOLS, possible values: 'yes', 'true', 'no' or 'false'"; \
+            echo "Invalid value for build argument INCLUDE_POSTGRESQL_TOOLS, possible values: 'yes', 'true', 'no' or 'false'"; \
             exit 1;; \
     esac
 
@@ -222,12 +224,12 @@ RUN case "$INCLUDE_MARIADB_TOOLS" in \
         true|yes|TRUE|YES) \
             apt-get install -y --no-install-recommends --no-install-suggests default-mysql-client mariadb-client; \
             cd meshcentral && \
-            echo -e "----------\nPREINSTALLING MARIADB/MYSQL LIBRARIES...\n----------"; \
+            echo "----------\nPREINSTALLING MARIADB/MYSQL LIBRARIES...\n----------"; \
             npm install mariadb@3.4.5 mysql2@3.15.1;; \
         false|no|FALSE|NO) \
             echo "Not including MariaDB/MySQL Tools.";; \
         *) \
-            echo -e "Invalid value for build argument INCLUDE_MARIADB_TOOLS, possible values: 'yes', 'true', 'no' or 'false'"; \
+            echo "Invalid value for build argument INCLUDE_MARIADB_TOOLS, possible values: 'yes', 'true', 'no' or 'false'"; \
             exit 1;; \
     esac
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+echo "NodeJS: $(node -v)"
+echo "NPM: $(npm -v)"
+
 # Origin: https://github.com/Melo-Professional/MeshCentral-Stylish-UI
 stylishui_base_url="https://github.com/Melo-Professional/MeshCentral-Stylish-UI/archive/refs"
 stylishui_compat="https://raw.githubusercontent.com/Melo-Professional/MeshCentral-Stylish-UI/refs/heads/main/metadata/compat.json"


### PR DESCRIPTION
<!--
⚠️ NO AI SLOP!!!
⚠️ If you didn't do manual QA and testing on this PR you shouldn't be PRing
-->

# Summary

In this pull request, the following changes are made:

The Debian Docker image now has another stage in the Docker building process, the NodeJS base stage. Which downloads and installs Node and NPM after which all the following stages build on that.

<!--Please link any GitHub issues or tasks that this pull request addresses-->

I AM THE ISSUE! AND THE FIX

<details>
<summary>Please follow this checklist to avoid unnecessary back and forth (click to expand)</summary>

- [x] 🧠 I used LLMs/AI in this contribution and reviewed all generated content.
      I understand that I am responsible for and able to explain every line of code I submit.
> I mean... Copilot did give me some advice?
- [ ] 🔍 Any UI changes adhere to visual style of this project.
- [x] 🛠️ I have self-reviewed and self-tested my code to ensure it works as expected.
- [ ] 🤖 I added or updated automated tests where appropriate.
- [ ] 📄 Documentation updates are included (if applicable).
- [ ] 🧰 Dependency updates are listed and explained.
- [x] ⚠️ CI passes and is green.
