### PR TITLE
Fix 2FA on Node 22 by preloading otplib via dynamic import()

### DIFF
--- a/meshuser.js
+++ b/meshuser.js
@@ -19,6 +19,12 @@ const driveType = { 0: "Unknown", 1: "No Root Directory", 2: "Removable Disk", 3
 const conversionStatus = { "-1": "Unknown", 0: "Fully Decrypted", 1: "Fully Encrypted", 2: "Encryption In Progress", 3: "Decryption In Progress", 4: "Encryption Paused", 5: "Decryption Paused" };
 const protectionStatus = { 0: "Off", 1: "On", 2: "Locked"};
 
+// otplib v13+ ships as an ES module. On Node.js 22 before 22.12, require() of an ES module throws
+// ERR_REQUIRE_ESM unless started with --experimental-require-module. Preload it once via dynamic
+// import() so 2FA works on every runtime without a Node flag (systemd, Docker, PM2, launchd, pkg, ...).
+var otplib = null;
+import('otplib').then(function (mod) { otplib = mod; }, function () { otplib = null; });
+
 // Construct a MeshAgent object, called upon connection
 module.exports.CreateMeshUser = function (parent, db, ws, req, args, domain, user) {
     const fs = require('fs');
@@ -3765,8 +3771,6 @@ module.exports.CreateMeshUser = function (parent, db, ws, req, args, domain, use
                     const twoStepLoginSupported = ((parent.parent.config.settings.no2factorauth !== true) && (domain.auth != 'sspi') && (parent.parent.certificates.CommonName.indexOf('.') != -1) && (args.nousers !== true));
                     if (twoStepLoginSupported) {
                         // Request a one time password to be setup
-                        var otplib = null;
-                        try { otplib = require('otplib'); } catch (ex) { }
                         if (otplib == null) { ws.send(JSON.stringify({ action: 'otpauth-request', err: 6 })); return; }
                         const secret = otplib.generateSecret(); // TODO: Check the random source of this value.
 
@@ -3797,10 +3801,8 @@ module.exports.CreateMeshUser = function (parent, db, ws, req, args, domain, use
                     const twoStepLoginSupported = ((parent.parent.config.settings.no2factorauth !== true) && (domain.auth != 'sspi') && (parent.parent.certificates.CommonName.indexOf('.') != -1) && (args.nousers !== true));
                     if (twoStepLoginSupported) {
                         // Perform the one time password setup
-                        var otplib = null;
-                        try { otplib = require('otplib'); } catch (ex) { }
                         if (otplib == null) { break; }
-                        const verified = require('otplib').verifySync({ 
+                        const verified = otplib.verifySync({
                             epochTolerance: 60, 
                             token: command.token, 
                             secret: command.secret,

--- a/webserver.js
+++ b/webserver.js
@@ -30,6 +30,12 @@ function SerialTunnel(options) {
 if (!String.prototype.startsWith) { String.prototype.startsWith = function (searchString, position) { position = position || 0; return this.substr(position, searchString.length) === searchString; }; }
 if (!String.prototype.endsWith) { String.prototype.endsWith = function (searchString, position) { var subjectString = this.toString(); if (typeof position !== 'number' || !isFinite(position) || Math.floor(position) !== position || position > subjectString.length) { position = subjectString.length; } position -= searchString.length; var lastIndex = subjectString.lastIndexOf(searchString, position); return lastIndex !== -1 && lastIndex === position; }; }
 
+// otplib v13+ ships as an ES module. On Node.js 22 before 22.12, require() of an ES module throws
+// ERR_REQUIRE_ESM unless started with --experimental-require-module. Preload it once via dynamic
+// import() so 2FA works on every runtime without a Node flag (systemd, Docker, PM2, launchd, pkg, ...).
+var otplib = null;
+import('otplib').then(function (mod) { otplib = mod; }, function () { otplib = null; });
+
 // Construct a HTTP server object
 module.exports.CreateWebServer = function (parent, db, args, certificates, doneFunc) {
     var obj = {}, i = 0;
@@ -1110,9 +1116,8 @@ module.exports.CreateWebServer = function (parent, db, args, certificates, doneF
         }
 
         // Check Google Authenticator
-        if (user.otpsecret && (typeof (token) == 'string') && (token.length == 6)){
-            const otplib = require('otplib');
-            const verified = otplib.verifySync({ 
+        if (user.otpsecret && (typeof (token) == 'string') && (token.length == 6) && (otplib != null)){
+            const verified = otplib.verifySync({
                 epochTolerance: 60, 
                 token: token, 
                 secret: user.otpsecret,


### PR DESCRIPTION
### Problem

`otplib` v13+ ships as an ES module. On Node.js 22 before 22.12, `require()` of an ES module throws `ERR_REQUIRE_ESM` unless the process is started with `--experimental-require-module`.

`meshuser.js` and `webserver.js` load otplib with `require('otplib')`, so on a default Node 22 install **TOTP two-factor auth is silently broken**:

- authenticator enrollment (`otpauth-request` / `otpauth-setup`) returns error `6` because `require('otplib')` throws and `otplib` stays `null`
- `checkUserOneTimePassword()` in `webserver.js` throws on login because that `require` is not wrapped in a guard

### Why not the Node flag

Requiring `--experimental-require-module` is not portable — it has to be set differently for systemd, Docker, PM2, launchd, `pkg` builds, Windows service wrappers, etc. That is why the generated‑systemd‑unit approach in #7936 was incomplete and closed.

### Fix

Preload otplib once at module scope with **dynamic `import()`** (which is allowed inside CommonJS) and reuse the module at the call sites. No Node flag is needed on any runtime. The existing `otplib == null` guards are kept, and the authenticator check in `webserver.js` now also guards on otplib being loaded.

Net change: +15 / −8 across `meshuser.js` and `webserver.js`, no new dependency.

### Testing (Node 22.11.0)

- `require('otplib')` fails with `ERR_REQUIRE_ESM` **without** the flag (reproduces the bug); `import('otplib')` resolves and a full `generateSecret` → `generateURI` → `generateSync` → `verifySync` (with `createGuardrails`) round‑trip succeeds.
- Applied the patch to a running MeshCentral 1.2.1 server, **removed** `NODE_OPTIONS=--experimental-require-module`, restarted: server starts cleanly, no `ERR_REQUIRE_ESM`, and the ES‑module `require()` experimental warning is gone.
- Confirmed in the live process that both modules populate `otplib` via `import()` (`verifySync` and `generateSecret` present) after startup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
