### PR TITLE
Don't clear the remote-input toggle when node rights can't be evaluated

### DIFF
--- a/views/default.handlebars
+++ b/views/default.handlebars
@@ -9495,7 +9495,13 @@
             QV('DeskBackgroundButton', inputAllowed && (deskState == 3) && (desktop.contype == 1) && (currentNode.agent) && (currentNode.agent.id != 11) && (currentNode.agent.id != 16) && online);
             QV('DeskControlSpan', inputAllowed)
             QV('DeskRefreshButton', (deskState == 3) && (desktop.contype == 1))
-            if (rights & 8) { Q('DeskControl').checked = (getstore('DeskControl', 1) == 1); } else { Q('DeskControl').checked = false; }
+            // GetNodeRights() returns 0 when currentNode is null or its device group is not (yet) in the
+            // local "meshes" cache, which is indistinguishable from "no remote control right". Remote input
+            // is enforced server-side by the agent and the desktop multiplexor, so only clear the toggle when
+            // we could actually evaluate the rights, instead of silently unchecking it on a transient state.
+            var deskRightsKnown = (currentNode != null) && (meshes[currentNode.meshid] != null);
+            if (rights & 8) { Q('DeskControl').checked = (getstore('DeskControl', 1) == 1); }
+            else if (deskRightsKnown) { Q('DeskControl').checked = false; }
             QS('DeskControlSpan').color = Q('DeskControl').checked?null:'red';
 
             if (online == false) QV('DeskTools', false);

--- a/views/default3.handlebars
+++ b/views/default3.handlebars
@@ -10840,7 +10840,13 @@
             QV('DeskBackgroundButton', inputAllowed && (deskState == 3) && (desktop.contype == 1) && (currentNode.agent) && (currentNode.agent.id != 11) && (currentNode.agent.id != 16) && online);
             QV('DeskControlSpan', inputAllowed)
             QV('DeskRefreshButton', (deskState == 3) && (desktop.contype == 1))
-            if (rights & 8) { Q('DeskControl').checked = (getstore('DeskControl', 1) == 1); } else { Q('DeskControl').checked = false; }
+            // GetNodeRights() returns 0 when currentNode is null or its device group is not (yet) in the
+            // local "meshes" cache, which is indistinguishable from "no remote control right". Remote input
+            // is enforced server-side by the agent and the desktop multiplexor, so only clear the toggle when
+            // we could actually evaluate the rights, instead of silently unchecking it on a transient state.
+            var deskRightsKnown = (currentNode != null) && (meshes[currentNode.meshid] != null);
+            if (rights & 8) { Q('DeskControl').checked = (getstore('DeskControl', 1) == 1); }
+            else if (deskRightsKnown) { Q('DeskControl').checked = false; }
             QS('DeskControlSpan').color = Q('DeskControl').checked ? null : 'red';
 
             if (online == false) QV('DeskTools', false);


### PR DESCRIPTION
### Problem

In `updateDesktopButtons()` (`views/default.handlebars`), the **Input** toggle (`DeskControl`) is unchecked whenever `(rights & 8)` is false:

```js
if (rights & 8) { Q('DeskControl').checked = (getstore('DeskControl', 1) == 1); } else { Q('DeskControl').checked = false; }
```

But `GetNodeRights()` returns `0` not only when the user lacks remote‑control rights, but also when `currentNode` is `null` or its device group is not (yet) in the local `meshes` cache — because `GetMeshRights()` does `if (mesh == null) return 0;` **before** the super‑admin shortcut. Those transient states can occur after a reconnect or a node/mesh refresh, so an active operator can watch the input checkbox **spontaneously uncheck itself (and turn red) mid‑session**, even though nothing about their permissions changed. Re‑checking it restores control.

### Why this is safe

Remote input is enforced server‑side by the agent (`agents/meshcore.js`, `rights & MESHRIGHT_REMOTECONTROL`) and the desktop multiplexor (`meshdesktopmultiplex.js`, which enforces view‑only). The checkbox is a client‑side convenience, not the security boundary — so not clearing it on an unevaluable state does not grant any extra access.

### Fix

Only clear the toggle when the rights were actually evaluable (node present and its mesh in cache); otherwise leave the current state untouched.

```js
var deskRightsKnown = (currentNode != null) && (meshes[currentNode.meshid] != null);
if (rights & 8) { Q('DeskControl').checked = (getstore('DeskControl', 1) == 1); }
else if (deskRightsKnown) { Q('DeskControl').checked = false; }
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
