### PR TITLE
Guard against null rauth cookie in CreateMeshRelayEx

### DIFF
--- a/meshdesktopmultiplex.js
+++ b/meshdesktopmultiplex.js
@@ -1052,8 +1052,8 @@ function CreateMeshRelayEx2(parent, ws, req, domain, user, cookie) {
     // Check relay authentication
     if ((user == null) && (obj.req.query != null) && (obj.req.query.rauth != null)) {
         const rcookie = parent.parent.decodeCookie(obj.req.query.rauth, parent.parent.loginCookieEncryptionKey, 240); // Cookie with 4 hour timeout
-        if (rcookie.ruserid != null) { obj.ruserid = rcookie.ruserid; } else if (rcookie.nouser === 1) { obj.rnouser = true; }
-        if (rcookie.nodeid != null) { obj.nodeid = rcookie.nodeid; }
+        if (rcookie != null) { if (rcookie.ruserid != null) { obj.ruserid = rcookie.ruserid; } else if (rcookie.nouser === 1) { obj.rnouser = true; } }
+        if (rcookie != null) { if (rcookie.nodeid != null) { obj.nodeid = rcookie.nodeid; } }
     }
 
     // If there is no authentication, drop this connection

--- a/meshdevicefile.js
+++ b/meshdevicefile.js
@@ -26,7 +26,7 @@ module.exports.CreateMeshDeviceFile = function (parent, ws, res, req, domain, us
     // Check relay authentication
     if ((user == null) && (obj.req.query != null) && (obj.req.query.rauth != null)) {
         const rcookie = parent.parent.decodeCookie(obj.req.query.rauth, parent.parent.loginCookieEncryptionKey, 240); // Cookie with 4 hour timeout
-        if (rcookie.ruserid != null) { obj.ruserid = rcookie.ruserid; }
+        if (rcookie != null) { if (rcookie.ruserid != null) { obj.ruserid = rcookie.ruserid; } }
     }
 
     // Relay session count (we may remove this in the future)

--- a/meshrelay.js
+++ b/meshrelay.js
@@ -183,7 +183,7 @@ function CreateMeshRelayEx(parent, ws, req, domain, user, cookie) {
     // Check relay authentication
     if ((user == null) && (obj.req.query != null) && (obj.req.query.rauth != null)) {
         const rcookie = parent.parent.decodeCookie(obj.req.query.rauth, parent.parent.loginCookieEncryptionKey, 240); // Cookie with 4 hour timeout
-        if (rcookie.ruserid != null) { obj.ruserid = rcookie.ruserid; } else if (rcookie.nouser === 1) { obj.rnouser = true; }
+        if (rcookie != null) { if (rcookie.ruserid != null) { obj.ruserid = rcookie.ruserid; } else if (rcookie.nouser === 1) { obj.rnouser = true; } }
     }
 
     // If there is no authentication, drop this connection


### PR DESCRIPTION
Fixes #7997.

`decodeCookie()` returns `null` when a cookie can't be decoded (for example after a restart rotates `loginCookieEncryptionKey`, which is exactly what the reporter saw: reconnecting worked after restarting the container or agent). In `CreateMeshRelayEx` the `rauth` result was used without that null check:

```js
const rcookie = parent.parent.decodeCookie(obj.req.query.rauth, parent.parent.loginCookieEncryptionKey, 240);
if (rcookie.ruserid != null) { ... }
```

so a stale `rauth` query value throws `TypeError: Cannot read properties of null (reading 'ruserid')` at meshrelay.js:186 and the relay connection fails. Every other `decodeCookie` caller in webserver.js already guards with `if (rcookie != null)` first; this adds the same guard here. When the cookie is null the code now falls through and the existing no-authentication check a few lines down closes the connection, same as before.

I didn't add a test since exercising this path needs a running relay with a real WebSocket handshake and encryption keys, and there's no unit harness for meshrelay.js.
