### PR TITLE
Allow serverversion WS action for Login Token sessions

### DIFF
--- a/meshuser.js
+++ b/meshuser.js
@@ -7128,9 +7128,6 @@ module.exports.CreateMeshUser = function (parent, db, ws, req, args, domain, use
     }
 
     function serverCommandServerVersion(command) {
-        // Do not allow this command when logged in using a login token
-        if (req.session.loginToken != null) return;
-
         // Check the server version
         if (userHasSiteUpdate() && domainHasMyServerUpgrade())
             parent.parent.getServerTags(function (tags, err) { obj.send({ action: 'serverversion', tags: tags }); });


### PR DESCRIPTION
Fixes #8008

`serverversion` is read-only — it just returns the installed/latest version tags — and is already gated behind `userHasSiteUpdate()` and `domainHasMyServerUpgrade()`, so any session reaching that check already belongs to a privileged account. The `loginToken` block added no additional security on top of that gate, it just silently broke automation/read-only clients authenticated via Login Token (e.g. Home Assistant integrations using `~t:...` credentials to bypass 2FA).

`serverupdate` is untouched and remains restricted for Login Token sessions, since it triggers an actual server update/install and that's a much higher-stakes action to allow from a token session.

See #8008 for the two options discussed; this PR implements option A (drop the check for `serverversion` specifically, rather than keeping both blocked and just returning an explicit denial).
