### PR TITLE
Remove obsolete mc1migration function

### DIFF
--- a/agents/meshcore.js
+++ b/agents/meshcore.js
@@ -7398,9 +7398,6 @@ function handleServerConnection(state) {
             sendAgentMessage("This is an old agent version, consider updating.", 3, 117);
         }
 
-        var oldNodeId = db.Get('OldNodeId');
-        if (oldNodeId != null) { mesh.SendCommand({ action: 'mc1migration', oldnodeid: oldNodeId }); }
-
         // Send SMBios tables if present
         if (SMBiosTablesRaw != null) { mesh.SendCommand({ action: 'smbios', value: SMBiosTablesRaw }); }
 

--- a/meshagent.js
+++ b/meshagent.js
@@ -1325,30 +1325,6 @@ module.exports.CreateMeshAgent = function (parent, db, ws, req, args, domain) {
                         }
                         break;
                     }
-                case 'mc1migration':
-                    {
-                        if (command.oldnodeid.length != 64) break;
-                        const oldNodeKey = 'node//' + command.oldnodeid.toLowerCase();
-                        db.Get(oldNodeKey, function (err, nodes) {
-                            if ((nodes == null) || (nodes.length != 1)) return;
-                            const node = nodes[0];
-                            if (node.meshid == obj.dbMeshKey) {
-                                // Update the device name & host
-                                const newNode = { "name": node.name };
-                                if (node.intelamt != null) { newNode.intelamt = node.intelamt; }
-                                ChangeAgentCoreInfo(newNode);
-
-                                // Delete this node including network interface information and events
-                                db.Remove(node._id);
-                                db.Remove('if' + node._id);
-
-                                // Event node deletion
-                                const change = 'Migrated device ' + node.name;
-                                parent.parent.DispatchEvent(parent.CreateMeshDispatchTargets(node.meshid, [obj.dbNodeKey]), obj, { etype: 'node', action: 'removenode', nodeid: node._id, msg: change, domain: node.domain });
-                            }
-                        });
-                        break;
-                    }
                 case 'openUrl':
                     {
                         // Sent by the agent to return the status of a open URL action.


### PR DESCRIPTION
# Summary

In this pull request, the following changes are made:

- Removed the obsolete `mc1migration` action. It dates back to the old MeshCentral1/.NET-era device migration and is no longer used by current agents, so both the server-side handler in `meshagent.js` and the agent-side call in `agents/meshcore.js` that sent it on server connect are removed.
- Left the `OldNodeId` diagnostic line in the agent `info` command as-is, since it is independent of this function.

As discussed over email — this removes dead code rather than fixing a bug.

<details>
<summary>Please follow this checklist to avoid unnecessary back and forth (click to expand)</summary>

- [x] 🧠 I used LLMs/AI in this contribution and reviewed all generated content. I understand that I am responsible for and able to explain every line of code I submit.
- [ ] 🔍 Any UI changes adhere to visual style of this project.
- [x] 🛠️ I have self-reviewed and self-tested my code to ensure it works as expected.
- [ ] 🤖 I added or updated automated tests where appropriate.
- [ ] 📄 Documentation updates are included (if applicable).
- [ ] 🧰 Dependency updates are listed and explained.
- [x] ⚠️ CI passes and is green.

</details>
