### PR TITLE
Fix a crash when an agent log help-request has no msgArgs

### DIFF
--- a/meshagent.js
+++ b/meshagent.js
@@ -1382,7 +1382,7 @@ module.exports.CreateMeshAgent = function (parent, db, ws, req, args, domain) {
                                 db.Get(obj.dbNodeKey, function (err, nodes) { // TODO: THIS IS A BIG RACE CONDITION HERE, WE NEED TO FIX THAT. If this call is made twice at the same time on the same device, data will be missed.
                                     if ((nodes == null) || (nodes.length != 1)) { delete obj.deviceChanging; return; }
                                     const device = nodes[0];
-                                    if (typeof device.name == 'string') { parent.parent.NotifyUserOfDeviceHelpRequest(domain, device.meshid, device._id, device.name, command.msgArgs[0], command.msgArgs[1]); }
+                                    if ((typeof device.name == 'string') && Array.isArray(command.msgArgs) && (command.msgArgs.length >= 2)) { parent.parent.NotifyUserOfDeviceHelpRequest(domain, device.meshid, device._id, device.name, command.msgArgs[0], command.msgArgs[1]); }
                                 });
                             }
                         }


### PR DESCRIPTION
# Summary

In this pull request, the following changes are made:

- Fixed a crash in the agent `log` handler. The `msgid == 98` (help request) branch read `command.msgArgs[0]`/`[1]` without checking that `msgArgs` was present, so a `log` message with `msgid` 98 and no `msgArgs` threw inside the async `db.Get` callback and stopped the server. The call is now guarded with `Array.isArray` and a length check before `msgArgs` is used.

<details>
<summary>Please follow this checklist to avoid unnecessary back and forth (click to expand)</summary>

- [x] 🧠 I used LLMs/AI in this contribution and reviewed all generated content. I understand that I am responsible for and able to explain every line of code I submit.
- [ ] 🔍 Any UI changes adhere to visual style of this project.
- [x] 🛠️ I have self-reviewed and self-tested my code to ensure it works as expected.
- [ ] 🤖 I added or updated automated tests where appropriate.
- [ ] 📄 Documentation updates are included (if applicable).
- [ ] 🧰 Dependency updates are listed and explained.
- [x] ⚠️ CI passes and is green.

</details>
