### PR TITLE
Fix RDP keyboard layout selection from browser locale (#5097)

### DIFF
--- a/rdp/protocol/rdp.js
+++ b/rdp/protocol/rdp.js
@@ -135,18 +135,25 @@ function RdpClient(config) {
     log.debug('screen ' + this.mcs.clientCoreData.obj.desktopWidth.value + 'x' + this.mcs.clientCoreData.obj.desktopHeight.value);
 
     // config keyboard layout
-    // config.locale is a browser language tag (ex: 'de-AT', 'fr-FR', 'en-US'), so only
-    // the primary language subtag is used to select the RDP keyboard layout.
+    // config.locale is a browser language tag (ex: 'en-GB', 'de-AT', 'fr-CH'). The region
+    // can select a different layout, since 'en-GB' is not 'en-US', so the full tag is
+    // looked up first and only then the language on its own.
     var localeToKeyboardLayout = {
-        'ar': 'ARABIC',    'bg': 'BULGARIAN', 'cs': 'CZECH',     'da': 'DANISH',
-        'de': 'GERMAN',    'el': 'GREEK',     'en': 'US',        'es': 'SPANISH',
-        'fi': 'FINNISH',   'fr': 'FRENCH',    'he': 'HEBREW',    'hu': 'HUNGARIAN',
-        'is': 'ICELANDIC', 'it': 'ITALIAN',   'ja': 'JAPANESE',  'ko': 'KOREAN',
-        'nb': 'NORWEGIAN', 'nl': 'DUTCH',     'nn': 'NORWEGIAN', 'no': 'NORWEGIAN',
-        'zh': 'CHINESE_US_KEYBOARD'
+        'ar':    'ARABIC',        'bg':    'BULGARIAN',        'cs':    'CZECH',
+        'da':    'DANISH',        'de':    'GERMAN',           'de-ch': 'SWISS_GERMAN',
+        'el':    'GREEK',         'en':    'US',               'en-gb': 'UNITED_KINGDOM',
+        'en-ie': 'IRISH',         'es':    'SPANISH',          'fi':    'FINNISH',
+        'fr':    'FRENCH',        'fr-be': 'BELGIAN_FRENCH',   'fr-ca': 'CANADIAN_FRENCH',
+        'fr-ch': 'SWISS_FRENCH',  'he':    'HEBREW',           'hu':    'HUNGARIAN',
+        'is':    'ICELANDIC',     'it':    'ITALIAN',          'ja':    'JAPANESE',
+        'ko':    'KOREAN',        'nb':    'NORWEGIAN',        'nl':    'DUTCH',
+        'nl-be': 'BELGIAN_DUTCH', 'nn':    'NORWEGIAN',        'no':    'NORWEGIAN',
+        'zh':    'CHINESE_US_KEYBOARD'
     };
-    var localeLanguage = String(config.locale || 'en').toLowerCase().split(/[-_]/)[0];
-    var keyboardLayoutName = localeToKeyboardLayout[localeLanguage] || 'US';
+    var browserLocale = String(config.locale || 'en').toLowerCase().replace('_', '-');
+    var keyboardLayoutName = localeToKeyboardLayout[browserLocale]
+        || localeToKeyboardLayout[browserLocale.split('-')[0]]
+        || 'US';
     log.debug(keyboardLayoutName.toLowerCase() + ' keyboard layout');
     this.mcs.clientCoreData.obj.kbdLayout.value = t125.gcc.KeyboardLayout[keyboardLayoutName];
 

--- a/rdp/protocol/rdp.js
+++ b/rdp/protocol/rdp.js
@@ -135,16 +135,20 @@ function RdpClient(config) {
     log.debug('screen ' + this.mcs.clientCoreData.obj.desktopWidth.value + 'x' + this.mcs.clientCoreData.obj.desktopHeight.value);
 
     // config keyboard layout
-    switch (config.locale) {
-        case 'fr':
-            log.debug('french keyboard layout');
-            this.mcs.clientCoreData.obj.kbdLayout.value = t125.gcc.KeyboardLayout.FRENCH;
-            break;
-        case 'en':
-        default:
-            log.debug('english keyboard layout');
-            this.mcs.clientCoreData.obj.kbdLayout.value = t125.gcc.KeyboardLayout.US;
-    }
+    // config.locale is a browser language tag (ex: 'de-AT', 'fr-FR', 'en-US'), so only
+    // the primary language subtag is used to select the RDP keyboard layout.
+    var localeToKeyboardLayout = {
+        'ar': 'ARABIC',    'bg': 'BULGARIAN', 'cs': 'CZECH',     'da': 'DANISH',
+        'de': 'GERMAN',    'el': 'GREEK',     'en': 'US',        'es': 'SPANISH',
+        'fi': 'FINNISH',   'fr': 'FRENCH',    'he': 'HEBREW',    'hu': 'HUNGARIAN',
+        'is': 'ICELANDIC', 'it': 'ITALIAN',   'ja': 'JAPANESE',  'ko': 'KOREAN',
+        'nb': 'NORWEGIAN', 'nl': 'DUTCH',     'nn': 'NORWEGIAN', 'no': 'NORWEGIAN',
+        'zh': 'CHINESE_US_KEYBOARD'
+    };
+    var localeLanguage = String(config.locale || 'en').toLowerCase().split(/[-_]/)[0];
+    var keyboardLayoutName = localeToKeyboardLayout[localeLanguage] || 'US';
+    log.debug(keyboardLayoutName.toLowerCase() + ' keyboard layout');
+    this.mcs.clientCoreData.obj.kbdLayout.value = t125.gcc.KeyboardLayout[keyboardLayoutName];
 
     this.cliprdr.on('clipboard', (content) => {
         this.emit('clipboard', content)

--- a/rdp/protocol/t125/gcc.js
+++ b/rdp/protocol/t125/gcc.js
@@ -190,7 +190,16 @@ var KeyboardLayout = {
     JAPANESE : 0x00000411,
     KOREAN : 0x00000412,
     DUTCH : 0x00000413,
-    NORWEGIAN : 0x00000414
+    NORWEGIAN : 0x00000414,
+    // Region specific layouts, where the region selects a different layout
+    // than the plain language does.
+    SWISS_GERMAN : 0x00000807,
+    UNITED_KINGDOM : 0x00000809,
+    BELGIAN_FRENCH : 0x0000080c,
+    BELGIAN_DUTCH : 0x00000813,
+    CANADIAN_FRENCH : 0x00001009,
+    SWISS_FRENCH : 0x0000100c,
+    IRISH : 0x00001809
 };
 
 /**


### PR DESCRIPTION
# Summary

In this pull request, the following changes are made:

- `rdp/protocol/rdp.js` now derives the RDP keyboard layout from the primary
  language subtag of `config.locale`, instead of comparing the whole locale
  string against `'fr'` and `'en'` only.

The Web-RDP client matched `config.locale` exactly, but browsers report full
language tags (`de-AT`, `de-DE`, `fr-FR`). Anything that was not literally
`'fr'` or `'en'` fell through to the default and was announced to the RDP host
as the US layout (0x409), so non-US users got an en-US input locale added to
their session on every new Web-RDP connection.

The new mapping only uses layouts that are already defined in
`t125.gcc.KeyboardLayout`, so no new constants are introduced and the default
stays US. As a side effect this also fixes French, which previously only worked
when the browser reported a bare `fr` rather than `fr-FR`.

Region variants (`de-CH` 0x807, `fr-CH` 0x100C, `en-GB` 0x809, `pt-BR` 0x416)
still fall back to their base language, because `KeyboardLayout` has no entries
for them. Happy to extend the enum in a follow-up if that is wanted.

The root cause was identified by @GA-Leftclick in #5097; this turns that finding
into a patch.

Fixes #5097

## Testing

Built into a custom image on top of `ghcr.io/ylianst/meshcentral:1.2.2` and
deployed on a production server (Synology Docker, Cloudflare Tunnel, WAN mode).
Verified in a Web-RDP session against German-language Windows hosts: the session
now comes up with the German input locale on first connect, QWERTZ, umlauts and
AltGr combinations behave correctly. Before the change the same session came up
as en-US every time.

<details>
<summary>Please follow this checklist to avoid unnecessary back and forth (click to expand)</summary>

- [x] 🧠 I used LLMs/AI in this contribution and reviewed all generated content.
      I understand that I am responsible for and able to explain every line of code I submit.
- [ ] 🔍 Any UI changes adhere to visual style of this project. (no UI changes)
- [x] 🛠️ I have self-reviewed and self-tested my code to ensure it works as expected.
- [ ] 🤖 I added or updated automated tests where appropriate. (no test harness for this path)
- [ ] 📄 Documentation updates are included (if applicable). (not applicable)
- [ ] 🧰 Dependency updates are listed and explained. (none)
- [ ] ⚠️ CI passes and is green.

</details>