### PR TITLE
Web-RDP: honor RDP performance flags in the standalone mstsc window

### DIFF
--- a/views/default.handlebars
+++ b/views/default.handlebars
@@ -3170,7 +3170,8 @@
                         if (node != null) { vncurl += '&name=' + encodeURIComponentEx(node.name); }
                         safeNewWindow(vncurl, 'mcnovnc/' + message.nodeid);
                     } else if (message.tag == 'mstsc') {
-                        var rdpurl = window.location.origin + domainUrl + 'mstsc.html?ws=' + message.cookie + (urlargs.key?('&key=' + urlargs.key):'');
+                        var rdpflags = (desktopsettings.rdpflags != null) ? ('flags=' + parseInt(desktopsettings.rdpflags) + '&') : '';
+                        var rdpurl = window.location.origin + domainUrl + 'mstsc.html?' + rdpflags + 'ws=' + message.cookie + (urlargs.key?('&key=' + urlargs.key):'');
                         var node = getNodeFromId(message.nodeid);
                         if (node != null) { rdpurl += '&name=' + encodeURIComponentEx(node.name); }
                         if (message.localRelay) { rdpurl += '&local=1'; }

--- a/views/default3.handlebars
+++ b/views/default3.handlebars
@@ -4053,7 +4053,8 @@
                         if (node != null) { vncurl += '&name=' + encodeURIComponentEx(node.name); }
                         safeNewWindow(vncurl, 'mcnovnc/' + message.nodeid);
                     } else if (message.tag == 'mstsc') {
-                        var rdpurl = window.location.origin + domainUrl + 'mstsc.html?ws=' + message.cookie + (urlargs.key ? ('&key=' + urlargs.key) : '');
+                        var rdpflags = (desktopsettings.rdpflags != null) ? ('flags=' + parseInt(desktopsettings.rdpflags) + '&') : '';
+                        var rdpurl = window.location.origin + domainUrl + 'mstsc.html?' + rdpflags + 'ws=' + message.cookie + (urlargs.key ? ('&key=' + urlargs.key) : '');
                         var node = getNodeFromId(message.nodeid);
                         if (node != null) { rdpurl += '&name=' + encodeURIComponentEx(node.name); }
                         if (message.localRelay) { rdpurl += '&local=1'; }

--- a/views/mstsc.handlebars
+++ b/views/mstsc.handlebars
@@ -117,6 +117,7 @@
             var password = Q('inputPassword').value;
             var savepass = Q('inputSaveCredentials').checked;
             var options = { savepass: savepass, useServerCreds: (Q('d3coreMode').value == 1) };
+            if (typeof urlargs.flags == 'number') { options.flags = urlargs.flags; }
             QV('myCanvas', true);
             QV('main', false);
             canvas.width = window.innerWidth;


### PR DESCRIPTION
# Summary

In this pull request, the following changes are made:

- The standalone Web-RDP window (`mstsc.html`) now applies the RDP options from
  the Remote Desktop Settings dialog. Previously it ignored them and always used
  the hardcoded `enablePerf` defaults, so for example the remote wallpaper was
  removed no matter what the user had configured. The embedded desktop tab
  already honoured these settings, and the server side already supports them —
  `apprelays.js` maps `infos.options.flags` to `args.perfFlags`.
- `desktopsettings.rdpflags` is now passed through the URL from
  `default.handlebars` and `default3.handlebars`, following the pattern already
  used for the noVNC window, and read back in `mstsc.handlebars` via the
  existing `urlargs` parser, which already coerces numeric values to Number.
- The `flags` argument is placed before `ws=` deliberately. `parseUriArgs()`
  splits the URL on `[?&|=]` and pairs even/odd indices, so a base64 cookie
  ending in a single `=` padding character shifts the pairing and drops every
  argument after it. Keeping `flags` first leaves it at index 0/1 and
  unaffected.
- Behaviour is unchanged when no `flags` argument is present. A value of `0`
  (all options unchecked) is handled correctly, since the check is
  `typeof == 'number'` rather than a truthy test and the server compares
  against `null`.

Note for the release: `views/translations/` and the `-min` variants are
gitignored and generated, so `translate.js translateall` needs to run for
non-English users to pick this up.

<details>
<summary>Please follow this checklist to avoid unnecessary back and forth (click to expand)</summary>

- [x] 🧠 I used LLMs/AI in this contribution and reviewed all generated content.
      I understand that I am responsible for and able to explain every line of code I submit.
- [ ] 🔍 Any UI changes adhere to visual style of this project. — n/a, no UI elements were added or changed
- [x] 🛠️ I have self-reviewed and self-tested my code to ensure it works as expected.
- [ ] 🤖 I added or updated automated tests where appropriate. — n/a, there is no test harness for the handlebars views
- [ ] 📄 Documentation updates are included (if applicable). — n/a
- [ ] 🧰 Dependency updates are listed and explained. — none
- [ ] ⚠️ CI passes and is green.

</details>

## Testing

Tested against 1.2.4 in Docker behind a Cloudflare tunnel, German browser
locale. Toggling "Disable Wallpaper" in the Remote Desktop Settings dialog is
now reflected in the standalone window: the URL changes from `flags=384` to
`flags=385` and the remote wallpaper disappears accordingly. Verified on
desktop Chrome, Brave, and Samsung Internet on mobile.

## Screenshots

| Disable Wallpaper | Result |
| --- | --- |
| unchecked (`flags=384`) | <img src="https://github.com/user-attachments/assets/6c569361-d7ae-4a10-91d5-6e98fd068e92" width="480"> |
| checked (`flags=385`) | <img src="https://github.com/user-attachments/assets/c4a18389-860f-4baa-a56a-a9f23ff87adb" width="480"> |
