### PR TITLE
meshctrl---user-id

### DIFF
--- a/meshctrl.js
+++ b/meshctrl.js
@@ -588,7 +588,8 @@ if (args['_'].length == 0) {
                         console.log("       4096 = Desktop Limited Input         8192 = Limit Events           ");
                         console.log("      16384 = Chat / Notify                32768 = Uninstall Agent        ");
                         console.log("      65536 = No Remote Desktop           131072 = Remote Commands        ");
-                        console.log("     262144 = Reset / Power off      4194304 = No Registry              ");
+                        console.log("     262144 = Reset / Power off          4194304 = No Registry            ");
+                        console.log("    8388608 = No Software                                                 ");
                         break;
                     }
                     case 'removefromusergroup': {
@@ -725,6 +726,7 @@ if (args['_'].length == 0) {
                         console.log("  --noterminal           - Hide the terminal tab from this user.");
                         console.log("  --nofiles              - Hide the files tab from this user.");
                         console.log("  --noregistry           - Hide the registry tab from this user.");
+                        console.log("  --nosoftware           - Hide the software tab from this user.");
                         console.log("  --noamt                - Hide the Intel AMT tab from this user.");
                         console.log("  --limitedevents        - User can only see his own events.");
                         console.log("  --chatnotify           - Allow chat and notification options.");
@@ -772,6 +774,7 @@ if (args['_'].length == 0) {
                         console.log("  --noterminal           - Hide the terminal tab from this user.");
                         console.log("  --nofiles              - Hide the files tab from this user.");
                         console.log("  --noregistry           - Hide the registry tab from this user.");
+                        console.log("  --nosoftware           - Hide the software tab from this user.");
                         console.log("  --noamt                - Hide the Intel AMT tab from this user.");
                         console.log("  --limitedevents        - User can only see his own events.");
                         console.log("  --chatnotify           - Allow chat and notification options.");

--- a/meshuser.js
+++ b/meshuser.js
@@ -6068,6 +6068,7 @@ module.exports.CreateMeshUser = function (parent, db, ws, req, args, domain, use
             var newuserid = command.userids[i], newuser = null;
             if (newuserid.startsWith('user/')) { newuser = parent.users[newuserid]; }
             else if (newuserid.startsWith('ugrp/')) { newuser = parent.userGroups[newuserid]; }
+            else { newuserid = 'user/' + domain.id + '/' + newuserid; newuser = parent.users[newuserid]; }
     
             // Search for a user name in that windows domain is the username starts with *\
             if ((newuser == null) && (newuserid.startsWith('user/' + domain.id + '/*\\')) == true) {


### PR DESCRIPTION
Regarding the documentation:
https://docs.meshcentral.com/meshctrl/#adding-and-removing-users-from-device-groups
also -userid without user// should be usable.

Added console logs for "no software"

Tested with meshctrl and the web

```
node meshctrl.js removeuserfromdevicegroup --id 'liCShAypMa5Lfx3@isAyCMSNH2QkB@623UaY4W1K0W99DwhJcw3ld$$GceTD6A4T' --userid user --loginuser "admin" --loginpass "admin"
node meshctrl.js addusertodevicegroup --id 'liCShAypMa5Lfx3@isAyCMSNH2QkB@623UaY4W1K0W99DwhJcw3ld$$GceTD6A4T' --userid user --remotecontrol --noterminal --loginuser "admin" --loginpass "admin"
```

Important notice: single quotes -> ' <- have to be used for the group id. I had the issue that $$ got translated to 99 