### PR TITLE
fix: add null check for obj.agentInfo to prevent TypeError crash

### DIFF
--- a/meshagent.js
+++ b/meshagent.js
@@ -826,7 +826,7 @@ module.exports.CreateMeshAgent = function (parent, db, ws, req, args, domain) {
                     db.Set(device);
 
                     // If this is a temporary device, don't log changes
-                    if (obj.agentInfo.capabilities & 0x20) { log = 0; }
+                    if ((obj.agentInfo) && (obj.agentInfo.capabilities & 0x20)) { log = 0; }
 
                     // Event the node change
                     var event = { etype: 'node', action: 'changenode', nodeid: obj.dbNodeKey, domain: domain.id, node: parent.CloneSafeNode(device) };
@@ -873,7 +873,7 @@ module.exports.CreateMeshAgent = function (parent, db, ws, req, args, domain) {
         db.Set(device);
 
         // Event the new node
-        if (obj.agentInfo.capabilities & 0x20) {
+        if ((obj.agentInfo) && (obj.agentInfo.capabilities & 0x20)) {
             // This is a temporary agent, don't log.
             parent.parent.DispatchEvent(parent.CreateMeshDispatchTargets(obj.dbMeshKey, [obj.dbNodeKey]), obj, { etype: 'node', action: 'addnode', node: device, domain: domain.id, nolog: 1 });
         } else {
@@ -2047,7 +2047,7 @@ module.exports.CreateMeshAgent = function (parent, db, ws, req, args, domain) {
 
                     // Event the node change
                     var event = { etype: 'node', action: 'changenode', nodeid: obj.dbNodeKey, domain: domain.id, node: parent.CloneSafeNode(device), msgid: 59, msgArgs: [device.name, mesh.name, changes.join(', ')], msg: 'Changed device ' + device.name + ' from group ' + mesh.name + ': ' + changes.join(', ') };
-                    if (obj.agentInfo.capabilities & 0x20) { event.nolog = 1; } // If this is a temporary device, don't log changes
+                    if ((obj.agentInfo) && (obj.agentInfo.capabilities & 0x20)) { event.nolog = 1; } // If this is a temporary device, don't log changes
                     if (db.changeStream) { event.noact = 1; } // If DB change stream is active, don't use this event to change the node. Another event will come.
                     parent.parent.DispatchEvent(parent.CreateMeshDispatchTargets(device.meshid, [obj.dbNodeKey]), obj, event);
                 }
@@ -2156,7 +2156,7 @@ module.exports.CreateMeshAgent = function (parent, db, ws, req, args, domain) {
     // Return 0 is no update needed, 1 update using native system, 2 update using meshcore system
     function compareAgentBinaryHash(agentExeInfo, agentHash) {
         // If this is a temporary agent and the server is set to not update temporary agents, don't update the agent.
-        if ((obj.agentInfo.capabilities & 0x20) && (args.temporaryagentupdate === false)) return 0;
+        if ((obj.agentInfo) && (obj.agentInfo.capabilities & 0x20) && (args.temporaryagentupdate === false)) return 0;
         // If we are testing the agent update system, always return true
         if ((args.agentupdatetest === true) || (args.agentupdatetest === 1)) return 1;
         if (args.agentupdatetest === 2) return 2;


### PR DESCRIPTION
Prevents TypeError: Cannot read properties of undefined (reading capabilities) when processing devices with missing agentInfo in the database.

4 lines modified in meshagent.js to add (obj.agentInfo) && guard before accessing obj.agentInfo.capabilities & 0x20.

Summary

In this pull request, the following changes are made:

- Added null guard (obj.agentInfo) && before accessing obj.agentInfo.capabilities & 0x20 in 4 locations in meshagent.js to prevent a TypeError crash when devices in the database have missing or corrupted agentInfo.
- Lines 92 and 2002 already had this guard — this PR extends the same pattern to the 4 remaining unguarded locations.
- The crash occurs during db.js iteration over device records: when obj.agentInfo is undefined, accessing obj.agentInfo.capabilities throws TypeError, crashing the server process.

Modified lines:

|Line | Before         | After         |
-----|------------------|-------------
|829  |  INLINECODE10  |  INLINECODE11 |
|876  |  INLINECODE12  |  INLINECODE13 |
|2050 |  INLINECODE14  |  INLINECODE15 |
|2159 |  INLINECODE16  |  INLINECODE17 |

**Error trace**:
`meshagent.js:2045
    if (obj.agentInfo.capabilities & 0x20) { event.nolog = 1; }
                      ^
TypeError: Cannot read properties of undefined (reading 'capabilities')
    at meshagent.js:2045:39
    at db.js:1598:21
    at Statement.<anonymous> (db.js:1457:29)`
    
- [x] 🧠 I used LLMs/AI in this contribution and reviewed all generated content. I understand that I am responsible for and able to explain every line of code I submit.
- [x] 🔍 Any UI changes adhere to visual style of this project. (N/A — no UI changes)
- [x] 🛠️ I have self-reviewed and self-tested my code to ensure it works as expected. (Syntax validated with node -c; tested in production server — crash stopped after applying the fix)
- [ ] 🤖 I added or updated automated tests where appropriate.
- [ ] 📄 Documentation updates are included (if applicable).
- [ ] 🧰 Dependency updates are listed and explained. (N/A — no dependency changes)
- [ ] ⚠️ CI passes and is green.
