### PR TITLE
Validate software action permissions

### DIFF
--- a/meshuser.js
+++ b/meshuser.js
@@ -13,6 +13,7 @@
 /*jshint esversion: 6 */
 "use strict";
 
+const softwareActions = require('./softwareactions.js');
 // volume & bitlocker statuses
 const encMethod = { 0: '', 1: "AES-128 with diffuser", 2: "AES-256 with diffuser", 3: 'AES-128', 4: 'AES-256', 5: "Hardware encryption", 6: 'XTS-AES-128', 7: 'XTS-AES-256' };
 const driveType = { 0: "Unknown", 1: "No Root Directory", 2: "Removable Disk", 3: "Local Disk", 4: "Network Drive", 5: "Compact Disc", 6: "RAM Disk" };
@@ -285,8 +286,9 @@ module.exports.CreateMeshUser = function (parent, db, ws, req, args, domain, use
                 parent.GetNodeWithRights(domain, user, agent.dbNodeKey, function (node, rights, visible) {
                     var mesh = parent.meshes[agent.dbMeshKey];
                     if ((node != null) && (mesh != null) && ((rights & MESHRIGHT_REMOTECONTROL) || (rights & MESHRIGHT_REMOTEVIEWONLY))) { // 8 is remote control permission, 256 is desktop read only
-                        if ((requiredRights != null) && ((rights & requiredRights) == 0)) { if (func) { func(false); return; } } // Check Required Rights
-                        if ((requiredNonRights != null) && (rights != MESHRIGHT_ADMIN) && ((rights & requiredNonRights) != 0)) { if (func) { func(false); return; } } // Check Required None Rights
+                        if ((options != null) && (options.softwareAction != null) && (softwareActions.isActionAllowed(options.softwareAction, rights) !== true)) { if (func) { func(false, 'denied'); } return; }
+                        if ((requiredRights != null) && ((rights & requiredRights) == 0)) { if (func) { func(false, 'denied'); } return; } // Check Required Rights
+                        if ((requiredNonRights != null) && (rights != MESHRIGHT_ADMIN) && ((rights & requiredNonRights) != 0)) { if (func) { func(false, 'denied'); } return; } // Check Required None Rights
 
                         command.sessionid = ws.sessionId;   // Set the session id, required for responses
                         command.rights = rights;            // Add user rights flags to the message
@@ -318,7 +320,8 @@ module.exports.CreateMeshUser = function (parent, db, ws, req, args, domain, use
                         if (typeof domain.desktopprivacybartext == 'string') { command.privacybartext = domain.desktopprivacybartext; } // Privacy bar text
                         delete command.nodeid;              // Remove the nodeid since it's implied
                         try { agent.send(JSON.stringify(command)); } catch (ex) { }
-                    } else { if (func) { func(false); } }
+                        if ((func != null) && (options != null) && (options.waitForRights === true)) { func(true); }
+                    } else { if (func) { func(false, 'denied'); } }
                 });
             } else {
                 // Check if a peer server is connected to this agent
@@ -326,11 +329,11 @@ module.exports.CreateMeshUser = function (parent, db, ws, req, args, domain, use
                 if (routing != null) {
                     // Check if we have permission to send a message to that node
                     parent.GetNodeWithRights(domain, user, command.nodeid, function (node, rights, visible) {
-                        if ((requiredRights != null) && ((rights & requiredRights) == 0)) { if (func) { func(false); return; } } // Check Required Rights
-                        if ((requiredNonRights != null) && (rights != MESHRIGHT_ADMIN) && ((rights & requiredNonRights) != 0)) { if (func) { func(false); return; } } // Check Required None Rights
-
                         var mesh = parent.meshes[routing.meshid];
                         if ((node != null) && (mesh != null) && ((rights & MESHRIGHT_REMOTECONTROL) || (rights & MESHRIGHT_REMOTEVIEWONLY))) { // 8 is remote control permission
+                            if ((options != null) && (options.softwareAction != null) && (softwareActions.isActionAllowed(options.softwareAction, rights) !== true)) { if (func) { func(false, 'denied'); } return; }
+                            if ((requiredRights != null) && ((rights & requiredRights) == 0)) { if (func) { func(false, 'denied'); } return; } // Check Required Rights
+                            if ((requiredNonRights != null) && (rights != MESHRIGHT_ADMIN) && ((rights & requiredNonRights) != 0)) { if (func) { func(false, 'denied'); } return; } // Check Required None Rights
                             command.fromSessionid = ws.sessionId;   // Set the session id, required for responses
                             command.rights = rights;                // Add user rights flags to the message
                             if ((options != null) && (options.removeViewOnlyLimitation === true) && (command.rights != 0xFFFFFFFF) && ((command.rights & 0x100) != 0)) { command.rights -= 0x100; } // Since the multiplexor will enforce view-only, remove MESHRIGHT_REMOTEVIEWONLY
@@ -357,12 +360,13 @@ module.exports.CreateMeshUser = function (parent, db, ws, req, args, domain, use
                             command.remoteaddr = req.clientIp;      // User's IP address
                             if (typeof domain.desktopprivacybartext == 'string') { command.privacybartext = domain.desktopprivacybartext; } // Privacy bar text
                             parent.parent.multiServer.DispatchMessageSingleServer(command, routing.serverid);
-                        } else { if (func) { func(false); } }
+                            if ((func != null) && (options != null) && (options.waitForRights === true)) { func(true); }
+                        } else { if (func) { func(false, 'denied'); } }
                     });
-                } else { if (func) { func(false); } return false; }
+                } else { if (func) { func(false, 'offline'); } return false; }
             }
-        } else { if (func) { func(false); } return false; }
-        if (func) { func(true); }
+        } else { if (func) { func(false, 'denied'); } return false; }
+        if ((func != null) && ((options == null) || (options.waitForRights !== true))) { func(true); }
         return true;
     }
 
@@ -987,21 +991,18 @@ module.exports.CreateMeshUser = function (parent, db, ws, req, args, domain, use
                     break;
                 }
             case 'software': {
-                if (command.responseid != null) { try { ws.send(JSON.stringify({ action: 'software', responseid: command.responseid, result: 'Denied' })); } catch (ex) { } }
-                
-                parent.GetNodeWithRights(domain, user, command.nodeid, function (node, rights, visible) {
-                    var mesh = parent.meshes[node.meshid];
-                    if ((node != null) && (mesh != null) && (rights === MESHRIGHT_ADMIN) || ((rights & MESHRIGHT_NOSOFTWARE) === 0)) {
-                        var agent = parent.wsagents[command.nodeid];
-                        if (agent != null) {
-                            routeCommandToNode(command, requiredRights, requiredNonRights, func, routingOptions);
-                        } else {
-                            if (command.responseid != null) { try { ws.send(JSON.stringify({ action: 'software', responseid: command.responseid, result: 'Agent offline' })); } catch (ex) { } }
-                        }
-                    } else {
-                        if (command.responseid != null) { try { ws.send(JSON.stringify({ action: 'software', responseid: command.responseid, result: 'Denied' })); } catch (ex) { } }
-                    }
-                });
+                if (softwareActions.getActionKind(command.type) == null) {
+                    if (command.responseid != null) { try { ws.send(JSON.stringify({ action: 'software', responseid: command.responseid, result: 'Denied' })); } catch (ex) { } }
+                    break;
+                }
+                var softwareRouteResult = null;
+                if (command.responseid != null) {
+                    softwareRouteResult = function (r, reason) {
+                        if (r === true) return;
+                        try { ws.send(JSON.stringify({ action: 'software', responseid: command.responseid, result: (reason === 'offline') ? 'Agent offline' : 'Denied' })); } catch (ex) { }
+                    };
+                }
+                routeCommandToNode(command, null, null, softwareRouteResult, { softwareAction: command.type, waitForRights: true });
                 break;
             }
             case 'msg':

--- a/softwareactions.js
+++ b/softwareactions.js
@@ -1,0 +1,30 @@
+/**
+* @description Software action permission checks
+* @license Apache-2.0
+*/
+
+/*jslint node: true */
+/*jshint node: true */
+/*jshint strict:false */
+/*jshint esversion: 6 */
+"use strict";
+
+const MESHRIGHT_NOSOFTWARE = 0x00800000;
+const MESHRIGHT_ADMIN = 0xFFFFFFFF;
+const readActions = new Set(['installedapps', 'installedstoreapps']);
+const changeActions = new Set(['uninstallapp', 'uninstallstoreapp']);
+
+module.exports.getActionKind = function (action) {
+    if (readActions.has(action)) return 'read';
+    if (changeActions.has(action)) return 'change';
+    return null;
+};
+
+module.exports.isActionAllowed = function (action, rights) {
+    if (typeof rights != 'number') return false;
+    const actionKind = module.exports.getActionKind(action);
+    if (actionKind == null) return false;
+    if (rights === MESHRIGHT_ADMIN) return true;
+    if (actionKind === 'change') return false;
+    return ((rights & MESHRIGHT_NOSOFTWARE) === 0);
+};

--- a/tests/softwareactions.test.js
+++ b/tests/softwareactions.test.js
@@ -1,0 +1,43 @@
+'use strict';
+
+const assert = require('assert');
+const softwareActions = require('../softwareactions.js');
+
+const ADMIN = 0xFFFFFFFF;
+const REMOTE_CONTROL = 0x00000008;
+const REMOTE_VIEW_ONLY = 0x00000100;
+const DEVICE_DETAILS = 0x00100000;
+const NO_SOFTWARE = 0x00800000;
+
+function permitted(action, rights) {
+    return softwareActions.isActionAllowed(action, rights);
+}
+
+assert.strictEqual(permitted('installedapps', REMOTE_CONTROL | REMOTE_VIEW_ONLY), true, 'view-only users retain inventory access');
+assert.strictEqual(permitted('installedstoreapps', REMOTE_CONTROL | REMOTE_VIEW_ONLY), true, 'view-only users retain store inventory access');
+assert.strictEqual(permitted('uninstallapp', REMOTE_CONTROL | REMOTE_VIEW_ONLY), false, 'view-only users cannot change software');
+assert.strictEqual(permitted('uninstallstoreapp', REMOTE_CONTROL | REMOTE_VIEW_ONLY), false, 'view-only users cannot change store software');
+
+assert.strictEqual(permitted('uninstallapp', DEVICE_DETAILS), false, 'device details does not permit software changes');
+assert.strictEqual(permitted('uninstallapp', REMOTE_CONTROL), false, 'remote control does not permit software changes');
+assert.strictEqual(permitted('uninstallstoreapp', REMOTE_CONTROL), false, 'remote control does not permit store software changes');
+
+assert.strictEqual(permitted('installedapps', ADMIN), true, 'administrators can read inventory');
+assert.strictEqual(permitted('installedstoreapps', ADMIN), true, 'administrators can read store inventory');
+assert.strictEqual(permitted('uninstallapp', ADMIN), true, 'administrators can change software');
+assert.strictEqual(permitted('uninstallstoreapp', ADMIN), true, 'administrators can change store software');
+
+assert.strictEqual(permitted('installedapps', REMOTE_CONTROL | REMOTE_VIEW_ONLY | NO_SOFTWARE), false, 'No Software denies inventory access');
+assert.strictEqual(permitted('uninstallapp', REMOTE_CONTROL | REMOTE_VIEW_ONLY | NO_SOFTWARE), false, 'No Software denies software changes');
+assert.strictEqual(permitted('unknown', ADMIN), false, 'unknown actions are denied');
+assert.strictEqual(permitted('UninstallApp', ADMIN), false, 'action names are exact');
+assert.strictEqual(permitted(undefined, ADMIN), false, 'missing actions are denied');
+assert.strictEqual(permitted('installedapps', undefined), false, 'missing rights are denied');
+
+assert.strictEqual(softwareActions.getActionKind('installedapps'), 'read');
+assert.strictEqual(softwareActions.getActionKind('installedstoreapps'), 'read');
+assert.strictEqual(softwareActions.getActionKind('uninstallapp'), 'change');
+assert.strictEqual(softwareActions.getActionKind('uninstallstoreapp'), 'change');
+assert.strictEqual(softwareActions.getActionKind('unknown'), null);
+
+console.log('software action permission checks passed');


### PR DESCRIPTION
## Summary

- distinguish software inventory requests from software-changing requests
- require the existing administrative permission before routing uninstall actions
- apply the same permission decision to local and peer routes
- return permission results after the rights lookup completes
- add focused coverage for view-only and administrative users

## Why

The shared software handler applied the inventory-view permission to both read-only and state-changing requests. This aligns direct software requests with the permission already enforced by the user interface, while preserving inventory access.

This is intentionally limited to server-side action permission checks and can coexist with the broader Software UI permission work in #8035.

## Testing

- `node tests/softwareactions.test.js`
- `node --check meshuser.js`
- `node --check softwareactions.js`
- `node --check tests/softwareactions.test.js`
- `npm pack --dry-run --ignore-scripts --json`
- verified inventory access for a read-only user
- verified uninstall routing for an administrative user
- verified uninstall requests are rejected for view-only, device-details, and non-administrative remote-control users
- verified unknown software actions are rejected

Related: #7880, #8035
