### PR TITLE
Ensure desktop key release on dialog open and window blur

### DIFF
--- a/views/default.handlebars
+++ b/views/default.handlebars
@@ -4510,7 +4510,9 @@
 
         //function ondocfocus() { }
         // TODO: Add handleReleaseKeys() for Intel AMT.
-        function ondocblur() { if (!xxdialogMode && xxcurrentView == 11 && desktop && Q('DeskControl').checked && desktop.m.handleReleaseKeys) { return desktop.m.handleReleaseKeys(); } }
+        // On window blur (e.g. alt-tab away mid-keypress), release any keys the desktop is still
+        // holding so they don't stick and auto-repeat on the remote. Runs regardless of dialog state.
+        function ondocblur() { if ((xxcurrentView == 11) && desktop && desktop.m && desktop.m.handleReleaseKeys && Q('DeskControl') && Q('DeskControl').checked) { return desktop.m.handleReleaseKeys(); } }
 
         // Highlights the device group hovered
         function devGrpMouseHover(element, over) {
@@ -20121,6 +20123,14 @@
         function setDialogMode(x, y, b, f, c, tag) {
             setSessionActivity();
             QV('uiMenu', false);
+            // Opening/closing a dialog over an active remote desktop: release any keys the desktop is
+            // still holding and pause keyboard capture, so keys typed into the dialog (e.g. Ctrl+V into
+            // the Clipboard box) don't leak to the agent and stick down (Wayland then auto-repeats the
+            // held key, e.g. "vvvv"). Resume capture when the dialog closes.
+            if ((xxcurrentView == 11) && desktop && desktop.m && Q('DeskControl') && Q('DeskControl').checked) {
+                if (x && !xxdialogMode) { if (desktop.m.handleReleaseKeys) { desktop.m.handleReleaseKeys(); } if (desktop.m.UnGrabKeyInput) { desktop.m.UnGrabKeyInput(); } }
+                else if (!x && xxdialogMode) { if (desktop.m.GrabKeyInput) { desktop.m.GrabKeyInput(); } }
+            }
             xxdialogMode = x;
             xxdialogFunc = f;
             xxdialogButtons = b;

--- a/views/default3.handlebars
+++ b/views/default3.handlebars
@@ -5417,7 +5417,9 @@
 
         //function ondocfocus() { }
         // TODO: Add handleReleaseKeys() for Intel AMT.
-        function ondocblur() { if (!xxdialogMode && xxcurrentView == 11 && desktop && Q('DeskControl').checked && desktop.m.handleReleaseKeys) { return desktop.m.handleReleaseKeys(); } }
+        // On window blur (e.g. alt-tab away mid-keypress), release any keys the desktop is still
+        // holding so they don't stick and auto-repeat on the remote. Runs regardless of dialog state.
+        function ondocblur() { if ((xxcurrentView == 11) && desktop && desktop.m && desktop.m.handleReleaseKeys && Q('DeskControl') && Q('DeskControl').checked) { return desktop.m.handleReleaseKeys(); } }
 
         // Highlights the device group hovered
         function devGrpMouseHover(element, over) {
@@ -6914,7 +6916,16 @@
 
         var xxModal;
 
+        // A dialog/modal opening over the active remote desktop swallows the in-flight key-up (the
+        // ondockey* handlers stop forwarding once xxdialogMode is set), leaving that key held down on
+        // the remote where it auto-repeats (e.g. Ctrl+V opening the Clipboard dialog pastes "vvvv...").
+        // Release held keys before the dialog takes the keyboard. Unlike the classic UI there is no
+        // UnGrabKeyInput/GrabKeyInput pair to pause/resume here: this UI never attaches the desktop
+        // module's own key handlers, the page-level ondockey* handlers gate on xxdialogMode instead.
+        function deskDialogReleaseKeys() { if (!xxdialogMode && (xxcurrentView == 11) && desktop && desktop.m && desktop.m.handleReleaseKeys && Q('DeskControl') && Q('DeskControl').checked) { desktop.m.handleReleaseKeys(); } }
+
         function setModalContent(modalId, title, bodyContent, size = null) {
+            deskDialogReleaseKeys();
             // Check if the modal elements exist
             var modalConfigurableElement = document.getElementById('xxAddAgentModalConf');
             var modalTitleElement = document.getElementById(modalId + 'Title');
@@ -22902,6 +22913,7 @@
         function setDialogMode(x, y, b, f, c, tag) {
             setSessionActivity();
             QV('uiMenu', false);
+            if (x) { deskDialogReleaseKeys(); }
             xxdialogMode = x;
             xxdialogFunc = f;
             xxdialogButtons = b;

--- a/views/sharing.handlebars
+++ b/views/sharing.handlebars
@@ -348,6 +348,7 @@
             document.onkeypress = ondockeypress;
             document.onkeydown = ondockeydown;
             document.onkeyup = ondockeyup;
+            window.onblur = ondocblur;
             setupDesktop();
             setupTerminal();
             setupFiles();
@@ -2283,7 +2284,16 @@
 
         // Display a dialog box
         // Parameters: Dialog Mode (0 = none), Dialog Title, Buttons (1 = OK, 2 = Cancel, 3 = OK & Cancel), Call back function(0 = Cancel, 1 = OK), Dialog Content (Mode 2 only)
+        // A dialog opening over the shared desktop swallows the in-flight key-up (ondockeyup gates on
+        // xxdialogMode), leaving the key held on the remote where Wayland auto-repeats it (e.g. Ctrl+V
+        // opening the Clipboard dialog pastes "vvvv..."). Release held keys before the dialog opens, and
+        // on window blur. No GrabKeyInput pause/resume here: the page-level ondockey* handlers gate on
+        // xxdialogMode, so re-grabbing would double-forward keys.
+        function deskDialogReleaseKeys() { if (!xxdialogMode && desktop && desktop.m && desktop.m.handleReleaseKeys && Q('DeskControl') && isInputAllowed()) { desktop.m.handleReleaseKeys(); } }
+        function ondocblur() { if (desktop && desktop.m && desktop.m.handleReleaseKeys && Q('DeskControl') && isInputAllowed()) { return desktop.m.handleReleaseKeys(); } }
+
         function setDialogMode(x, y, b, f, c, tag) {
+            if (x) { deskDialogReleaseKeys(); }
             xxdialogMode = x;
             xxdialogFunc = f;
             xxdialogButtons = b;


### PR DESCRIPTION
Fixes key leakage to the agent when dialogs open over active remote desktops by releasing held keys and pausing keyboard capture (handleReleaseKeys + UnGrabKeyInput), resuming on close (GrabKeyInput). Adds key release on window blur to prevent stuck keys when alt-tabbing mid-keypress.

- Relates to https://github.com/Ylianst/MeshAgent/pull/351

- [x] 🧠 I used LLMs/AI in this contribution and reviewed all generated content.
      I understand that I am responsible for and able to explain every line of code I submit.
- [x] 🔍 Any UI changes adhere to visual style of this project.
- [x] 🛠️ I have self-reviewed and self-tested my code to ensure it works as expected.
- [ ] 🤖 I added or updated automated tests where appropriate.
- [ ] 📄 Documentation updates are included (if applicable).
- [ ] 🧰 Dependency updates are listed and explained.
- [ ] ⚠️ CI passes and is green.