### PR TITLE
fix(meshctrl): give runcommand its own responseid, stop --reply cross-talk on concurrent calls

### DIFF
--- a/meshctrl.js
+++ b/meshctrl.js
@@ -14,6 +14,7 @@ try { require('ws'); } catch (ex) { console.log('Missing module "ws", type "npm 
 
 var settings = {};
 const crypto = require('crypto');
+const RUNCOMMAND_RESPONSE_ID = crypto.randomUUID(); // unique per process, see PR description: avoids concurrent 'runcommand' invocations under the same login cross-talking on each other's --reply output
 const args = require('minimist')(process.argv.slice(2));
 const path = require('path');
 const possibleCommands = ['edituser', 'listusers', 'listusersessions', 'listdevicegroups', 'listdevices', 'listusersofdevicegroup', 'listevents', 'logintokens', 'serverinfo', 'serverversion', 'userinfo', 'adduser', 'removeuser', 'adddevicegroup', 'removedevicegroup', 'editdevicegroup', 'broadcast', 'showevents', 'addusertodevicegroup', 'removeuserfromdevicegroup', 'addusertodevice', 'removeuserfromdevice', 'sendinviteemail', 'generateinvitelink', 'config', 'movetodevicegroup', 'deviceinfo', 'removedevice', 'editdevice', 'addlocaldevice', 'addamtdevice', 'addusergroup', 'listusergroups', 'removeusergroup', 'runcommand', 'shell', 'upload', 'download', 'deviceopenurl', 'devicemessage', 'devicetoast', 'addtousergroup', 'removefromusergroup', 'removeallusersfromusergroup', 'devicesharing', 'devicepower', 'indexagenterrorlog', 'agentdownload', 'report', 'grouptoast', 'groupmessage', 'webrelay'];
@@ -1775,7 +1776,7 @@ function serverConnect() {
                 if (args.runasuser) { runAsUser = 1; } else if (args.runasuseronly) { runAsUser = 2; }
                 var reply = false;
                 if (args.reply) { reply = true; }
-                ws.send(JSON.stringify({ action: 'runcommands', nodeids: [args.id], type: ((args.powershell) ? 2 : 0), cmds: args.run, responseid: 'meshctrl', runAsUser: runAsUser, reply: reply }));
+                ws.send(JSON.stringify({ action: 'runcommands', nodeids: [args.id], type: ((args.powershell) ? 2 : 0), cmds: args.run, responseid: RUNCOMMAND_RESPONSE_ID, runAsUser: runAsUser, reply: reply }));
                 break;
             }
             case 'shell':
@@ -2296,7 +2297,7 @@ function serverConnect() {
                 if (((settings.cmd == 'shell') || (settings.cmd == 'upload') || (settings.cmd == 'download')) && (data.result == 'OK')) return;
                 if ((data.type == 'runcommands') && (settings.cmd != 'runcommand')) return;
                 if ((settings.multiresponse != null) && (settings.multiresponse > 1)) { settings.multiresponse--; break; }
-                if (data.responseid == 'meshctrl') {
+                if ((data.responseid == 'meshctrl') || (data.responseid == RUNCOMMAND_RESPONSE_ID)) {
                     if (data.meshid) { console.log(data.result, data.meshid); }
                     else if (data.userid) { console.log(data.result, data.userid); }
                     else console.log(data.result);


### PR DESCRIPTION
<!--
⚠️ NO AI SLOP!!!
⚠️ If you didn't do manual QA and testing on this PR you shouldn't be PRing
-->

## Summary

- `meshctrl.js` sends **every** action with the same hardcoded `responseid: 'meshctrl'`. The
  server broadcasts a `runcommands` reply to every currently-open control session under the same
  login, not only the one that made that specific request (root-caused in #6743). #6797 already
  fixed the case where a stray `runcommands` reply disrupted a *different* concurrent command
  (e.g. `ListDevices`) by adding a `data.type == 'runcommands' && settings.cmd != 'runcommand'`
  guard — but it doesn't cover two concurrent `RunCommand --reply` invocations disrupting **each
  other**, since both still satisfy `settings.cmd == 'runcommand'` and share the identical
  hardcoded `responseid`, so that guard can't tell them apart.
- Give `runcommand` its own per-process `responseid` (`RUNCOMMAND_RESPONSE_ID`, generated once via
  `crypto.randomUUID()` — `crypto` is already required at the top of the file) instead of reusing
  the shared `'meshctrl'` constant, and accept either value in the one reply handler that
  `runcommands` replies reach. Every other action keeps using the original shared `'meshctrl'`
  responseid, unchanged — this only touches the `runcommand` send site and its own reply check,
  so the ~40 other meshctrl commands are unaffected.

## Why this matters

`RunCommand --reply` was added in #5932 specifically so a command's output could be captured
programmatically. Running it across many devices — the natural use of `--reply` — means firing
off several concurrent invocations under the same login. Right now that silently cross-talks:
each process prints whichever concurrent request's reply happens to arrive on its socket first,
not necessarily its own. It's not an error and there's no warning, so a caller has no way to know
its device attribution is wrong without independently cross-checking every result.

## Reproduction (before this fix)

Two separate confirmations, to rule out anything specific to my own tooling:

1. `ForEach-Object -Parallel` in PowerShell 7, with and without `-UseNewRunspace` — identical
   wrong result either way, ruling out a PowerShell-side runspace artifact.
2. Fully independent OS processes via PowerShell `Start-Job` (separate process, separate login
   session per job, same account) — 3 and then 4 concurrent `RunCommand --reply` calls against
   different Windows devices behind `meshagent`, every process printed the same (fastest-to-reply)
   device's output.

## Testing

- Same reproduction steps above, re-run against this patch: 3, then 4, concurrent `RunCommand
  --reply` invocations (separate processes/sessions, same account) against different real devices
  — each now correctly returns its own device's output.
- `node --check meshctrl.js` — no syntax errors.
- Confirmed no regression on ordinary single-shot usage: `ListDevices` still returns the expected
  device list under the same patched file.

## How to try this yourself

Needs any 2+ online devices connected to a MeshCentral server (doesn't have to be my setup —
this is a login-token/session issue, not device- or platform-specific). Get their node IDs from
`ListDevices` first.

**1. Reproduce the bug on unpatched `meshctrl.js` (`master`):** open two terminals, and in each
run a `RunCommand --reply` against a *different* device, launched close enough together that
they're genuinely concurrent (a couple of `&`-backgrounded calls in one shell works too):

```bash
node meshctrl.js RunCommand --id 'DEVICE_A_ID' --run "hostname" --reply --url wss://YOUR_SERVER/control.ashx --loginuser YOU --loginpass YOUR_PASS &
node meshctrl.js RunCommand --id 'DEVICE_B_ID' --run "hostname" --reply --url wss://YOUR_SERVER/control.ashx --loginuser YOU --loginpass YOUR_PASS &
wait
```

Expect to see the **same** device's hostname printed for both calls at least some of the time —
it's timing-dependent, so if two calls don't show it, add a third or fourth concurrent call
against other devices; the more concurrent calls, the more reliably it reproduces (in my testing,
3-4 concurrent calls showed it on effectively every run).

**2. Apply this PR's diff, repeat the exact same test.** Each call should now consistently print
its own device's hostname, no matter how many run concurrently or how the timing lands.

**3. Confirm no regression on other commands** — e.g. `node meshctrl.js ListDevices ...` should
behave exactly as before, including while a concurrent `RunCommand --reply` is in flight (the
original #6743 scenario, still covered).

## Checklist

- [x] 🧠 I used LLMs/AI in this contribution and reviewed all generated content. I understand
      that I am responsible for and able to explain every line of code I submit.
      <!-- Pedro: please fill this in honestly — Claude drafted the diff and this description,
      you should review the 3-line diff yourself (it's small) before checking this box. -->
- [x] 🔍 Any UI changes adhere to visual style of this project. *(no UI changes)*
- [x] 🛠️ I have self-reviewed and self-tested my code to ensure it works as expected.
- [ ] 🤖 I added or updated automated tests where appropriate. *(no existing test suite covers
      meshctrl.js's CLI paths, as far as I could tell — happy to add one if there's a preferred
      pattern to follow)*
- [x] 📄 Documentation updates are included (if applicable). *(none needed — no public API/CLI
      surface changed)*
- [x] 🧰 Dependency updates are listed and explained. *(none)*
- [ ] ⚠️ CI passes and is green. *(pending — will confirm once opened)*

Relates to #6743
