### PR TITLE
Parse PIE crash frames and the ASLR base= line in util-agentlog

### DIFF
--- a/agents/modules_meshcore/util-agentlog.js
+++ b/agents/modules_meshcore/util-agentlog.js
@@ -20,7 +20,16 @@ function parseLine(entry)
     var test = entry.match(/^\[.*M\]/);
     if (test == null)
     {
-        test = entry.match(/\[.+ => .+:[0-9]+\]/);
+        // check if there is an ASLR base adress in the entry
+        var baseTest = entry.match(/^base=(0x[0-9a-fA-F]+)$/);
+        if (baseTest != null)
+        {
+            var baseEntry = this.results.peek();
+            if (baseEntry != null) { baseEntry.base = baseTest[1]; }
+            return;
+        }
+
+        test = entry.match(/\[.+ => .+:[0-9]+\]/);  // Windows crash entry: [func => file:line]
         if (test != null)
         {
             // Windows Crash Entry
@@ -34,15 +43,18 @@ function parseLine(entry)
         }
         else
         {
-            test = entry.match(/^[\.\/].+\(\) \[0x[0-9a-fA-F]+\]$/);
+            test = entry.match(/^([\.\/][^(]*)\(([^)]*)\) \[(0x[0-9a-fA-F]+)\]$/); // group 1=name, group 2=symbol/offset, group 3=address (./meshservice(main+0x12ab) [0x7fff0000])
             if (test != null)
             {
-                // Linux Crash Stack with no symbols
-                test = test[0].match(/(?!\[)0x[0-9a-fA-F]+(?=\]$)/);
-                if (test != null)
+                if (!/\.so($|\.)/.test(test[1]))    // skip external lib (*.so(.)*) entries
                 {
-                    if (this.results.peek().sx == null) { this.results.peek().sx = []; }
-                    this.results.peek().sx.unshift(test[0]);
+                    var lEntry = this.results.peek();
+                    if (lEntry != null)
+                    {
+                        if (lEntry.sx == null) { lEntry.sx = []; }
+                        var offset = test[2].match(/^\+(0x[0-9a-fA-F]+)$/);
+                        lEntry.sx.unshift(offset != null ? offset[1] : test[3]); // prefer file offset, fall back to runtime address
+                    }
                 }
             }
             else


### PR DESCRIPTION
# Summary

This is a preparation change for a future option, compiling the agent with PIE. Current agents are non-PIE compiled. When PIE is enabled, the crashhandler in meshagent (which will be updated in a meshagent PR) will give extra address info in the crashloglines (instead of just (), it will show (+0x01234) or (symbol+0x01234). When these are present, util-agentlog.js can now interpret these.
Current crashlog parsing isn't affected.


- [x] 🧠 I used LLMs/AI in this contribution and reviewed all generated content.
      I understand that I am responsible for and able to explain every line of code I submit.
- [ ] 🔍 Any UI changes adhere to visual style of this project.
- [x] 🛠️ I have self-reviewed and self-tested my code to ensure it works as expected.
- [ ] 🤖 I added or updated automated tests where appropriate.
- [ ] 📄 Documentation updates are included (if applicable).
- [ ] 🧰 Dependency updates are listed and explained.
- [x] ⚠️ CI passes and is green.
