### PR TITLE
Fix mouse position when the desktop view is rotated

### DIFF
--- a/public/scripts/agent-desktop-0.0.2.js
+++ b/public/scripts/agent-desktop-0.0.2.js
@@ -590,6 +590,9 @@ var CreateAgentRemoteDesktop = function (canvasid, scrolldiv) {
             if (event.addy) { Y += event.addy; }
 
             if (X >= 0 && X <= obj.Canvas.canvas.width && Y >= 0 && Y <= obj.Canvas.canvas.height) {
+                // Map the displayed (view-rotated) canvas position back to desktop coordinates,
+                // like amt-desktop does; without this every rotated view sends wrong mouse positions.
+                if (obj.rotation != 0) { var rotatedX = obj.crotX(X, Y); Y = obj.crotY(X, Y); X = rotatedX; }
                 var Button = 0;
                 var Delta = 0;
                 if (Action == obj.KeyAction.UP || Action == obj.KeyAction.DOWN) {


### PR DESCRIPTION
# Summary

The desktop viewer defines crotX/crotY to map view-rotated canvas coordinates back to desktop coordinates, but SendMouseMsg never called them, so any use of the Rotate buttons sent unrotated coordinates and clicks landed in the wrong place (on any agent OS, worse with multiple monitors). The AMT viewer already applies its identical _crotX/_crotY pair; this makes agent-desktop-0.0.2.js do the same.


- Relates to https://github.com/Ylianst/MeshAgent/pull/351

<summary>Please follow this checklist to avoid unnecessary back and forth (click to expand)</summary>

- [x] 🧠 I used LLMs/AI in this contribution and reviewed all generated content.
      I understand that I am responsible for and able to explain every line of code I submit.
- [x] 🔍 Any UI changes adhere to visual style of this project.
- [x] 🛠️ I have self-reviewed and self-tested my code to ensure it works as expected.
- [ ] 🤖 I added or updated automated tests where appropriate.
- [ ] 📄 Documentation updates are included (if applicable).
- [ ] 🧰 Dependency updates are listed and explained.
- [x] ⚠️ CI passes and is green.