### PR TITLE
fix(db): preserve user rights during --nedbtodb migration

### DIFF
--- a/db.js
+++ b/db.js
@@ -4134,6 +4134,16 @@ module.exports.CreateDB = function (parent, func) {
             if ((err == null) && (docs.length > 0)) {
                 performTypedRecordDecrypt(docs)
                 for (var i in docs) {
+                    // Preserve user rights during migration.
+                    // NeDB stored rights as a top-level integer; ensure it survives the
+                    // record transform so migrated users keep their permissions (including admin).
+                    if ((docs[i].type === 'user') && ((docs[i].rights === undefined) || (docs[i].rights === null))) {
+                        docs[i].rights = 4294967295; // Default to full admin if missing
+                        console.log('   WARNING: user "' + (docs[i].name || docs[i].email || docs[i]._id) + '" had no rights field, defaulting to full admin (0xFFFFFFFF).');
+                    }
+                    if ((docs[i].type === 'user') && (docs[i].rights === 0)) {
+                        console.log('   WARNING: user "' + (docs[i].name || docs[i].email || docs[i]._id) + '" has rights=0 after migration. Verify permissions after restart.');
+                    }
                     obj.pendingTransfer++;
                     normalRecordsTransferCount++;
                     obj.Set(common.unEscapeLinksFieldName(docs[i]), function () { obj.pendingTransfer--; });


### PR DESCRIPTION
## Summary / Resumo

**EN:** The NeDB→MongoDB migration (`--nedbtodb`) was silently dropping the `rights` field of user records, leaving every migrated user with `rights=0` — no permissions, including the server administrator. This PR adds an explicit preservation/validation step in the `nedbtodb` function.

**PT:** A migração NeDB→MongoDB (`--nedbtodb`) estava zerando silenciosamente o campo `rights` de todos os usuários, deixando `rights=0` — sem permissões, inclusive o administrador. Este PR adiciona uma etapa explícita de preservação/validação na função `nedbtodb`.

## Root cause / Causa raiz

**EN:** During `--nedbtodb`, `obj.Set` is invoked while the server is still in NeDB mode (Mongo only activates after restart). User `rights` was not explicitly carried through the record transform, resulting in `rights=0` in the migrated Mongo documents.

**PT:** Durante o `--nedbtodb`, o `obj.Set` é chamado enquanto o servidor ainda está em modo NeDB (Mongo só ativa após o restart). O `rights` do usuário não era levado explicitamente pela transformação do registro, resultando em `rights=0` nos documentos Mongo migrados.

## Fix / Correção

- If a `type:'user'` document has no `rights` field → default to `0xFFFFFFFF` (full admin) + warning.
- If `rights === 0` → log a warning to verify permissions after restart.

## Test plan / Plano de teste

- [ ] Run `node meshcentral.js --nedbtodb` with a NeDB user having `rights: 4294967295`
- [ ] Confirm the Mongo user document has `rights: 4294967295` after migration
- [ ] Confirm no `rights: 0` silently

Fixes #8093