### PR TITLE
Pr 7947 reviewed and updated

### DIFF
--- a/backup.js
+++ b/backup.js
@@ -40,8 +40,38 @@ module.exports.zipDirectory = async function (dirPath, outputZip, password = '',
     }
 }
 
+// Move the folders zipExtract kept at the root of destPath to where they belong
+// Try rename (move) first, else copy/remove
+module.exports.moveExtractedFolders = async function (destPath, destinations) {
+    const path = require('path');
+    const fsp = require('fs/promises');
+    const { existsSync } = require('fs');
+    const moved = [], failed = [];
+
+    for (const folderName in destinations) {
+        const srcPath = path.join(destPath, folderName);
+        const folderDest = destinations[folderName];
+        if (!existsSync(srcPath)) continue;
+        if (typeof folderDest != 'string') { failed.push(folderName + ': no destination, left in ' + srcPath); continue; }
+        try {
+            await fsp.mkdir(path.dirname(folderDest), { recursive: true });
+            try {
+                await fsp.rename(srcPath, folderDest);
+            } catch (e) {
+                if (['EXDEV', 'ENOTEMPTY', 'EEXIST', 'EPERM', 'EACCES'].indexOf(e.code) == -1) throw e;
+                await fsp.cp(srcPath, folderDest, { recursive: true, force: true });
+                await fsp.rm(srcPath, { recursive: true, force: true });
+            }
+            moved.push(folderName + ' -> ' + folderDest);
+        } catch (e) {
+            failed.push(folderName + ' -> ' + folderDest + ': ' + e.message);
+        }
+    }
+
+    return { res: (failed.length == 0), moved: moved, mes: failed.length ? ('Unable to move: ' + failed.join('; ')) : ('Moved ' + moved.length + ' folder(s)') };
+}
+
 // restore zipfile
-// removePath: optional path to remove from destination path
 // First check archive on illegal paths (updirs and absolute paths), then extract
 module.exports.zipExtract = async function (zipPath, destPath, removePath = '', password = "") {
     try {
@@ -64,7 +94,10 @@ module.exports.zipExtract = async function (zipPath, destPath, removePath = '', 
 
             // anchored prefix strip — must match what the extraction pass writes
             let name = entry.filename;
-            if (removePath && name.startsWith(removePath)) name = name.slice(removePath.length);
+            if (Array.isArray(removePath)) {
+                const parts = name.split(/[/\\]/);
+                if ((parts.length > 1) && (removePath.indexOf(parts[0]) == -1)) { name = parts.slice(1).join('/'); }
+            } else if (removePath && name.startsWith(removePath)) { name = name.slice(removePath.length); }
 
             // reject any parent-dir token outright (split on both separators; segment match, not substring)
             if (name.split(/[/\\]/).includes('..')) {

--- a/db.js
+++ b/db.js
@@ -3701,126 +3701,244 @@ module.exports.CreateDB = function (parent, func) {
         return 'Starting auto-backup...';
     };
 
-    obj.createBackupfile = function(func) {
-        parent.debug('backup', 'Entering createBackupfile');
-        let archiver = require('archiver');
-        let archive = null;
-        let zipLevel = Math.min(Math.max(Number(parent.config.settings.autobackup.zipcompression ? parent.config.settings.autobackup.zipcompression : 5),1),9);
+	obj.createBackupfile = function (func) {
+		parent.debug('backup', 'Entering createBackupfile');
 
-        //if password defined, or a password entered for the manual backup, create encrypted zip
-        if ((parent.config.settings.autobackup.zippasswordrequest != '') && ((typeof parent.config.settings.autobackup.zippassword == 'string') || (typeof parent.config.settings.autobackup.zippasswordrequest == 'string')))  {
-            try {
-                //Only register format once, otherwise it triggers an error
-                if (archiver.isRegisteredFormat('zip-encrypted') == false) { archiver.registerFormat('zip-encrypted', require('archiver-zip-encrypted')); }
-                archive = archiver.create('zip-encrypted', { zlib: { level: zipLevel }, encryptionMethod: 'aes256',
-                    password: (typeof parent.config.settings.autobackup.zippasswordrequest == 'string')?parent.config.settings.autobackup.zippasswordrequest:parent.config.settings.autobackup.zippassword });
-                if (func) { func('Creating encrypted ZIP'); }
-            } catch (ex) { // registering encryption failed, do not fall back to non-encrypted, fail backup and skip old backup removal as a precaution to not lose any backups
-                obj.backupStatus |= BACKUPFAIL_ZIPMODULE;
-                if (func) { func('Zipencryptionmodule failed, aborting');}
-                console.error('Zipencryptionmodule failed, aborting');
-            }
-        } else {
-            if (func) { func('Creating a NON-ENCRYPTED ZIP'); }
-            archive = archiver('zip', { zlib: { level: zipLevel } });
-        }
-        delete parent.config.settings.autobackup.zippasswordrequest;
+		const { Readable, Writable } = require('node:stream');
+		const { finished } = require('node:stream/promises');
 
-        //original behavior, just a filebackup if dbdump fails : (obj.backupStatus == 0 || obj.backupStatus == BACKUPFAIL_DBDUMP)
-        if (obj.backupStatus == 0) {
-            // Zip the data directory with the dbdump|NeDB files
-            let output = fs.createWriteStream(obj.newAutoBackupFile);
+		let ZipWriter = null;
+		try {
+			ZipWriter = require('@zip.js/zip.js').ZipWriter;
+		} catch (ex) {
+			obj.backupStatus |= BACKUPFAIL_ZIPMODULE;
+			if (func) { func('@zip.js/zip.js module failed, aborting'); }
+			console.error('@zip.js/zip.js module failed, aborting: ' + ex.message);
+		}
 
-            // Archive finalized and closed
-            output.on('close', function () { 
-                if (obj.backupStatus == 0) {
-                    let mesg = 'Auto-backup completed: ' + obj.newAutoBackupFile + ', backup-size: ' + ((archive.pointer() / 1048576).toFixed(2)) + "Mb";
-                    console.log(mesg);
-                    if (func) { func(mesg); };
-                    obj.performCloudBackup(obj.newAutoBackupFile, func);
-                    obj.removeExpiredBackupfiles(func);
+		const minimatchModule = require('minimatch');
+		const minimatch = minimatchModule.minimatch || minimatchModule;
 
-                } else {
-                    let mesg = 'Zipbackup failed (' + obj.backupStatus.toString(2).slice(-8) + '), deleting incomplete backup: ' + obj.newAutoBackupFile;
-                    if (func) { func(mesg) }
-                    else { parent.addServerWarning(mesg, true ) };
-                    if (fs.existsSync(obj.newAutoBackupFile)) { fs.unlink(obj.newAutoBackupFile, function (err) { if (err) {console.error('Failed to clean up backupfile: ' + err.message)} }) };
-                };
-                if (obj.databaseType != DB_NEDB) {
-                    //remove dump archive file, because zipped and otherwise fills up
-                    if (fs.existsSync(obj.newDBDumpFile)) { fs.unlink(obj.newDBDumpFile, function (err) { if (err) {console.error('Failed to clean up dbdump file: ' + err.message) } }) };
-                };
-                obj.performingBackup = false;
-                obj.backupStatus = 0x0;
-                }
-            );
-            output.on('end', function () { });
-            output.on('error', function (err) {
-                if ((obj.backupStatus & BACKUPFAIL_ZIPCREATE) == 0) {
-                    console.error('Output error: ' + err.message);
-                    if (func) { func('Output error: ' + err.message); };
-                    obj.backupStatus |= BACKUPFAIL_ZIPCREATE;
-                    archive.abort();
-                };
-            });
-            archive.on('warning', function (err) {
-                //if files added to the archiver object aren't reachable anymore (e.g. sqlite-journal files)
-                //an ENOENT warning is given, but the archiver module has no option to/does not skip/resume
-                //so the backup needs te be aborted as it otherwise leaves an incomplete zip and never 'ends'
-                if ((obj.backupStatus & BACKUPFAIL_ZIPCREATE) == 0) {
-                    console.log('Zip warning: ' + err.message); 
-                    if (func) { func('Zip warning: ' + err.message); };
-                    obj.backupStatus |= BACKUPFAIL_ZIPCREATE;
-                    archive.abort();
-                };
-            });
-            archive.on('error', function (err) {
-                if ((obj.backupStatus & BACKUPFAIL_ZIPCREATE) == 0) {
-                    console.error('Zip error: ' + err.message);
-                    if (func) { func('Zip error: ' + err.message); };
-                    obj.backupStatus |= BACKUPFAIL_ZIPCREATE;
-                    archive.abort();
-                }
-                });
-            archive.pipe(output);
+		const zipLevel = Math.min(Math.max(Number(parent.config.settings.autobackup.zipcompression ? parent.config.settings.autobackup.zipcompression : 5), 1), 9);
 
-            let globIgnoreFiles;
-            //slice in case exclusion gets pushed
-            globIgnoreFiles = parent.config.settings.autobackup.backupignorefilesglob ? parent.config.settings.autobackup.backupignorefilesglob.slice() : [];
-            if (parent.config.settings.sqlite3) { globIgnoreFiles.push (datapathFoldername + '/' + databaseName + '.sqlite*'); }; //skip sqlite database file, and temp files with ext -journal, -wal & -shm
-            //archiver.glob doesn't seem to use the third param, archivesubdir. Bug?
-            //workaround: go up a dir and add data dir explicitly to keep the zip tidy
-            archive.glob((datapathFoldername + '/**'), {
-                cwd: datapathParentPath,
-                ignore: globIgnoreFiles,
-                skip: (parent.config.settings.autobackup.backupskipfoldersglob ? parent.config.settings.autobackup.backupskipfoldersglob : [])
-            });
+		let zipPassword = null;
+		if ((parent.config.settings.autobackup.zippasswordrequest != '') &&
+			((typeof parent.config.settings.autobackup.zippassword == 'string') ||
+			 (typeof parent.config.settings.autobackup.zippasswordrequest == 'string'))) {
+			zipPassword = (typeof parent.config.settings.autobackup.zippasswordrequest == 'string')
+				? parent.config.settings.autobackup.zippasswordrequest
+				: parent.config.settings.autobackup.zippassword;
 
-            if (parent.config.settings.autobackup.backupwebfolders) {
-                if (parent.webViewsOverridePath) { archive.directory(parent.webViewsOverridePath, 'meshcentral-views'); }
-                if (parent.webPublicOverridePath) { archive.directory(parent.webPublicOverridePath, 'meshcentral-public'); }
-                if (parent.webEmailsOverridePath) { archive.directory(parent.webEmailsOverridePath, 'meshcentral-emails'); }
-            };
-            if (parent.config.settings.autobackup.backupotherfolders) {
-                archive.directory(parent.filespath, 'meshcentral-files');
-                archive.directory(parent.recordpath, 'meshcentral-recordings');
-            };
-            //add dbdump to the root of the zip
-            if (obj.newDBDumpFile != null) archive.file(obj.newDBDumpFile, { name: path.basename(obj.newDBDumpFile) });
-            archive.finalize();
-        } else {
-            //failed somewhere before zipping
-            console.error('Backup failed ('+ obj.backupStatus.toString(2).slice(-8) + ')');
-            if (func) { func('Backup failed ('+ obj.backupStatus.toString(2).slice(-8) + ')') }
-            else {
-                parent.addServerWarning('Backup failed ('+ obj.backupStatus.toString(2).slice(-8) + ')', true);
-            }
-            //Just in case something's there
-            if (fs.existsSync(obj.newDBDumpFile)) { fs.unlink(obj.newDBDumpFile, function (err) { if (err) {console.error('Failed to clean up dbdump file: ' + err.message) } }); };
-            obj.backupStatus = 0x0;
-            obj.performingBackup = false;
-        };
-    };
+			if (func) { func('Creating encrypted ZIP'); }
+		} else {
+			if (func) { func('Creating a NON-ENCRYPTED ZIP'); }
+		}
+
+		delete parent.config.settings.autobackup.zippasswordrequest;
+
+		function zipName(p) {
+			return p.split(path.sep).join('/').replace(/^\/+/, '');
+		}
+
+		function matchesGlob(name, patterns) {
+			if (!patterns || patterns.length === 0) return false;
+			const opts = { dot: true, nocase: (process.platform === 'win32') };
+			return patterns.some(function (pattern) {
+				return minimatch(name, pattern, opts) || minimatch(name + '/', pattern, opts);
+			});
+		}
+
+		function shouldSkipDirectory(name, skipPatterns) {
+			if (!skipPatterns || skipPatterns.length === 0) return false;
+			const opts = { dot: true, nocase: (process.platform === 'win32') };
+			return skipPatterns.some(function (pattern) {
+				return minimatch(name, pattern, opts) ||
+					   minimatch(name + '/', pattern, opts) ||
+					   minimatch(name + '/__dummy__', pattern, opts);
+			});
+		}
+
+		async function addDirectoryTree(zipWriter, sourceDir, archiveRoot, options) {
+			options = options || {};
+			const ignoreFiles = options.ignoreFiles || [];
+			const skipFolders = options.skipFolders || [];
+
+			async function walk(currentFsPath, currentZipPath) {
+				const stat = await fs.promises.stat(currentFsPath);
+				const currentZipName = zipName(currentZipPath);
+
+				if (matchesGlob(currentZipName, ignoreFiles)) return;
+
+				if (stat.isDirectory()) {
+					if (shouldSkipDirectory(currentZipName, skipFolders)) return;
+
+					await zipWriter.add(currentZipName.endsWith('/') ? currentZipName : currentZipName + '/', undefined, {
+						directory: true,
+						lastModDate: stat.mtime
+					});
+
+					const entries = await fs.promises.readdir(currentFsPath, { withFileTypes: true });
+					for (const entry of entries) {
+						await walk(path.join(currentFsPath, entry.name), path.join(currentZipPath, entry.name));
+					}
+				} else if (stat.isFile()) {
+					await zipWriter.add(currentZipName, Readable.toWeb(fs.createReadStream(currentFsPath)), {
+						lastModDate: stat.mtime
+					});
+				}
+			}
+
+			await walk(sourceDir, archiveRoot);
+		}
+
+		async function cleanupAfterZip() {
+			if (obj.databaseType != DB_NEDB) {
+				if (fs.existsSync(obj.newDBDumpFile)) {
+					fs.unlink(obj.newDBDumpFile, function (err) {
+						if (err) { console.error('Failed to clean up dbdump file: ' + err.message); }
+					});
+				}
+			}
+
+			obj.performingBackup = false;
+			obj.backupStatus = 0x0;
+		}
+
+		async function failZip(mesg) {
+			if (func) { func(mesg); }
+			else { parent.addServerWarning(mesg, true); }
+
+			if (fs.existsSync(obj.newAutoBackupFile)) {
+				fs.unlink(obj.newAutoBackupFile, function (err) {
+					if (err) { console.error('Failed to clean up backupfile: ' + err.message); }
+				});
+			}
+
+			await cleanupAfterZip();
+		}
+
+		(async function () {
+			if (obj.backupStatus != 0) {
+				console.error('Backup failed (' + obj.backupStatus.toString(2).slice(-8) + ')');
+				if (func) { func('Backup failed (' + obj.backupStatus.toString(2).slice(-8) + ')'); }
+				else { parent.addServerWarning('Backup failed (' + obj.backupStatus.toString(2).slice(-8) + ')', true); }
+
+				if (fs.existsSync(obj.newDBDumpFile)) {
+					fs.unlink(obj.newDBDumpFile, function (err) {
+						if (err) { console.error('Failed to clean up dbdump file: ' + err.message); }
+					});
+				}
+
+				obj.backupStatus = 0x0;
+				obj.performingBackup = false;
+				return;
+			}
+
+			if (ZipWriter == null) {
+				await failZip('Zipbackup failed (' + obj.backupStatus.toString(2).slice(-8) + '), deleting incomplete backup: ' + obj.newAutoBackupFile);
+				return;
+			}
+
+			const output = fs.createWriteStream(obj.newAutoBackupFile);
+			const abortController = new AbortController();
+
+			output.on('error', function (err) {
+				if ((obj.backupStatus & BACKUPFAIL_ZIPCREATE) == 0) {
+					console.error('Output error: ' + err.message);
+					if (func) { func('Output error: ' + err.message); }
+					obj.backupStatus |= BACKUPFAIL_ZIPCREATE;
+					abortController.abort();
+				}
+			});
+
+			const zipOptions = {
+				level: zipLevel,
+				keepOrder: true,
+				signal: abortController.signal
+			};
+
+			if (zipPassword != null) {
+				zipOptions.password = zipPassword;
+				zipOptions.encryptionStrength = 3; // AES-256
+			}
+
+			const zipWriter = new ZipWriter(Writable.toWeb(output), zipOptions);
+
+			try {
+				let globIgnoreFiles = parent.config.settings.autobackup.backupignorefilesglob
+					? parent.config.settings.autobackup.backupignorefilesglob.slice()
+					: [];
+
+				if (parent.config.settings.sqlite3) {
+					globIgnoreFiles.push(datapathFoldername + '/' + databaseName + '.sqlite*');
+				}
+
+				const skipFolders = parent.config.settings.autobackup.backupskipfoldersglob
+					? parent.config.settings.autobackup.backupskipfoldersglob
+					: [];
+
+				await addDirectoryTree(
+					zipWriter,
+					path.join(datapathParentPath, datapathFoldername),
+					datapathFoldername,
+					{
+						ignoreFiles: globIgnoreFiles,
+						skipFolders: skipFolders
+					}
+				);
+
+				if (parent.config.settings.autobackup.backupwebfolders) {
+					if (parent.webViewsOverridePath) {
+						await addDirectoryTree(zipWriter, parent.webViewsOverridePath, 'meshcentral-views');
+					}
+					if (parent.webPublicOverridePath) {
+						await addDirectoryTree(zipWriter, parent.webPublicOverridePath, 'meshcentral-public');
+					}
+					if (parent.webEmailsOverridePath) {
+						await addDirectoryTree(zipWriter, parent.webEmailsOverridePath, 'meshcentral-emails');
+					}
+				}
+
+				if (parent.config.settings.autobackup.backupotherfolders) {
+					await addDirectoryTree(zipWriter, parent.filespath, 'meshcentral-files');
+					await addDirectoryTree(zipWriter, parent.recordpath, 'meshcentral-recordings');
+				}
+
+				if (obj.newDBDumpFile != null) {
+					const dumpStat = await fs.promises.stat(obj.newDBDumpFile);
+					await zipWriter.add(path.basename(obj.newDBDumpFile), Readable.toWeb(fs.createReadStream(obj.newDBDumpFile)), {
+						lastModDate: dumpStat.mtime
+					});
+				}
+
+				await zipWriter.close();
+				await finished(output);
+
+				if (obj.backupStatus == 0) {
+					const sizeMb = ((output.bytesWritten || fs.statSync(obj.newAutoBackupFile).size) / 1048576).toFixed(2);
+					const mesg = 'Auto-backup completed: ' + obj.newAutoBackupFile + ', backup-size: ' + sizeMb + 'Mb';
+					console.log(mesg);
+					if (func) { func(mesg); }
+
+					obj.performCloudBackup(obj.newAutoBackupFile, func);
+					obj.removeExpiredBackupfiles(func);
+					await cleanupAfterZip();
+				} else {
+					await failZip('Zipbackup failed (' + obj.backupStatus.toString(2).slice(-8) + '), deleting incomplete backup: ' + obj.newAutoBackupFile);
+				}
+			} catch (err) {
+				if ((obj.backupStatus & BACKUPFAIL_ZIPCREATE) == 0) {
+					console.error('Zip error: ' + err.message);
+					if (func) { func('Zip error: ' + err.message); }
+					obj.backupStatus |= BACKUPFAIL_ZIPCREATE;
+				}
+
+				abortController.abort();
+				output.destroy();
+				await failZip('Zipbackup failed (' + obj.backupStatus.toString(2).slice(-8) + '), deleting incomplete backup: ' + obj.newAutoBackupFile);
+			}
+		})();
+	};
 
     // Remove expired backupfiles by filenamedate
     obj.removeExpiredBackupfiles = function (func) {

--- a/db.js
+++ b/db.js
@@ -3716,8 +3716,19 @@ module.exports.CreateDB = function (parent, func) {
 			console.error('@zip.js/zip.js module failed, aborting: ' + ex.message);
 		}
 
-		const minimatchModule = require('minimatch');
-		const minimatch = minimatchModule.minimatch || minimatchModule;
+		const GLOB_NOCASE = (typeof parent.config.settings.autobackup.globnocase === 'boolean')
+        ? parent.config.settings.autobackup.globnocase
+        : (process.platform === 'win32');
+        
+		// path.matchesGlob() doesn't support case-insensitive matching or dot-files, normalizeGlob() fixes this.
+		function normalizeGlob(str) {
+			str = str.replace(/(^|\/)\./g, '$1\uE200');
+			if (GLOB_NOCASE) return str.toLowerCase();
+			return str.replace(/[a-zA-Z]/g, function (ch) {
+				const code = ch.charCodeAt(0);
+				return String.fromCharCode(code <= 90 ? (0xE100 + (code - 65)) : (0xE000 + (code - 97)));
+			});
+		}
 
 		const zipLevel = Math.min(Math.max(Number(parent.config.settings.autobackup.zipcompression ? parent.config.settings.autobackup.zipcompression : 5), 1), 9);
 
@@ -3740,39 +3751,39 @@ module.exports.CreateDB = function (parent, func) {
 			return p.split(path.sep).join('/').replace(/^\/+/, '');
 		}
 
+		// patterns: array of pre-normalized glob strings
 		function matchesGlob(name, patterns) {
-			if (!patterns || patterns.length === 0) return false;
-			const opts = { dot: true, nocase: (process.platform === 'win32') };
+			if (patterns.length === 0) return false;
+			name = normalizeGlob(name);
 			return patterns.some(function (pattern) {
-				return minimatch(name, pattern, opts) || minimatch(name + '/', pattern, opts);
+				return path.matchesGlob(name, pattern) || path.matchesGlob(name + '/', pattern);
 			});
 		}
 
-		function shouldSkipDirectory(name, skipPatterns) {
-			if (!skipPatterns || skipPatterns.length === 0) return false;
-			const opts = { dot: true, nocase: (process.platform === 'win32') };
-			return skipPatterns.some(function (pattern) {
-				return minimatch(name, pattern, opts) ||
-					   minimatch(name + '/', pattern, opts) ||
-					   minimatch(name + '/__dummy__', pattern, opts);
-			});
+		// Returns true if name or any parent folder matches a skip pattern.
+		function isUnderSkippedFolder(name, skipPatterns) {
+			if (skipPatterns.length === 0) return false;
+			let prefix = '';
+			for (const part of normalizeGlob(name).split('/')) {
+				prefix = prefix ? (prefix + '/' + part) : part;
+				if (skipPatterns.some(function (pattern) { return path.matchesGlob(prefix, pattern); })) { return true; }
+			}
+			return false;
 		}
 
 		async function addDirectoryTree(zipWriter, sourceDir, archiveRoot, options) {
 			options = options || {};
-			const ignoreFiles = options.ignoreFiles || [];
-			const skipFolders = options.skipFolders || [];
+			// Compiled once per tree, reused for every entry.
+			const ignoreFiles = (options.ignoreFiles || []).map(normalizeGlob);
+			const skipFolders = (options.skipFolders || []).map(normalizeGlob);
 
-			const exclude = (name) => {
-				const currentZipName = zipName(path.join(archiveRoot, name));
-				if (shouldSkipDirectory(currentZipName, skipFolders)) return true;
-				if (matchesGlob(currentZipName, ignoreFiles)) return true;
-				return false;
-			};
+			// fs.glob's exclude callback is unreliable per-entry (not always called with the full
+			// path), so it only skips directories during traversal; the loop below filters individual entries.
+			const exclude = (name) => isUnderSkippedFolder(zipName(path.join(archiveRoot, String(name))), skipFolders);
 
 			const rootStat = await fs.promises.stat(sourceDir);
 			const rootZipName = zipName(archiveRoot);
-			if (!shouldSkipDirectory(rootZipName, skipFolders) && !matchesGlob(rootZipName, ignoreFiles)) {
+			if (!isUnderSkippedFolder(rootZipName, skipFolders) && !matchesGlob(rootZipName, ignoreFiles)) {
 				await zipWriter.add(rootZipName.endsWith('/') ? rootZipName : rootZipName + '/', undefined, {
 					directory: true,
 					lastModDate: rootStat.mtime
@@ -3780,8 +3791,13 @@ module.exports.CreateDB = function (parent, func) {
 			}
 
 			for await (const file of fs.promises.glob('**/*', { cwd: sourceDir, exclude })) {
-				const fullFsPath = path.join(sourceDir, file);
 				const currentZipName = zipName(path.join(archiveRoot, file));
+
+				// Apply ignore-file and skip-folder globs against the full archive-relative path.
+				if (matchesGlob(currentZipName, ignoreFiles)) continue;
+				if (isUnderSkippedFolder(currentZipName, skipFolders)) continue;
+
+				const fullFsPath = path.join(sourceDir, file);
 				const stat = await fs.promises.stat(fullFsPath);
 
 				if (stat.isDirectory()) {
@@ -3879,35 +3895,28 @@ module.exports.CreateDB = function (parent, func) {
 					globIgnoreFiles.push(datapathFoldername + '/' + databaseName + '.sqlite*');
 				}
 
-				const skipFolders = parent.config.settings.autobackup.backupskipfoldersglob
-					? parent.config.settings.autobackup.backupskipfoldersglob
-					: [];
+				const treeOptions = {
+					ignoreFiles: globIgnoreFiles,
+					skipFolders: parent.config.settings.autobackup.backupskipfoldersglob || []
+				};
 
-				await addDirectoryTree(
-					zipWriter,
-					path.join(datapathParentPath, datapathFoldername),
-					datapathFoldername,
-					{
-						ignoreFiles: globIgnoreFiles,
-						skipFolders: skipFolders
-					}
-				);
+				await addDirectoryTree(zipWriter, path.join(datapathParentPath, datapathFoldername), datapathFoldername, treeOptions);
 
 				if (parent.config.settings.autobackup.backupwebfolders) {
 					if (parent.webViewsOverridePath) {
-						await addDirectoryTree(zipWriter, parent.webViewsOverridePath, 'meshcentral-views');
+						await addDirectoryTree(zipWriter, parent.webViewsOverridePath, 'meshcentral-views', treeOptions);
 					}
 					if (parent.webPublicOverridePath) {
-						await addDirectoryTree(zipWriter, parent.webPublicOverridePath, 'meshcentral-public');
+						await addDirectoryTree(zipWriter, parent.webPublicOverridePath, 'meshcentral-public', treeOptions);
 					}
 					if (parent.webEmailsOverridePath) {
-						await addDirectoryTree(zipWriter, parent.webEmailsOverridePath, 'meshcentral-emails');
+						await addDirectoryTree(zipWriter, parent.webEmailsOverridePath, 'meshcentral-emails', treeOptions);
 					}
 				}
 
 				if (parent.config.settings.autobackup.backupotherfolders) {
-					await addDirectoryTree(zipWriter, parent.filespath, 'meshcentral-files');
-					await addDirectoryTree(zipWriter, parent.recordpath, 'meshcentral-recordings');
+					await addDirectoryTree(zipWriter, parent.filespath, 'meshcentral-files', treeOptions);
+					await addDirectoryTree(zipWriter, parent.recordpath, 'meshcentral-recordings', treeOptions);
 				}
 
 				if (obj.newDBDumpFile != null) {

--- a/db.js
+++ b/db.js
@@ -3763,32 +3763,38 @@ module.exports.CreateDB = function (parent, func) {
 			const ignoreFiles = options.ignoreFiles || [];
 			const skipFolders = options.skipFolders || [];
 
-			async function walk(currentFsPath, currentZipPath) {
-				const stat = await fs.promises.stat(currentFsPath);
-				const currentZipName = zipName(currentZipPath);
+			const exclude = (name) => {
+				const currentZipName = zipName(path.join(archiveRoot, name));
+				if (shouldSkipDirectory(currentZipName, skipFolders)) return true;
+				if (matchesGlob(currentZipName, ignoreFiles)) return true;
+				return false;
+			};
 
-				if (matchesGlob(currentZipName, ignoreFiles)) return;
+			const rootStat = await fs.promises.stat(sourceDir);
+			const rootZipName = zipName(archiveRoot);
+			if (!shouldSkipDirectory(rootZipName, skipFolders) && !matchesGlob(rootZipName, ignoreFiles)) {
+				await zipWriter.add(rootZipName.endsWith('/') ? rootZipName : rootZipName + '/', undefined, {
+					directory: true,
+					lastModDate: rootStat.mtime
+				});
+			}
+
+			for await (const file of fs.promises.glob('**/*', { cwd: sourceDir, exclude })) {
+				const fullFsPath = path.join(sourceDir, file);
+				const currentZipName = zipName(path.join(archiveRoot, file));
+				const stat = await fs.promises.stat(fullFsPath);
 
 				if (stat.isDirectory()) {
-					if (shouldSkipDirectory(currentZipName, skipFolders)) return;
-
 					await zipWriter.add(currentZipName.endsWith('/') ? currentZipName : currentZipName + '/', undefined, {
 						directory: true,
 						lastModDate: stat.mtime
 					});
-
-					const entries = await fs.promises.readdir(currentFsPath, { withFileTypes: true });
-					for (const entry of entries) {
-						await walk(path.join(currentFsPath, entry.name), path.join(currentZipPath, entry.name));
-					}
 				} else if (stat.isFile()) {
-					await zipWriter.add(currentZipName, Readable.toWeb(fs.createReadStream(currentFsPath)), {
+					await zipWriter.add(currentZipName, Readable.toWeb(fs.createReadStream(fullFsPath)), {
 						lastModDate: stat.mtime
 					});
 				}
 			}
-
-			await walk(sourceDir, archiveRoot);
 		}
 
 		async function cleanupAfterZip() {
@@ -3945,39 +3951,39 @@ module.exports.CreateDB = function (parent, func) {
         if (parent.config.settings.autobackup && (typeof parent.config.settings.autobackup.keeplastdaysbackup == 'number')) {
             let cutoffDate = new Date();
             cutoffDate.setDate(cutoffDate.getDate() - parent.config.settings.autobackup.keeplastdaysbackup);
-            fs.readdir(parent.backuppath, function (err, dir) {
+
+            (async () => {
                 try {
-                    if (err == null) {
-                        if (dir.length > 0) {
-                            let fileName = parent.config.settings.autobackup.backupname;
-                            let checked = 0;
-                            let removed = 0;
-                            for (var i in dir) {
-                                var name = dir[i];
-                                parent.debug('backup', "checking file: ", path.join(parent.backuppath, name));
-                                if (name.startsWith(fileName) && name.endsWith('.zip')) {
-                                    var timex = name.substring(fileName.length, name.length - 4).split('-');
-                                    if (timex.length == 5) {
-                                        checked++;
-                                        var fileDate = new Date(parseInt(timex[0]), parseInt(timex[1]) - 1, parseInt(timex[2]), parseInt(timex[3]), parseInt(timex[4]));
-                                        if (fileDate && (cutoffDate > fileDate)) {
-                                            console.log("Removing expired backup file: ", path.join(parent.backuppath, name));
-                                            fs.unlink(path.join(parent.backuppath, name), function (err) { if (err) { console.error(err.message); if (func) {func('Error removing: ' + err.message); } } });
-                                            removed++;
-                                        }
-                                    }
-                                    else { parent.debug('backup', "file: " + name + " timestamp failure: ", timex); }
+                    let fileName = parent.config.settings.autobackup.backupname;
+                    let checked = 0;
+                    let removed = 0;
+                    for await (const name of fs.promises.glob(fileName + '*.zip', { cwd: parent.backuppath })) {
+                        parent.debug('backup', "checking file: ", path.join(parent.backuppath, name));
+                        var timex = name.substring(fileName.length, name.length - 4).split('-');
+                        if (timex.length == 5) {
+                            checked++;
+                            var fileDate = new Date(parseInt(timex[0]), parseInt(timex[1]) - 1, parseInt(timex[2]), parseInt(timex[3]), parseInt(timex[4]));
+                            if (fileDate && (cutoffDate > fileDate)) {
+                                console.log("Removing expired backup file: ", path.join(parent.backuppath, name));
+                                try {
+                                    await fs.promises.unlink(path.join(parent.backuppath, name));
+                                    removed++;
+                                } catch (err) {
+                                    console.error(err.message); if (func) { func('Error removing: ' + err.message); }
                                 }
                             }
-                            let mesg= 'Checked ' + checked + ' candidates in ' + parent.backuppath + '. Removed ' + removed + ' expired backupfiles using cutoffDate: '+ cutoffDate.toLocaleString('default', { dateStyle: 'short', timeStyle: 'short' });
-                            parent.debug (mesg);
-                            if (func) { func(mesg); }
-                        } else { console.error('No files found in ' + parent.backuppath + '. There should be at least one.')}
+                        } else {
+                            parent.debug('backup', "file: " + name + " timestamp failure: ", timex);
+                        }
                     }
-                    else
-                    { console.error(err); parent.addServerWarning( 'Reading files in backup directory ' + parent.backuppath + ' failed, check errorlog: ' + err.message, true); }
-                } catch (ex) { console.error(ex); parent.addServerWarning( 'Something went wrong during removeExpiredBackupfiles, check errorlog: ' +ex.message, true); }
-            });
+                    let mesg = 'Checked ' + checked + ' candidates in ' + parent.backuppath + '. Removed ' + removed + ' expired backupfiles using cutoffDate: ' + cutoffDate.toLocaleString('default', { dateStyle: 'short', timeStyle: 'short' });
+                    parent.debug(mesg);
+                    if (func) { func(mesg); }
+                } catch (err) {
+                    console.error(err);
+                    parent.addServerWarning('Reading files in backup directory ' + parent.backuppath + ' failed, check errorlog: ' + err.message, true);
+                }
+            })();
         }
     }
 

--- a/dependencies.txt
+++ b/dependencies.txt
@@ -1,6 +1,5 @@
     "@seald-io/nedb": "4.1.2",
     "@zip.js/zip.js": "2.8.26",
-    "archiver": "7.0.1",
     "cbor": "5.2.0",
     "compression": "1.8.1",
     "cookie-session": "2.1.1",

--- a/meshcentral-config-schema.json
+++ b/meshcentral-config-schema.json
@@ -981,6 +981,10 @@
               "default": [],
               "description": "Glob for ignoring directories in the data directory. For example [\"**/signedagents\"]"
             },
+            "globNocase": {
+              "type": "boolean",
+              "description": "Enable case-insensitive glob matching. Defaults: true on Windows, false elsewhere."
+            },
             "googleDrive": {
               "type": "object",
               "description": "Enabled automated upload of the server backups to a Google Drive account, once enabled you need to go in \"My Server\" tab as administrator to associate the account.",

--- a/meshcentral.js
+++ b/meshcentral.js
@@ -3678,7 +3678,7 @@ function CreateMeshCentralServer(config, args) {
 						// Compress the agent using ZIP
 						const x = this.meshAgentBinary;
 
-						const zipWriter = new zip.ZipWriter(new zip.Uint8ArrayWriter(), { level: 9 });
+						const zipWriter = new zip.ZipWriter(new zip.Uint8ArrayWriter(), { level: 9, zip64: false });
 
 						zipWriter.add(
 							'meshagent',
@@ -3718,7 +3718,7 @@ function CreateMeshCentralServer(config, args) {
 					// Compress the agent using ZIP
 					const zip = require('@zip.js/zip.js');
 					const x = objx.meshAgentBinaries[archid];
-					const zipWriter = new zip.ZipWriter(new zip.Uint8ArrayWriter(), { level: 9 });
+					const zipWriter = new zip.ZipWriter(new zip.Uint8ArrayWriter(), { level: 9, zip64: false });
 
 					zipWriter.add(
 						'meshagent',

--- a/meshcentral.js
+++ b/meshcentral.js
@@ -3682,8 +3682,7 @@ function CreateMeshCentralServer(config, args) {
 
 						zipWriter.add(
 							'meshagent',
-							new zip.Uint8ArrayReader(x.data),
-							{ level: 9 }
+							new zip.Uint8ArrayReader(x.data)
 						).then(function () {
 							return zipWriter.close();
 						}).then(function (zipData) {
@@ -3723,8 +3722,7 @@ function CreateMeshCentralServer(config, args) {
 
 					zipWriter.add(
 						'meshagent',
-						new zip.Uint8ArrayReader(x.data),
-						{ level: 9 }
+						new zip.Uint8ArrayReader(x.data)
 					).then(function () {
 						return zipWriter.close();
 					}).then(function (zipData) {

--- a/meshcentral.js
+++ b/meshcentral.js
@@ -15,7 +15,7 @@
 "use strict";
 
 const common = require('./common.js');
-const { zipExtract } = require('./backup.js');
+const { zipExtract, moveExtractedFolders } = require('./backup.js');
 
 // If app metrics is available
 if (process.argv[2] == '--launch') { try { require('appmetrics-dash').monitor({ url: '/', title: 'MeshCentral', port: 88, host: '127.0.0.1' }); } catch (ex) { } }
@@ -92,6 +92,7 @@ function CreateMeshCentralServer(config, args) {
         obj.webViewsPath = obj.path.join(__dirname, 'views');
         obj.webPublicPath = obj.path.join(__dirname, 'public');
         obj.webEmailsPath = obj.path.join(__dirname, 'emails');
+        obj.webOverrideBasePath = obj.path.join(__dirname, '../../meshcentral-web'); // set even if absent, a restore may create it
         if (obj.fs.existsSync(obj.path.join(__dirname, '../../meshcentral-web/views'))) { obj.webViewsOverridePath = obj.path.join(__dirname, '../../meshcentral-web/views'); }
         if (obj.fs.existsSync(obj.path.join(__dirname, '../../meshcentral-web/public'))) { obj.webPublicOverridePath = obj.path.join(__dirname, '../../meshcentral-web/public'); }
         if (obj.fs.existsSync(obj.path.join(__dirname, '../../meshcentral-web/emails'))) { obj.webEmailsOverridePath = obj.path.join(__dirname, '../../meshcentral-web/emails'); }
@@ -104,6 +105,7 @@ function CreateMeshCentralServer(config, args) {
         obj.webViewsPath = obj.path.join(__dirname, 'views');
         obj.webPublicPath = obj.path.join(__dirname, 'public');
         obj.webEmailsPath = obj.path.join(__dirname, 'emails');
+        obj.webOverrideBasePath = obj.path.join(__dirname, '../meshcentral-web'); // set even if absent, a restore may create it
         if (obj.fs.existsSync(obj.path.join(__dirname, '../meshcentral-web/views'))) { obj.webViewsOverridePath = obj.path.join(__dirname, '../meshcentral-web/views'); }
         if (obj.fs.existsSync(obj.path.join(__dirname, '../meshcentral-web/public'))) { obj.webPublicOverridePath = obj.path.join(__dirname, '../meshcentral-web/public'); }
         if (obj.fs.existsSync(obj.path.join(__dirname, '../meshcentral-web/emails'))) { obj.webEmailsOverridePath = obj.path.join(__dirname, '../meshcentral-web/emails'); }
@@ -2408,9 +2410,22 @@ function CreateMeshCentralServer(config, args) {
             if (restoreFile) {
                 obj.debug('main', obj.common.format("Server stopped, updating settings: {0}", restoreFile));
                 console.log("Updating settings folder...");     // do not alter. This specific log message, with the process.exit(123) further on, triggers a process restart. See obj.launchChildServer>childProcess.stdout.on function
-                zipExtract(restoreFile, obj.datapath, 'meshcentral-data/', restorePassword)
-                    .then((res) => {
-                        res['res'] ? console.log(res['mes']) : console.error(res['mes']);
+                const webBase = obj.webOverrideBasePath;
+                const destinations = {
+                    'meshcentral-views': obj.webViewsOverridePath || obj.path.join(webBase, 'views'),
+                    'meshcentral-public': obj.webPublicOverridePath || obj.path.join(webBase, 'public'),
+                    'meshcentral-emails': obj.webEmailsOverridePath || obj.path.join(webBase, 'emails'),
+                    'meshcentral-files': obj.filespath,
+                    'meshcentral-recordings': obj.recordpath
+                };
+                zipExtract(restoreFile, obj.datapath, Object.keys(destinations), restorePassword)
+                    .then(async (res) => {
+                        if (res.res) {
+                            console.log(res.mes);
+                            const move = await moveExtractedFolders(obj.datapath, destinations);
+                            move.moved.forEach(function (folder) { console.log('Restored ' + folder); });
+                            if (!move.res) { console.error(move.mes); }
+                        } else { console.error(res.mes); }
                         process.exit(123);      // this triggers the childserver process restart
                     });
             } else {

--- a/meshcentral.js
+++ b/meshcentral.js
@@ -4380,7 +4380,7 @@ function mainStart() {
 
         // Build the list of required modules
         // NOTE: ALL MODULES MUST HAVE A VERSION NUMBER AND THE VERSION MUST MATCH THAT USED IN Dockerfile
-        var modules = ['archiver@7.0.1', 'cbor@5.2.0', 'compression@1.8.1', 'cookie-session@2.1.1', 'express@4.22.2', 'express-handlebars@7.1.3', 'express-ws@5.0.2', 'ipcheck@0.1.0', 'minimist@1.2.8', 'multiparty@4.3.0', '@seald-io/nedb@4.1.2', 'node-forge@1.4.0', 'ua-parser-js@1.0.40', 'ua-client-hints-js@0.1.2', 'ws@8.21.1', 'yauzl@2.10.0', '@zip.js/zip.js@2.8.26']; // Base modules
+        var modules = ['cbor@5.2.0', 'compression@1.8.1', 'cookie-session@2.1.1', 'express@4.22.2', 'express-handlebars@7.1.3', 'express-ws@5.0.2', 'ipcheck@0.1.0', 'minimist@1.2.8', 'multiparty@4.3.0', '@seald-io/nedb@4.1.2', 'node-forge@1.4.0', 'ua-parser-js@1.0.40', 'ua-client-hints-js@0.1.2', 'ws@8.21.1', 'yauzl@2.10.0', '@zip.js/zip.js@2.8.26']; // Base modules
         if (require('os').platform() == 'win32') { modules.push('node-windows@0.1.14'); modules.push('loadavg-windows@1.1.1'); if (sspi == true) { modules.push('node-sspi@0.2.10'); } } // Add Windows modules
         if (ldap == true) { modules.push('ldapauth-fork@5.0.5'); }
         if (ssh == true) { modules.push('ssh2@1.17.0'); }
@@ -4408,8 +4408,6 @@ function mainStart() {
         if (config.settings.prometheus != null) { modules.push('prom-client@15.1.3'); } // Add Prometheus Metrics support
 
         if (typeof config.settings.autobackup == 'object') {
-            // Setup encrypted zip support if needed
-            if (config.settings.autobackup.zippassword) { modules.push('archiver-zip-encrypted@2.0.0'); }
             // Enable Google Drive Support
             if (typeof config.settings.autobackup.googledrive == 'object') { modules.push('googleapis@128.0.0'); }
             // Enable WebDAV Support

--- a/meshcentral.js
+++ b/meshcentral.js
@@ -3673,41 +3673,34 @@ function CreateMeshCentralServer(config, args) {
                         this.meshAgentBinary.fileHash = hash.digest('binary');
                         this.meshAgentBinary.fileHashHex = Buffer.from(this.meshAgentBinary.fileHash, 'binary').toString('hex');
 
-                        // Compress the agent using ZIP
-                        const archive = require('archiver')('zip', { level: 9 }); // Sets the compression method.
-                        const onZipData = function onZipData(buffer) { onZipData.x.zacc.push(buffer); }
-                        const onZipEnd = function onZipEnd() {
-                            // Concat all the buffer for create compressed zip agent
-                            const concatData = Buffer.concat(onZipData.x.zacc);
-                            delete onZipData.x.zacc;
+						const zip = require('@zip.js/zip.js');
 
-                            // Hash the compressed binary
-                            const hash = obj.crypto.createHash('sha384').update(concatData);
-                            onZipData.x.zhash = hash.digest('binary');
-                            onZipData.x.zhashhex = Buffer.from(onZipData.x.zhash, 'binary').toString('hex');
+						// Compress the agent using ZIP
+						const x = this.meshAgentBinary;
 
-                            // Set the agent
-                            onZipData.x.zdata = concatData;
-                            onZipData.x.zsize = concatData.length;
-                        }
-                        const onZipError = function onZipError() { delete onZipData.x.zacc; }
-                        this.meshAgentBinary.zacc = [];
-                        onZipData.x = this.meshAgentBinary;
-                        onZipEnd.x = this.meshAgentBinary;
-                        onZipError.x = this.meshAgentBinary;
-                        archive.on('data', onZipData);
-                        archive.on('end', onZipEnd);
-                        archive.on('error', onZipError);
+						const zipWriter = new zip.ZipWriter(new zip.Uint8ArrayWriter(), { level: 9 });
 
-                        // Starting with NodeJS v16, passing in a buffer at archive.append() will result a compressed file with zero byte length. To fix this, we pass in the buffer as a stream.
-                        // archive.append(this.meshAgentBinary.data, { name: 'meshagent' }); // This is the version that does not work on NodeJS v16.
-                        const ReadableStream = require('stream').Readable;
-                        const zipInputStream = new ReadableStream();
-                        zipInputStream.push(this.meshAgentBinary.data);
-                        zipInputStream.push(null);
-                        archive.append(zipInputStream, { name: 'meshagent' });
+						zipWriter.add(
+							'meshagent',
+							new zip.Uint8ArrayReader(x.data),
+							{ level: 9 }
+						).then(function () {
+							return zipWriter.close();
+						}).then(function (zipData) {
+							// Convert zip.js Uint8Array output to Buffer
+							const concatData = Buffer.from(zipData);
 
-                        archive.finalize();
+							// Hash the compressed binary
+							const hash = obj.crypto.createHash('sha384').update(concatData);
+							x.zhash = hash.digest('binary');
+							x.zhashhex = Buffer.from(x.zhash, 'binary').toString('hex');
+
+							// Set the agent
+							x.zdata = concatData;
+							x.zsize = concatData.length;
+						}).catch(function (err) {
+							console.log('ZIP compression failed', err);
+						});
                     })
                     obj.exeHandler.streamExeWithMeshPolicy(
                         {
@@ -3719,39 +3712,39 @@ function CreateMeshCentralServer(config, args) {
                             peinfo: objx.meshAgentBinaries[archid].pe
                         });
                 } else {
-                    // Load the agent as-is
-                    objx.meshAgentBinaries[archid].data = obj.fs.readFileSync(agentpath);
+					
+					// Load the agent as-is
+					objx.meshAgentBinaries[archid].data = obj.fs.readFileSync(agentpath);
 
-                    // Compress the agent using ZIP
-                    const archive = require('archiver')('zip', { level: 9 }); // Sets the compression method.
+					// Compress the agent using ZIP
+					const zip = require('@zip.js/zip.js');
+					const x = objx.meshAgentBinaries[archid];
+					const zipWriter = new zip.ZipWriter(new zip.Uint8ArrayWriter(), { level: 9 });
 
-                    const onZipData = function onZipData(buffer) { onZipData.x.zacc.push(buffer); }
-                    const onZipEnd = function onZipEnd() {
-                        // Concat all the buffer for create compressed zip agent
-                        const concatData = Buffer.concat(onZipData.x.zacc);
-                        delete onZipData.x.zacc;
+					zipWriter.add(
+						'meshagent',
+						new zip.Uint8ArrayReader(x.data),
+						{ level: 9 }
+					).then(function () {
+						return zipWriter.close();
+					}).then(function (zipData) {
+						// Convert zip.js Uint8Array output to Buffer
+						const concatData = Buffer.from(zipData);
 
-                        // Hash the compressed binary
-                        const hash = obj.crypto.createHash('sha384').update(concatData);
-                        onZipData.x.zhash = hash.digest('binary');
-                        onZipData.x.zhashhex = Buffer.from(onZipData.x.zhash, 'binary').toString('hex');
+						// Hash the compressed binary
+						const hash = obj.crypto.createHash('sha384').update(concatData);
+						x.zhash = hash.digest('binary');
+						x.zhashhex = Buffer.from(x.zhash, 'binary').toString('hex');
 
-                        // Set the agent
-                        onZipData.x.zdata = concatData;
-                        onZipData.x.zsize = concatData.length;
+						// Set the agent
+						x.zdata = concatData;
+						x.zsize = concatData.length;
 
-                        //console.log('Packed', onZipData.x.size, onZipData.x.zsize);
-                    }
-                    const onZipError = function onZipError() { delete onZipData.x.zacc; }
-                    objx.meshAgentBinaries[archid].zacc = [];
-                    onZipData.x = objx.meshAgentBinaries[archid];
-                    onZipEnd.x = objx.meshAgentBinaries[archid];
-                    onZipError.x = objx.meshAgentBinaries[archid];
-                    archive.on('data', onZipData);
-                    archive.on('end', onZipEnd);
-                    archive.on('error', onZipError);
-                    archive.append(objx.meshAgentBinaries[archid].data, { name: 'meshagent' });
-                    archive.finalize();
+						//console.log('Packed', x.size, x.zsize);
+					}).catch(function (err) {
+						// Keep this silent if the old code ignored ZIP errors.
+						// parent.debug('web', 'ZIP compression failed: ' + err);
+					});
                 }
             }
 

--- a/meshcentral.js
+++ b/meshcentral.js
@@ -3698,7 +3698,7 @@ function CreateMeshCentralServer(config, args) {
 							x.zdata = concatData;
 							x.zsize = concatData.length;
 						}).catch(function (err) {
-							console.log('ZIP compression failed', err);
+							console.error('ZIP compression failed', err);
 						});
                     })
                     obj.exeHandler.streamExeWithMeshPolicy(
@@ -3740,8 +3740,7 @@ function CreateMeshCentralServer(config, args) {
 
 						//console.log('Packed', x.size, x.zsize);
 					}).catch(function (err) {
-						// Keep this silent if the old code ignored ZIP errors.
-						// parent.debug('web', 'ZIP compression failed: ' + err);
+						console.error('ZIP compression failed', err);
 					});
                 }
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "meshcentral",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "meshcentral",
-      "version": "1.2.4",
+      "version": "1.2.5",
       "license": "Apache-2.0",
       "dependencies": {
         "@seald-io/nedb": "4.1.2",
@@ -165,18 +165,6 @@
         "node": ">=18.0.0"
       }
     },
-    "node_modules/abort-controller": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
-      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
-      "license": "MIT",
-      "dependencies": {
-        "event-target-shim": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=6.5"
-      }
-    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -229,12 +217,6 @@
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
     },
-    "node_modules/async": {
-      "version": "3.2.6",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.6.tgz",
-      "integrity": "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA==",
-      "license": "MIT"
-    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -250,124 +232,10 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/b4a": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.8.1.tgz",
-      "integrity": "sha512-aiqre1Nr0B/6DgE2N5vwTc+2/oQZ4Wh1t4NznYY4E00y8LCt6NqdRv81so00oo27D8MVKTpUa/MwUUtBLXCoDw==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "react-native-b4a": "*"
-      },
-      "peerDependenciesMeta": {
-        "react-native-b4a": {
-          "optional": true
-        }
-      }
-    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
-      "license": "MIT"
-    },
-    "node_modules/bare-events": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/bare-events/-/bare-events-2.9.1.tgz",
-      "integrity": "sha512-Z0oHEHAFDZkffN8Qc39zNZjQlMDkPJRyyyZieU1VH7u8c5S+qHZ2S8ixdKIAxEjfHO7FJxXmJWgteOghVanIsg==",
-      "license": "Apache-2.0",
-      "peerDependencies": {
-        "bare-abort-controller": "*"
-      },
-      "peerDependenciesMeta": {
-        "bare-abort-controller": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/bare-fs": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/bare-fs/-/bare-fs-4.8.0.tgz",
-      "integrity": "sha512-fM+MhCvdQhZ7NV6S95a07gPSqjIYKn6mFaXfx266wN3ajZGl/+1AzH+ubkXQ0fFZvOe2nk9VHkzdYkQE5zMV3Q==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bare-events": "^2.5.4",
-        "bare-path": "^3.0.0",
-        "bare-stream": "^2.6.4",
-        "bare-url": "^2.2.2",
-        "fast-fifo": "^1.3.2"
-      },
-      "engines": {
-        "bare": ">=1.28.0"
-      },
-      "peerDependencies": {
-        "bare-buffer": "*"
-      },
-      "peerDependenciesMeta": {
-        "bare-buffer": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/bare-path": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/bare-path/-/bare-path-3.1.1.tgz",
-      "integrity": "sha512-JprUlveX3QjApC1cTpsUOiscADftCGVWkzitbHsRqv84hzYwYHw2mbluddsq5TvI8mH/8Ov1f4BiMAdcB0oYnQ==",
-      "license": "Apache-2.0"
-    },
-    "node_modules/bare-stream": {
-      "version": "2.13.3",
-      "resolved": "https://registry.npmjs.org/bare-stream/-/bare-stream-2.13.3.tgz",
-      "integrity": "sha512-Kc+brLqvEqGkjyfiwJmImAOqLZL7OsoLKuavx+hJjgVV3nLTOjloJyPMFxjUPerGGHrNH0fLU06jjykMLWrERQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "b4a": "^1.8.1",
-        "streamx": "^2.25.0",
-        "teex": "^1.0.1"
-      },
-      "peerDependencies": {
-        "bare-abort-controller": "*",
-        "bare-buffer": "*",
-        "bare-events": "*"
-      },
-      "peerDependenciesMeta": {
-        "bare-abort-controller": {
-          "optional": true
-        },
-        "bare-buffer": {
-          "optional": true
-        },
-        "bare-events": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/bare-url": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.5.2.tgz",
-      "integrity": "sha512-L13PCJzKG8RGvx8V1/DdMi12ERhC3tprr7/8a94BxpmnRsFqxh5XZNdhtMxu5HPkRshYOOWRGY8lDP7ZhpG9Cg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bare-path": "^3.0.0"
-      }
-    },
-    "node_modules/base64-js": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
       "license": "MIT"
     },
     "node_modules/bignumber.js": {
@@ -410,39 +278,6 @@
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^1.0.0"
-      }
-    },
-    "node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
-    "node_modules/buffer-crc32": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
-      "integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.0.0"
       }
     },
     "node_modules/bytes": {
@@ -531,22 +366,6 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "license": "MIT"
-    },
-    "node_modules/compress-commons": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-6.0.2.tgz",
-      "integrity": "sha512-6FqVXeETqWPoGcfzrXb37E50NP0LXT8kAMu5ooZayhWWdgEY4lBEEcbQNXtkuKQsGduxiIcI4gOTsxTmuq/bSg==",
-      "license": "MIT",
-      "dependencies": {
-        "crc-32": "^1.2.0",
-        "crc32-stream": "^6.0.0",
-        "is-stream": "^2.0.1",
-        "normalize-path": "^3.0.0",
-        "readable-stream": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
     },
     "node_modules/compressible": {
       "version": "2.0.18",
@@ -655,37 +474,6 @@
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-      "license": "MIT"
-    },
-    "node_modules/crc-32": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/crc-32/-/crc-32-1.2.2.tgz",
-      "integrity": "sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==",
-      "license": "Apache-2.0",
-      "bin": {
-        "crc32": "bin/crc32.njs"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/crc32-stream": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-6.0.0.tgz",
-      "integrity": "sha512-piICUB6ei4IlTv1+653yq5+KoqfBYmj9bw6LqXoOneTMDXk5nM1qt12mFW1caG3LlJXEKW1Bp0WggEmIfQB34g==",
-      "license": "MIT",
-      "dependencies": {
-        "crc-32": "^1.2.0",
-        "readable-stream": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/cross-spawn": {
@@ -833,33 +621,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/event-target-shim": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
-      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/events": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
-      "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.8.x"
-      }
-    },
-    "node_modules/events-universal": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/events-universal/-/events-universal-1.0.1.tgz",
-      "integrity": "sha512-LUd5euvbMLpwOF8m6ivPCbhQeSiYVNb8Vs0fQ8QjXo0JTkEHpz8pxdQf0gStltaPpw0Cca8b39KxvK9cfKRiAw==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "bare-events": "^2.7.0"
-      }
-    },
     "node_modules/express": {
       "version": "4.22.2",
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
@@ -955,12 +716,6 @@
           "optional": true
         }
       }
-    },
-    "node_modules/fast-fifo": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/fast-fifo/-/fast-fifo-1.3.2.tgz",
-      "integrity": "sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==",
-      "license": "MIT"
     },
     "node_modules/fd-slicer": {
       "version": "1.1.0",
@@ -1236,26 +991,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "BSD-3-Clause"
-    },
     "node_modules/immediate": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
@@ -1357,18 +1092,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-stream": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/is-typed-array": {
       "version": "1.1.15",
       "resolved": "https://registry.npmjs.org/is-typed-array/-/is-typed-array-1.1.15.tgz",
@@ -1383,12 +1106,6 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
-    },
-    "node_modules/isarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -1423,48 +1140,6 @@
         "node": ">= 0.6"
       }
     },
-    "node_modules/lazystream": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.1.tgz",
-      "integrity": "sha512-b94GiNHQNy6JNTrt5w6zNyffMrNkXZb3KTkCZJb2V1xaEGCk093vkZ2jk3tpaeP33/OiXC+WvK9AxUebnf5nbw==",
-      "license": "MIT",
-      "dependencies": {
-        "readable-stream": "^2.0.5"
-      },
-      "engines": {
-        "node": ">= 0.6.3"
-      }
-    },
-    "node_modules/lazystream/node_modules/readable-stream": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
-      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
-      "license": "MIT",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.3",
-        "isarray": "~1.0.0",
-        "process-nextick-args": "~2.0.0",
-        "safe-buffer": "~5.1.1",
-        "string_decoder": "~1.1.1",
-        "util-deprecate": "~1.0.1"
-      }
-    },
-    "node_modules/lazystream/node_modules/safe-buffer": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "license": "MIT"
-    },
-    "node_modules/lazystream/node_modules/string_decoder": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.1.0"
-      }
-    },
     "node_modules/lie": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
@@ -1482,12 +1157,6 @@
       "dependencies": {
         "lie": "3.1.1"
       }
-    },
-    "node_modules/lodash": {
-      "version": "4.18.1",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
-      "license": "MIT"
     },
     "node_modules/lru-cache": {
       "version": "10.4.3",
@@ -1684,15 +1353,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/normalize-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/object-inspect": {
       "version": "1.13.4",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -1801,21 +1461,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/process": {
-      "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 0.6.0"
-      }
-    },
-    "node_modules/process-nextick-args": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "license": "MIT"
-    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -1876,43 +1521,6 @@
       },
       "engines": {
         "node": ">= 0.8"
-      }
-    },
-    "node_modules/readable-stream": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
-      "integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
-      "license": "MIT",
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "buffer": "^6.0.3",
-        "events": "^3.3.0",
-        "process": "^0.11.10",
-        "string_decoder": "^1.3.0"
-      },
-      "engines": {
-        "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
-      }
-    },
-    "node_modules/readdir-glob": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/readdir-glob/-/readdir-glob-1.1.3.tgz",
-      "integrity": "sha512-v05I2k7xN8zXvPD9N+z/uhXPaj0sUFCe2rcWZIpBsqxfP7xXFQ0tipAd/wjj1YxWyWtUS5IDJpOG82JKt2EAVA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "minimatch": "^5.1.0"
-      }
-    },
-    "node_modules/readdir-glob/node_modules/minimatch": {
-      "version": "5.1.9",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.9.tgz",
-      "integrity": "sha512-7o1wEA2RyMP7Iu7GNba9vc0RWWGACJOCZBJX2GJWip0ikV+wcOsgVuY9uE8CPiyQhkGFSlhuSkZPavN7u1c2Fw==",
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/safe-buffer": {
@@ -2149,26 +1757,6 @@
         "node": ">= 0.8"
       }
     },
-    "node_modules/streamx": {
-      "version": "2.28.0",
-      "resolved": "https://registry.npmjs.org/streamx/-/streamx-2.28.0.tgz",
-      "integrity": "sha512-1Yowhzjf0ivGMrTIkY9hav5TxobO9qIVqUE41fiCGMGgc3CLlf4MY+9AHmZqBWgDTue0fY9zWjYFVyf6Diuobw==",
-      "license": "MIT",
-      "dependencies": {
-        "events-universal": "^1.0.0",
-        "fast-fifo": "^1.3.2",
-        "text-decoder": "^1.1.0"
-      }
-    },
-    "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "license": "MIT",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
-      }
-    },
     "node_modules/string-width": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
@@ -2263,36 +1851,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/tar-stream": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
-      "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
-      "license": "MIT",
-      "dependencies": {
-        "b4a": "^1.6.4",
-        "bare-fs": "^4.5.5",
-        "fast-fifo": "^1.2.0",
-        "streamx": "^2.15.0"
-      }
-    },
-    "node_modules/teex": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/teex/-/teex-1.0.1.tgz",
-      "integrity": "sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==",
-      "license": "MIT",
-      "dependencies": {
-        "streamx": "^2.12.5"
-      }
-    },
-    "node_modules/text-decoder": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.7.tgz",
-      "integrity": "sha512-vlLytXkeP4xvEq2otHeJfSQIRyWxo/oZGEbXrtEEF9Hnmrdly59sUbzZ/QgyWuLYHctCHxFF4tRQZNQ9k60ExQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "b4a": "^1.6.4"
       }
     },
     "node_modules/toidentifier": {
@@ -2418,12 +1976,6 @@
         "is-typed-array": "^1.1.3",
         "which-typed-array": "^1.1.2"
       }
-    },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "license": "MIT"
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",
@@ -2614,20 +2166,6 @@
       "license": "MIT",
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/zip-stream": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-6.0.1.tgz",
-      "integrity": "sha512-zK7YHHz4ZXpW89AHXUPbQVGKI7uvkd3hzusTdotCg1UxyaVtg0zFJSTfW/Dq5f7OBBVnq6cZIaC8Ti4hb6dtCA==",
-      "license": "MIT",
-      "dependencies": {
-        "archiver-utils": "^5.0.0",
-        "compress-commons": "^6.0.2",
-        "readable-stream": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 14"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@seald-io/nedb": "4.1.2",
         "@zip.js/zip.js": "2.8.26",
-        "archiver": "7.0.1",
         "cbor": "5.2.0",
         "compression": "1.8.1",
         "cookie-session": "2.1.1",
@@ -222,42 +221,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/archiver": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/archiver/-/archiver-7.0.1.tgz",
-      "integrity": "sha512-ZcbTaIqJOfCc03QwD468Unz/5Ir8ATtvAHsK+FdXbDIbGfihqh9mrvdcYunQzqn4HrvWWaFyaxJhGZagaJJpPQ==",
-      "license": "MIT",
-      "dependencies": {
-        "archiver-utils": "^5.0.2",
-        "async": "^3.2.4",
-        "buffer-crc32": "^1.0.0",
-        "readable-stream": "^4.0.0",
-        "readdir-glob": "^1.1.2",
-        "tar-stream": "^3.0.0",
-        "zip-stream": "^6.0.1"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
-    "node_modules/archiver-utils": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-5.0.2.tgz",
-      "integrity": "sha512-wuLJMmIBQYCsGZgYLTy5FIB2pF6Lfb6cXMSF8Qywwk3t20zWnAi7zLcQFdKQmIB8wyZpY5ER38x08GbwtR2cLA==",
-      "license": "MIT",
-      "dependencies": {
-        "glob": "^10.0.0",
-        "graceful-fs": "^4.2.0",
-        "is-stream": "^2.0.1",
-        "lazystream": "^1.0.0",
-        "lodash": "^4.17.15",
-        "normalize-path": "^3.0.0",
-        "readable-stream": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 14"
       }
     },
     "node_modules/array-flatten": {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
   "dependencies": {
     "@seald-io/nedb": "4.1.2",
     "@zip.js/zip.js": "2.8.26",
-    "archiver": "7.0.1",
     "cbor": "5.2.0",
     "compression": "1.8.1",
     "cookie-session": "2.1.1",

--- a/webserver.js
+++ b/webserver.js
@@ -6741,7 +6741,6 @@ module.exports.CreateWebServer = function (parent, db, args, certificates, doneF
         }
 
 		require('./macosinstaller').createMacOSInstaller(macosInstallerOpts).then(async function (installer) {
-			setContentDispositionHeader(res, 'application/octet-stream', meshfilename, null, 'MeshAgent.zip');
 			const { Writable } = require('node:stream');
 			const zip = require('@zip.js/zip.js');
 

--- a/webserver.js
+++ b/webserver.js
@@ -6693,9 +6693,6 @@ module.exports.CreateWebServer = function (parent, db, args, certificates, doneF
         if (domain.agentTranslations != null) { meshsettings += 'translation=' + domain.agentTranslations + '\r\n'; }
 
         // Setup the response output
-        var archive = require('archiver')('zip', { level: 5 }); // Sets the compression method.
-        archive.on('error', function (err) { throw err; });
-
         // Customize the mesh agent file name
         var meshfilename = 'MeshAgent-' + mesh.name + '.zip';
         var meshexecutablename = 'meshagent';
@@ -6726,7 +6723,6 @@ module.exports.CreateWebServer = function (parent, db, args, certificates, doneF
 
         // Set the agent download including the mesh name.
         setContentDispositionHeader(res, 'application/octet-stream', meshfilename, null, 'MeshAgent.zip');
-        archive.pipe(res);
 
         // Create a flat XAR macOS installer package. Bundle .mpkg installers are rejected by recent macOS versions.
         const macosInstallerOpts = {
@@ -6744,14 +6740,40 @@ module.exports.CreateWebServer = function (parent, db, args, certificates, doneF
             macosInstallerOpts.backgroundPath = parent.path.join(parent.datapath, domain.agentcustomization.macosinstallerimage);
         }
 
-        require('./macosinstaller').createMacOSInstaller(macosInstallerOpts).then(function (installer) {
-            archive.append(installer.pkg, { name: meshpkgname });
-            archive.append(installer.uninstall, { name: 'Uninstall.command', mode: 493 });
-            archive.finalize();
-        }).catch(function (err) {
-            parent.debug('web', 'Failed to build macOS MeshAgent package: ' + err);
-            try { res.sendStatus(500); } catch (ex) { }
-        });
+		require('./macosinstaller').createMacOSInstaller(macosInstallerOpts).then(async function (installer) {
+			setContentDispositionHeader(res, 'application/octet-stream', meshfilename, null, 'MeshAgent.zip');
+			const { Writable } = require('node:stream');
+			const zip = require('@zip.js/zip.js');
+
+			const zipWriter = new zip.ZipWriter(Writable.toWeb(res), { level: 5 });
+
+			await zipWriter.add(
+				meshpkgname,
+				new zip.Uint8ArrayReader(installer.pkg)
+			);
+
+			await zipWriter.add(
+				'Uninstall.command',
+				(typeof installer.uninstall === 'string')
+					? new zip.TextReader(installer.uninstall)
+					: new zip.Uint8ArrayReader(installer.uninstall),
+				{
+					executable: true,
+					unixMode: 0o100755
+				}
+			);
+
+			await zipWriter.close();
+		}).catch(function (err) {
+			parent.debug('web', 'Failed to build macOS MeshAgent package: ' + err);
+			try {
+				if (!res.headersSent) {
+					res.sendStatus(500);
+				} else {
+					res.destroy(err);
+				}
+			} catch (ex) { }
+		});
     }
 
     // Return a .msh file from a given request, id is the device group identifier or encrypted cookie with the identifier.


### PR DESCRIPTION
As I couldn't push to the pr, a fork. Better anyway as it had some conflicts which are resolved now.

- Relates to #7947 

the edits of pr 7947 and removal of minimatch, now using node's path.matchesGlob(), as discussed the pr
Also fixed a restorebug, everything was restored to the meshcentral-data folder, now it uses the configured paths.
adds an option to force case-sensitivity for the globs.