### PR TITLE
Fix remote-desktop frames dropped when jumbo packets are padded

### DIFF
--- a/mcrec.js
+++ b/mcrec.js
@@ -108,8 +108,9 @@ function processBlock(state, block, err) {
                     if (block.data.length >= 12) {
                         command = block.data.readUInt16BE(8);
                         cmdsize = block.data.readUInt32BE(4);
-                        if (block.data.length == (cmdsize + 8)) {
-                            block.data = block.data.slice(8, block.data.length);
+                        // Same padding issue as in meshdesktopmultiplex.js.
+                        if (block.data.length >= (cmdsize + 8)) {
+                            block.data = block.data.slice(8, cmdsize + 8);
                         } else {
                             console.log('TODO-PARTIAL-JUMBO', command, cmdsize, block.data.length);
                             return; // TODO

--- a/meshdesktopmultiplex.js
+++ b/meshdesktopmultiplex.js
@@ -684,8 +684,11 @@ function CreateDesktopMultiplexor(parent, domain, nodeid, id, func) {
             if (data.length >= 12) {
                 command = data.readUInt16BE(8);
                 cmdsize = data.readUInt32BE(4);
-                if (data.length == (cmdsize + 8)) {
-                    data = data.slice(8, data.length);
+                // The agent pads jumbo packets up to an 8-byte boundary, so data.length is
+                // usually 1..7 bytes longer than (cmdsize + 8). The previous exact-equality
+                // check classified those complete frames as partial and dropped them.
+                if (data.length >= (cmdsize + 8)) {
+                    data = data.slice(8, cmdsize + 8);
                 } else {
                     console.log('TODO-PARTIAL-JUMBO', command, cmdsize, data.length);
                     return; // TODO

--- a/public/scripts/agent-redir-ws-0.1.1.js
+++ b/public/scripts/agent-redir-ws-0.1.1.js
@@ -223,11 +223,16 @@ var CreateAgentRedirect = function (meshserver, module, serverPublicNamePort, au
                     var view = new Uint8Array(e.data), cmd = (view[0] << 8) + view[1], cmdsize = (view[2] << 8) + view[3];
                     if ((cmd == 27) && (cmdsize == 8)) { cmd = (view[8] << 8) + view[9]; cmdsize = (view[5] << 16) + (view[6] << 8) + view[7]; view = view.slice(8); }
                     //console.log(cmdsize, view.byteLength);
-                    if (cmdsize != view.byteLength) {
+                    // The agent pads packets up to an 8-byte boundary, so view.byteLength is
+                    // usually larger than cmdsize. With '!=' every complete frame was pushed
+                    // into the accumulator (which exists for WebRTC fragmentation) and was only
+                    // released when the next packet arrived - swallowing that next frame.
+                    // Accumulate only when the data is genuinely short; trim padding otherwise.
+                    if (cmdsize > view.byteLength) {
                         //console.log('AccumulatorRequired', cmd, cmdsize, view.byteLength);
                         cmdAccCmd = cmd; cmdAccCmdSize = cmdsize; cmdAccLen = view.byteLength, cmdAcc = [view];
                     } else {
-                        obj.m.ProcessBinaryCommand(cmd, cmdsize, view);
+                        obj.m.ProcessBinaryCommand(cmd, cmdsize, (cmdsize < view.byteLength) ? view.slice(0, cmdsize) : view);
                     }
                 }
             } else if (obj.m.ProcessBinaryData) {


### PR DESCRIPTION
### What this fixes

Remote-desktop frames are silently discarded when the agent pads a jumbo packet.

The agent pads jumbo packets up to an 8-byte boundary, so the received payload is typically 1..7 bytes longer than the size declared in the header. Three places assume an exact match and therefore classify a complete frame as partial.

**Server — `meshdesktopmultiplex.js` and `mcrec.js`**

```js
if (data.length == (cmdsize + 8)) { data = data.slice(8, data.length); }
else { console.log('TODO-PARTIAL-JUMBO', command, cmdsize, data.length); return; }
```

Every padded frame takes the `else` branch and is dropped.

**Browser — `public/scripts/agent-redir-ws-0.1.1.js`**

```js
if (cmdsize != view.byteLength) { ...start accumulator... } else { ...process... }
```

Because `view.byteLength` is larger than `cmdsize`, the condition is always true, so every complete frame is placed in the accumulator that exists for WebRTC fragmentation. Nothing checks whether the data is already complete, so the frame is only released when the next packet arrives — and that next frame is consumed as part of it.

### How it was observed

Running MeshCentral 1.2.5 with `desktopMultiplex` enabled, connecting from Chrome to a Windows x64 agent at 1920×1080.

Server console during a single desktop session (20 consecutive lines, all of the same shape):

```
TODO-PARTIAL-JUMBO 27 97752 97760
TODO-PARTIAL-JUMBO 27 85721 85728
TODO-PARTIAL-JUMBO 27 217868 217872
TODO-PARTIAL-JUMBO 27 175995 176000
```

In every line `data.length` exceeds `cmdsize + 8` by 1..7 bytes and every `data.length` is an exact multiple of 8 — i.e. padding, not truncation.

Two observations pointed at the length check rather than at the data:

* With `desktopMultiplex` disabled the same session renders correctly, so the packets themselves are intact.
* Small frames (< 65000 bytes) are not sent as jumbo packets and were never affected — desktop icons and the mouse cursor updated normally while large repaints (dragging a window, full-screen refresh) left stale tiles behind.

The visible symptom is torn screen content that does not recover, because the redraw that would repair it is itself a large frame and is dropped too.

### The change

All three checks now accept a payload that is at least as long as declared and slice exactly `cmdsize` bytes, discarding the padding. The genuinely-short path is left as it was, including the existing `TODO` markers.

### Verification

Applied to a production MeshCentral 1.2.5 instance and used daily for about a month for real support sessions. `TODO-PARTIAL-JUMBO` no longer appears, and the tearing that prompted the investigation is gone.

Only the server-side change is not sufficient on its own — it reduces the tearing but does not remove it. The browser-side accumulator condition is the larger half.

### Notes

* No configuration or protocol change; the agent is untouched.
* ⚠️ If `minify` is enabled the browser file is served from the `-min` bundle, so that bundle needs regenerating for the browser part to take effect.
* Related report: #8095.

Contributed by Ali Furkan Ateş.
