### PR TITLE
Fix Linux URL opening from system agent sessions

### DIFF
--- a/agents/meshcore.js
+++ b/agents/meshcore.js
@@ -4544,6 +4544,28 @@ function consoleHttpResponse(response) {
 }
 
 // Open a local file on current user's desktop
+function getLinuxDesktopEnvironment(uid) {
+    var env = {};
+    for (var i in process.env) { env[i] = process.env[i]; }
+
+    // Services do not inherit the graphical user's environment. Get it from
+    // the active user's processes so xdg-open can contact their desktop.
+    var sessions = require('user-sessions');
+    env.HOME = sessions.getHomeFolder(uid);
+    var sessionVariables = ['XDG_RUNTIME_DIR', 'DBUS_SESSION_BUS_ADDRESS', 'WAYLAND_DISPLAY', 'DISPLAY'];
+    for (var j in sessionVariables) {
+        var value = sessions.findEnv(uid, sessionVariables[j]);
+        if (value != null) { env[sessionVariables[j]] = value; }
+    }
+
+    // A systemd user session has predictable runtime and bus paths. Use these
+    // as a fallback when no process exposed the corresponding environment.
+    var runtimeDir = '/run/user/' + uid;
+    if (env.XDG_RUNTIME_DIR == null) { env.XDG_RUNTIME_DIR = runtimeDir; }
+    if (env.DBUS_SESSION_BUS_ADDRESS == null) { env.DBUS_SESSION_BUS_ADDRESS = 'unix:path=' + runtimeDir + '/bus'; }
+    return env;
+}
+
 function openFileOnDesktop(file) {
     var child = null;
     try {
@@ -4588,7 +4610,8 @@ function openFileOnDesktop(file) {
                 }
                 break;
             case 'linux':
-                child = require('child_process').execFile('/usr/bin/xdg-open', ['xdg-open', file], { uid: require('user-sessions').consoleUid() });
+                var uid = require('user-sessions').consoleUid();
+                child = require('child_process').execFile('/usr/bin/xdg-open', ['xdg-open', file], { uid: uid, env: getLinuxDesktopEnvironment(uid) });
                 break;
             case 'darwin':
                 child = require('child_process').execFile('/usr/bin/open', ['open', file]);
@@ -4647,7 +4670,8 @@ function openUserDesktopUrl(url) {
                 }
                 break;
             case 'linux':
-                child = require('child_process').execFile('/usr/bin/xdg-open', ['xdg-open', url], { uid: require('user-sessions').consoleUid() });
+                var uid = require('user-sessions').consoleUid();
+                child = require('child_process').execFile('/usr/bin/xdg-open', ['xdg-open', url], { uid: uid, env: getLinuxDesktopEnvironment(uid) });
                 break;
             case 'darwin':
                 child = require('child_process').execFile('/usr/bin/open', ['open', url], { uid: require('user-sessions').consoleUid() });


### PR DESCRIPTION
## Summary

Fix Linux `openUrl` and desktop-file actions when MeshAgent runs as a system service and the active user is in a graphical Wayland session.

The service environment does not include the user's D-Bus session variables. `xdg-open` is already launched as the console user, but without that environment it cannot ask the desktop session to open the URL. This is observable with Mesh Messenger on GNOME Wayland, where `xdg-open` exits with code 3.

The change builds an environment for the active user using the existing `user-sessions` module:

- set the user's `HOME`;
- import `XDG_RUNTIME_DIR`, `DBUS_SESSION_BUS_ADDRESS`, `WAYLAND_DISPLAY`, and `DISPLAY` from the user's processes;
- use standard systemd user-session paths as a fallback for the runtime directory and D-Bus address.

The existing `xdg-open` call is retained.

## Validation

- `git diff --check`
- `node --check agents/meshcore.js`
- Manual Ubuntu 26.04 GNOME/Mutter Wayland test: `xdg-open` opens a URL in the existing Chrome session with the same user-session environment passed by this patch.

Related: Ylianst/MeshAgent#115

## Development note

This change and PR description were prepared with assistance from an AI coding agent. The contributor reviewed the result, confirmed the observed behavior, and authorized the submission.