### PR TITLE
Fix opening URLs and files on the user's Linux desktop

### DIFF
--- a/agents/meshcore.js
+++ b/agents/meshcore.js
@@ -4588,7 +4588,18 @@ function openFileOnDesktop(file) {
                 }
                 break;
             case 'linux':
-                child = require('child_process').execFile('/usr/bin/xdg-open', ['xdg-open', file], { uid: require('user-sessions').consoleUid() });
+                // Same as openUserDesktopUrl: run as the interactive user with their graphical-session
+                // env, and prefer gio (xdg-open's KDE path breaks on Plasma with no KDE_SESSION_VERSION).
+                var luid = require('user-sessions').consoleUid();
+                var lenv = {};
+                for (var le in process.env) { lenv[le] = process.env[le]; }
+                var lvars = ['XDG_RUNTIME_DIR', 'DBUS_SESSION_BUS_ADDRESS', 'WAYLAND_DISPLAY', 'DISPLAY', 'HOME'];
+                for (var lv in lvars) { var lval = require('user-sessions').findEnv(luid, lvars[lv]); if (lval != null) { lenv[lvars[lv]] = lval; } }
+                if (require('fs').existsSync('/usr/bin/gio')) {
+                    child = require('child_process').execFile('/usr/bin/gio', ['gio', 'open', file], { uid: luid, env: lenv });
+                } else {
+                    child = require('child_process').execFile('/usr/bin/xdg-open', ['xdg-open', file], { uid: luid, env: lenv });
+                }
                 break;
             case 'darwin':
                 child = require('child_process').execFile('/usr/bin/open', ['open', file]);
@@ -4647,7 +4658,20 @@ function openUserDesktopUrl(url) {
                 }
                 break;
             case 'linux':
-                child = require('child_process').execFile('/usr/bin/xdg-open', ['xdg-open', url], { uid: require('user-sessions').consoleUid() });
+                // The opener needs the interactive user's graphical-session env or it can't reach the
+                // session bus (Wayland/GNOME/KDE) and nothing opens. Prefer 'gio open': xdg-open's
+                // desktop detection is fragile (e.g. Plasma with no KDE_SESSION_VERSION falls back to
+                // a missing kfmclient), while gio hands off to the session's default handler directly.
+                var luid = require('user-sessions').consoleUid();
+                var lenv = {};
+                for (var le in process.env) { lenv[le] = process.env[le]; }
+                var lvars = ['XDG_RUNTIME_DIR', 'DBUS_SESSION_BUS_ADDRESS', 'WAYLAND_DISPLAY', 'DISPLAY', 'HOME'];
+                for (var lv in lvars) { var lval = require('user-sessions').findEnv(luid, lvars[lv]); if (lval != null) { lenv[lvars[lv]] = lval; } }
+                if (require('fs').existsSync('/usr/bin/gio')) {
+                    child = require('child_process').execFile('/usr/bin/gio', ['gio', 'open', url], { uid: luid, env: lenv });
+                } else {
+                    child = require('child_process').execFile('/usr/bin/xdg-open', ['xdg-open', url], { uid: luid, env: lenv });
+                }
                 break;
             case 'darwin':
                 child = require('child_process').execFile('/usr/bin/open', ['open', url], { uid: require('user-sessions').consoleUid() });


### PR DESCRIPTION
# Summary

In this pull request, the following changes are made:

openUrl (used by Mesh Messenger) and the desktop Open action ran xdg-open as the interactive user but without their graphical-session environment. On Wayland the opener cannot reach the session bus, so dbus-send fails, xdg-open exits 3, and nothing opens. On Plasma 6 xdg-open also falls back to kfmclient (gone in Plasma 6) because KDE_SESSION_VERSION is not set.

Import the console user's session environment (XDG_RUNTIME_DIR, DBUS_SESSION_BUS_ADDRESS, WAYLAND_DISPLAY, DISPLAY, HOME) before launching the opener, and prefer "gio open" with an xdg-open fallback.

Resolves https://github.com/Ylianst/MeshAgent/issues/115#issuecomment-5385090810

- [x] 🧠 I used LLMs/AI in this contribution and reviewed all generated content.
      I understand that I am responsible for and able to explain every line of code I submit.
- [ ] 🔍 Any UI changes adhere to visual style of this project.
- [x] 🛠️ I have self-reviewed and self-tested my code to ensure it works as expected.
- [ ] 🤖 I added or updated automated tests where appropriate.
- [ ] 📄 Documentation updates are included (if applicable).
- [ ] 🧰 Dependency updates are listed and explained.
- [x] ⚠️ CI passes and is green.