### PR TITLE
Fix bulk user group delete dialog closing prematurely in modern UI

### DIFF
--- a/views/default3.handlebars
+++ b/views/default3.handlebars
@@ -20291,6 +20291,8 @@
                 document.getElementById('idx_dlgOkButton').onclick = function () {
                     p50groupActionFunctionDelExec(3);
                 };
+                // Keep the modal open; the rewired OK button must handle closing once the user confirms.
+                return false;
             }
         }
 


### PR DESCRIPTION
## Summary

The two-stage confirmation dialog for bulk user group deletion in the modern UI silently does nothing. After the first OK click, `p50usersGroupActionFunctionEx` rewrites the modal content and rewires the OK button, but the modal closes immediately, so the rewired OK button is never reachable and `deleteusergroup` is never sent to the server.

## Root cause

`showModal` treats any callback result other than the literal `false` as "close the modal":

```js
var callbackResult = okCallback(b, tag);
if (callbackResult !== false) { xxModal.hide(); }
```

`p50usersGroupActionFunctionEx()` returns `undefined` when the user picks "Delete group", so the modal is hidden as soon as the confirmation content has been written into it.

## Fix

Add `return false;` after the modal is rebuilt and the OK button is rewired so the modal stays open until the user ticks the confirmation checkbox and clicks OK again. This matches the pattern already used elsewhere in `default3.handlebars` (e.g. `p10showDeleteNodeDialog`, the registry rename flow).

## Diff

```diff
                 document.getElementById('idx_dlgOkButton').onclick = function () {
                     p50groupActionFunctionDelExec(3);
                 };
+                // Keep the modal open; the rewired OK button must handle closing once the user confirms.
+                return false;
             }
         }
```

## Test plan

- Log in as a site administrator with user group rights and the modern UI selected.
- Go to *My Users* -> *User Groups*, tick one or more groups, click *Group Action*.
- Leave the operation as *Delete group* and click OK.
- The "Confirm delete selected user group(s)?" dialog now stays visible with a Confirm checkbox.
- Tick Confirm, click OK, the dialog closes and `deleteusergroup` is sent. Groups are removed and stay removed after a page reload.

Manually verified the flow against a local 1.2.5 server with the modern UI and the dialog now stays open through both stages.

Resolves #8091