### PR TITLE
Fix theme pack static file path resolution

### DIFF
--- a/webserver.js
+++ b/webserver.js
@@ -8101,9 +8101,20 @@ module.exports.CreateWebServer = function (parent, db, args, certificates, doneF
                 var domain = getDomain(req);
                 // Serve theme pack files if domain has a theme pack configured
                 if (domain && domain.themepack) {
-                    var themeFilePath = obj.path.join(obj.parent.datapath, 'theme-pack', domain.themepack, 'public', req.path);
-                    // Prevent directory traversal
-                    if (themeFilePath.indexOf('..') >= 0) return next();
+                    // Keep theme pack names as a single folder under theme-pack
+                    if ((typeof domain.themepack !== 'string') || (domain.themepack.indexOf('..') >= 0) || (domain.themepack.indexOf('/') >= 0) || (domain.themepack.indexOf('\\') >= 0)) { return next(); }
+
+                    var themePublicRoot = obj.path.resolve(obj.parent.datapath, 'theme-pack', domain.themepack, 'public');
+                    var requestPath = (typeof req.path === 'string') ? req.path : '';
+                    while ((requestPath.length > 0) && ((requestPath.charAt(0) === '/') || (requestPath.charAt(0) === '\\'))) { requestPath = requestPath.slice(1); }
+
+                    // Resolve the requested file and keep it inside the theme public folder
+                    var themeFilePath = obj.path.resolve(themePublicRoot, requestPath);
+                    var themePublicRootCmp = isWindowsPlatform ? themePublicRoot.toLowerCase() : themePublicRoot;
+                    var themeFilePathCmp = isWindowsPlatform ? themeFilePath.toLowerCase() : themeFilePath;
+                    if ((themePublicRootCmp.length > 1) && themePublicRootCmp.endsWith(obj.path.sep)) { themePublicRootCmp = themePublicRootCmp.slice(0, -1); }
+                    if ((themeFilePathCmp.length > 1) && themeFilePathCmp.endsWith(obj.path.sep)) { themeFilePathCmp = themeFilePathCmp.slice(0, -1); }
+                    if ((themeFilePathCmp !== themePublicRootCmp) && (themeFilePathCmp.startsWith(themePublicRootCmp + obj.path.sep) === false)) { return next(); }
 
                     obj.fs.stat(themeFilePath, function (err, stats) {
                         if (err || !stats.isFile()) return next();


### PR DESCRIPTION
## Summary
- Keep theme pack static file responses inside the configured theme `public` folder after path resolution.
- Reject theme pack names that include path separators or parent-folder segments.
- Fall through to the normal static handlers when the resolved path is outside the theme folder or the file is missing.

## Test plan
- [x] With a domain `themePack` set, confirm normal theme assets under `/styles/` and `/scripts/` still load.
- [x] Confirm requests with parent-folder segments in the path do not return files from outside the theme `public` folder and fall through as before.
- [x] Confirm behavior is unchanged when no `themePack` is configured.