### PR TITLE
Max invalid login  - blocking types: iprange, ip, username

### DIFF
--- a/meshcentral-config-schema.json
+++ b/meshcentral-config-schema.json
@@ -1102,6 +1102,16 @@
               "default": 10,
               "description": "Maximum number of invalid login attempts from an IP address in the time period."
             },
+            "blocking": {
+              "type": "string",
+              "default": "iprange",
+              "enum": [
+                "iprange",
+                "ip",
+                "username"
+              ],
+              "description": "Selects what is blocked when the invalid login limit is reached. 'iprange' (default) keeps the current behavior of blocking IPv4 /24 ranges, 'ip' blocks the exact client IP, and 'username' blocks only the login name."
+            },
             "coolofftime": {
               "type": "integer",
               "default": null,

--- a/meshctrl.js
+++ b/meshctrl.js
@@ -2630,7 +2630,7 @@ function serverConnect() {
                         console.log('Authentication token required, use --token [number].');
                     } else if (data.msg == 'nokey') {
                         console.log('URL key is invalid or missing, please specify ?key=xxx in url');
-                    }  else {
+                    } else {
                         if ((args.loginkeyfile != null) || (args.loginkey != null)) {
                             console.log('Invalid login, check the login key and that this computer has the correct time.');
                         } else {

--- a/meshctrl.js
+++ b/meshctrl.js
@@ -137,6 +137,7 @@ if (args['_'].length == 0) {
             break;
         }
         case 'removeuserfromdevicegroup': {
+            console.log(args.id + ' ' + args.group + ' ' + args.userid);
             if ((args.id == null) && (args.group == null)) { console.log(winRemoveSingleQuotes("Device group identifier missing, use --id '[groupid]' or --group [groupname]")); }
             else if (args.userid == null) { console.log("Remove user from group missing useid, use --userid [userid]"); }
             else { ok = true; }
@@ -588,8 +589,7 @@ if (args['_'].length == 0) {
                         console.log("       4096 = Desktop Limited Input         8192 = Limit Events           ");
                         console.log("      16384 = Chat / Notify                32768 = Uninstall Agent        ");
                         console.log("      65536 = No Remote Desktop           131072 = Remote Commands        ");
-                        console.log("     262144 = Reset / Power off          4194304 = No Registry            ");
-                        console.log("    8388608 = No Software                                                 ");
+                        console.log("     262144 = Reset / Power off      4194304 = No Registry              ");
                         break;
                     }
                     case 'removefromusergroup': {
@@ -727,6 +727,7 @@ if (args['_'].length == 0) {
                         console.log("  --nofiles              - Hide the files tab from this user.");
                         console.log("  --noregistry           - Hide the registry tab from this user.");
                         console.log("  --nosoftware           - Hide the software tab from this user.");
+                        console.log("  --noregistry           - Hide the registry tab from this user.");
                         console.log("  --noamt                - Hide the Intel AMT tab from this user.");
                         console.log("  --limitedevents        - User can only see his own events.");
                         console.log("  --chatnotify           - Allow chat and notification options.");
@@ -1561,12 +1562,14 @@ function serverConnect() {
                 // Remove a device group from a user group
                 if (args.meshid != null) {
                     var meshid = args.meshid;
+                    console.log('meshid: ' + meshid);
                     if ((args.domain != null) && (userid.indexOf('/') < 0)) { meshid = 'mesh/' + args.domain + '/' + meshid; }
                     ws.send(JSON.stringify({ action: 'removemeshuser', meshid: meshid, userid: ugrpid, responseid: 'meshctrl' }));
                     break;
                 }
 
                 if ((args.id != null) && (args.id.startsWith('mesh/'))) {
+                    console.log('meshid_2: ' + args.id);
                     ws.send(JSON.stringify({ action: 'removemeshuser', meshid: args.id, userid: ugrpid, responseid: 'meshctrl' }));
                     break;
                 }
@@ -1672,6 +1675,7 @@ function serverConnect() {
                 if (args.nofiles) { meshrights |= 1024; }
                 if (args.noregistry) { meshrights |= 4194304; }
                 if (args.nosoftware) { meshrights |= 8388608; }
+                if (args.softwareread) { meshrights |= 16777216; }
                 if (args.noamt) { meshrights |= 2048; }
                 if (args.limiteddesktop) { meshrights |= 4096; }
                 if (args.limitedevents) { meshrights |= 8192; }
@@ -1683,6 +1687,7 @@ function serverConnect() {
                 break;
             }
             case 'removeuserfromdevicegroup': {
+                console.log('Removing user ' + args.userid + ' from device group ' + (args.id ? args.id : args.group));
                 var op = { action: 'removemeshuser', userid: args.userid, responseid: 'meshctrl' };
                 if (args.id) { op.meshid = args.id; } else if (args.group) { op.meshname = args.group; }
                 ws.send(JSON.stringify(op));
@@ -1701,6 +1706,7 @@ function serverConnect() {
                 if (args.nofiles) { meshrights |= 1024; }
                 if (args.noregistry) { meshrights |= 4194304; }
                 if (args.nosoftware) { meshrights |= 8388608; }
+                if (args.softwareread) { meshrights |= 16777216; }
                 if (args.noamt) { meshrights |= 2048; }
                 if (args.limiteddesktop) { meshrights |= 4096; }
                 if (args.limitedevents) { meshrights |= 8192; }
@@ -2630,13 +2636,17 @@ function serverConnect() {
                         console.log('Authentication token required, use --token [number].');
                     } else if (data.msg == 'nokey') {
                         console.log('URL key is invalid or missing, please specify ?key=xxx in url');
-                    } else {
+                    }  else {
                         if ((args.loginkeyfile != null) || (args.loginkey != null)) {
                             console.log('Invalid login, check the login key and that this computer has the correct time.');
                         } else {
                             console.log('Invalid login.');
                         }
                     }
+                } else if (data.cause == 'locked') {
+                    console.log('Account locked. Please contact the administrator.');
+                } else if (data.cause == 'banned') {
+                    console.log('Access temporarily blocked due to too many failed login attempts.');
                 }
                 process.exit();
                 break;

--- a/meshctrl.js
+++ b/meshctrl.js
@@ -137,7 +137,6 @@ if (args['_'].length == 0) {
             break;
         }
         case 'removeuserfromdevicegroup': {
-            console.log(args.id + ' ' + args.group + ' ' + args.userid);
             if ((args.id == null) && (args.group == null)) { console.log(winRemoveSingleQuotes("Device group identifier missing, use --id '[groupid]' or --group [groupname]")); }
             else if (args.userid == null) { console.log("Remove user from group missing useid, use --userid [userid]"); }
             else { ok = true; }
@@ -589,7 +588,8 @@ if (args['_'].length == 0) {
                         console.log("       4096 = Desktop Limited Input         8192 = Limit Events           ");
                         console.log("      16384 = Chat / Notify                32768 = Uninstall Agent        ");
                         console.log("      65536 = No Remote Desktop           131072 = Remote Commands        ");
-                        console.log("     262144 = Reset / Power off      4194304 = No Registry              ");
+                        console.log("     262144 = Reset / Power off          4194304 = No Registry            ");
+                        console.log("    8388608 = No Software                                                 ");
                         break;
                     }
                     case 'removefromusergroup': {
@@ -727,7 +727,6 @@ if (args['_'].length == 0) {
                         console.log("  --nofiles              - Hide the files tab from this user.");
                         console.log("  --noregistry           - Hide the registry tab from this user.");
                         console.log("  --nosoftware           - Hide the software tab from this user.");
-                        console.log("  --noregistry           - Hide the registry tab from this user.");
                         console.log("  --noamt                - Hide the Intel AMT tab from this user.");
                         console.log("  --limitedevents        - User can only see his own events.");
                         console.log("  --chatnotify           - Allow chat and notification options.");
@@ -1562,14 +1561,12 @@ function serverConnect() {
                 // Remove a device group from a user group
                 if (args.meshid != null) {
                     var meshid = args.meshid;
-                    console.log('meshid: ' + meshid);
                     if ((args.domain != null) && (userid.indexOf('/') < 0)) { meshid = 'mesh/' + args.domain + '/' + meshid; }
                     ws.send(JSON.stringify({ action: 'removemeshuser', meshid: meshid, userid: ugrpid, responseid: 'meshctrl' }));
                     break;
                 }
 
                 if ((args.id != null) && (args.id.startsWith('mesh/'))) {
-                    console.log('meshid_2: ' + args.id);
                     ws.send(JSON.stringify({ action: 'removemeshuser', meshid: args.id, userid: ugrpid, responseid: 'meshctrl' }));
                     break;
                 }
@@ -1675,7 +1672,6 @@ function serverConnect() {
                 if (args.nofiles) { meshrights |= 1024; }
                 if (args.noregistry) { meshrights |= 4194304; }
                 if (args.nosoftware) { meshrights |= 8388608; }
-                if (args.softwareread) { meshrights |= 16777216; }
                 if (args.noamt) { meshrights |= 2048; }
                 if (args.limiteddesktop) { meshrights |= 4096; }
                 if (args.limitedevents) { meshrights |= 8192; }
@@ -1687,7 +1683,6 @@ function serverConnect() {
                 break;
             }
             case 'removeuserfromdevicegroup': {
-                console.log('Removing user ' + args.userid + ' from device group ' + (args.id ? args.id : args.group));
                 var op = { action: 'removemeshuser', userid: args.userid, responseid: 'meshctrl' };
                 if (args.id) { op.meshid = args.id; } else if (args.group) { op.meshname = args.group; }
                 ws.send(JSON.stringify(op));
@@ -1706,7 +1701,6 @@ function serverConnect() {
                 if (args.nofiles) { meshrights |= 1024; }
                 if (args.noregistry) { meshrights |= 4194304; }
                 if (args.nosoftware) { meshrights |= 8388608; }
-                if (args.softwareread) { meshrights |= 16777216; }
                 if (args.noamt) { meshrights |= 2048; }
                 if (args.limiteddesktop) { meshrights |= 4096; }
                 if (args.limitedevents) { meshrights |= 8192; }

--- a/webserver.js
+++ b/webserver.js
@@ -9155,7 +9155,7 @@ module.exports.CreateWebServer = function (parent, db, args, certificates, doneF
                             // If not authenticated, close the websocket connection
                             parent.debug('web', 'ERR: Websocket bad user/pass auth');
                             //obj.parent.DispatchEvent(['*', 'server-users', 'user/' + domain.id + '/' + obj.args.user.toLowerCase()], obj, { action: 'authfail', userid: 'user/' + domain.id + '/' + obj.args.user.toLowerCase(), username: obj.args.user, domain: domain.id, msg: 'Invalid user login attempt from ' + req.clientIp });
-                            parent.debug("Failed login for user:", req.query.user);
+                            //parent.debug('web', "Failed login for user:", req.query.user);
                             obj.setbadLogin(req, req.query.user);
                             try { ws.send(JSON.stringify({ action: 'close', cause: 'noauth', msg: 'noauth-2a' })); ws.close(); } catch (e) { }
                         }
@@ -9287,7 +9287,7 @@ module.exports.CreateWebServer = function (parent, db, args, certificates, doneF
                         } else {
                             // If not authenticated, close the websocket connection
                             parent.debug('web', 'ERR: Websocket bad user/pass auth');
-                            parent.debug("Failed login for user:", s[0]);
+                            //parent.debug('web', "Failed login for user:", s[0]);
                             obj.setbadLogin(req, s[0]);
                             try { ws.send(JSON.stringify({ action: 'close', cause: 'noauth', msg: 'noauth-2d' })); ws.close(); } catch (e) { }
                         }

--- a/webserver.js
+++ b/webserver.js
@@ -9154,9 +9154,9 @@ module.exports.CreateWebServer = function (parent, db, args, certificates, doneF
                         } else {
                             // If not authenticated, close the websocket connection
                             parent.debug('web', 'ERR: Websocket bad user/pass auth');
-                            console.log("1");
                             //obj.parent.DispatchEvent(['*', 'server-users', 'user/' + domain.id + '/' + obj.args.user.toLowerCase()], obj, { action: 'authfail', userid: 'user/' + domain.id + '/' + obj.args.user.toLowerCase(), username: obj.args.user, domain: domain.id, msg: 'Invalid user login attempt from ' + req.clientIp });
-                            //obj.setbadLogin(req);
+                            parent.debug("Failed login for user:", req.query.user);
+                            obj.setbadLogin(req, req.query.user);
                             try { ws.send(JSON.stringify({ action: 'close', cause: 'noauth', msg: 'noauth-2a' })); ws.close(); } catch (e) { }
                         }
                     }

--- a/webserver.js
+++ b/webserver.js
@@ -1232,8 +1232,10 @@ module.exports.CreateWebServer = function (parent, db, args, certificates, doneF
         if (req.body == null) { res.sendStatus(404); return; } // Post body is empty or can't be parsed
         if (req.session == null) { req.session = {}; }
 
+        const blockingMode = parent.config.settings.maxinvalidlogin?.blocking || 'iprange';
+
         // Check if this is a banned ip address
-        if (obj.checkAllowLogin(req) == false) {
+        if (blockingMode !== 'username' && obj.checkAllowLogin(req) === false) {
             // Wait and redirect the user
             setTimeout(function () {
                 req.session.messageid = 114; // IP address blocked, try again later.
@@ -1247,6 +1249,16 @@ module.exports.CreateWebServer = function (parent, db, args, certificates, doneF
         if ((xusername == null) && (xpassword == null) && (req.body.token != null)) {
             const sec = parent.decryptSessionData(req.session.e);
             xusername = sec.tuser; xpassword = sec.tpass;
+        }
+console.log("blockingMode", blockingMode, xusername, obj.checkAllowLogin(null, xusername));
+        // Check if the user is locked out
+        if (blockingMode === 'username' && obj.checkAllowLogin(null, xusername) === false) {
+            // Wait and redirect the user
+            setTimeout(function () {
+                req.session.messageid = 110; // Account locked
+                if (direct === true) { handleRootRequestEx(req, res, domain); } else { res.redirect(domain.url + getQueryPortion(req)); }
+            }, 2000 + (obj.crypto.randomBytes(2).readUInt16BE(0) % 4095));
+            return;
         }
 
         // Authenticate the user
@@ -1461,19 +1473,19 @@ module.exports.CreateWebServer = function (parent, db, args, certificates, doneF
                             req.session.messageid = 110; // Account locked.
                             const ua = obj.getUserAgentInfo(req);
                             obj.parent.DispatchEvent(['*', 'server-users', xuserid], obj, { action: 'authfail', userid: xuserid, username: xusername, domain: domain.id, msg: 'User login attempt on locked account from ' + req.clientIp, msgid: 109, msgArgs: [req.clientIp, ua.browserStr, ua.osStr] });
-                            obj.setbadLogin(req);
+                            obj.setbadLogin(req, xusername);
                         } else if (err == 'denied') {
                             parent.debug('web', 'handleLoginRequest: login failed, access denied');
                             req.session.messageid = 111; // Access denied.
                             const ua = obj.getUserAgentInfo(req);
                             obj.parent.DispatchEvent(['*', 'server-users', xuserid], obj, { action: 'authfail', userid: xuserid, username: xusername, domain: domain.id, msg: 'Denied user login from ' + req.clientIp, msgid: 155, msgArgs: [req.clientIp, ua.browserStr, ua.osStr] });
-                            obj.setbadLogin(req);
+                            obj.setbadLogin(req, xusername);
                         } else {
                             parent.debug('web', 'handleLoginRequest: login failed, bad username and password');
                             req.session.messageid = 112; // Login failed, check username and password.
                             const ua = obj.getUserAgentInfo(req);
                             obj.parent.DispatchEvent(['*', 'server-users', xuserid], obj, { action: 'authfail', userid: xuserid, username: xusername, domain: domain.id, msg: 'Invalid user login attempt from ' + req.clientIp, msgid: 110, msgArgs: [req.clientIp, ua.browserStr, ua.osStr] });
-                            obj.setbadLogin(req);
+                            obj.setbadLogin(req, xusername);
                         }
                     }
 
@@ -10611,39 +10623,129 @@ module.exports.CreateWebServer = function (parent, db, args, certificates, doneF
         if (typeof parent.config.settings.maxinvalidlogin.time != 'number') { parent.config.settings.maxinvalidlogin.time = 10; }
         if (typeof parent.config.settings.maxinvalidlogin.count != 'number') { parent.config.settings.maxinvalidlogin.count = 10; }
         if ((typeof parent.config.settings.maxinvalidlogin.coolofftime != 'number') || (parent.config.settings.maxinvalidlogin.coolofftime < 1)) { parent.config.settings.maxinvalidlogin.coolofftime = null; }
-    }
-    obj.setbadLogin = function (ip) { // Set an IP address that just did a bad login request
-        if (parent.config.settings.maxinvalidlogin === false) return;
-        if (typeof ip == 'object') { ip = ip.clientIp; }
-        if (parent.config.settings.maxinvalidlogin != null) {
-            if (typeof parent.config.settings.maxinvalidlogin.exclude == 'string') {
-                const excludeSplit = parent.config.settings.maxinvalidlogin.exclude.split(',');
-                for (var i in excludeSplit) { if (require('ipcheck').match(ip, excludeSplit[i])) return; }
-            } else if (Array.isArray(parent.config.settings.maxinvalidlogin.exclude)) {
-                for (var i in parent.config.settings.maxinvalidlogin.exclude) { if (require('ipcheck').match(ip, parent.config.settings.maxinvalidlogin.exclude[i])) return; }
+        if (typeof parent.config.settings.maxinvalidlogin.blocking != 'string') {
+            parent.config.settings.maxinvalidlogin.blocking = 'iprange';
+        } else {
+            parent.config.settings.maxinvalidlogin.blocking = parent.config.settings.maxinvalidlogin.blocking.toLowerCase();
+            if (['iprange', 'ip', 'username'].indexOf(parent.config.settings.maxinvalidlogin.blocking) < 0) {
+                parent.config.settings.maxinvalidlogin.blocking = 'iprange';
             }
         }
-        var splitip = ip.split('.');
-        if (splitip.length == 4) { ip = (splitip[0] + '.' + splitip[1] + '.' + splitip[2] + '.*'); }
-        if (++obj.badLoginTableLastClean > 100) { obj.cleanBadLoginTable(); }
-        if (typeof obj.badLoginTable[ip] == 'number') { if (obj.badLoginTable[ip] < Date.now()) { delete obj.badLoginTable[ip]; } else { return; } }  // Check cooloff period
-        if (obj.badLoginTable[ip] == null) { obj.badLoginTable[ip] = [Date.now()]; } else { obj.badLoginTable[ip].push(Date.now()); }
-        if ((obj.badLoginTable[ip].length >= parent.config.settings.maxinvalidlogin.count) && (parent.config.settings.maxinvalidlogin.coolofftime != null)) {
-            obj.badLoginTable[ip] = Date.now() + (parent.config.settings.maxinvalidlogin.coolofftime * 60000); // Move to cooloff period
-        }
     }
-    obj.checkAllowLogin = function (ip) { // Check if an IP address is allowed to login
+    function getBadLoginKey(ip, username) {
+        if (typeof ip === 'object' && ip != null) { ip = ip.clientIp; }
+
+        const mode = parent.config.settings.maxinvalidlogin?.blocking || 'iprange';
+
+        if (mode === 'username') {
+            return (typeof username === 'string' && username.length > 0) ? username.toLowerCase() : null;
+        }
+
+        if (mode === 'ip') { return ip; }
+        if (mode === 'iprange') {
+            const splitip = ip.split('.');
+            if (splitip.length === 4) { // Check if IP v4
+                return `${splitip[0]}.${splitip[1]}.${splitip[2]}.*`;
+            }
+            return ip;
+        }
+        return null; // Return null if mode is 'username'
+    }
+    obj.isKeyAllowed = function (key) {
+        if (!parent.config.settings.maxinvalidlogin || !key) return true;
+console.log('Checking if key is allowed:', key);
+        const entry = obj.badLoginTable[key];
+    console.log('Entry for key:', entry);
+        if (entry == null) return true;
+
+        const now = Date.now();
+
+        // Check cooloff period (number timestamp)
+        if (typeof entry === 'number') {
+            if (entry < now) {
+                delete obj.badLoginTable[key];
+                return true;
+            }
+            return false;
+        }
+console.log('Entry is an array:', entry);
+        // Check sliding window timestamps (array)
+        const cutoffTime = now - (parent.config.settings.maxinvalidlogin.time * 60000);
+        while (entry.length > 0 && entry[0] < cutoffTime) {
+            entry.shift();
+        }
+console.log('Entry after cleanup:', entry);
+        if (entry.length === 0) {
+            delete obj.badLoginTable[key];
+            return true;
+        }
+console.log('Entry length:', entry.length, 'Max allowed:', parent.config.settings.maxinvalidlogin.count);
+        return entry.length < parent.config.settings.maxinvalidlogin.count;
+    };
+    obj.setbadLogin = function (ip, username) {
+        if (!parent.config.settings.maxinvalidlogin) return;
+
+        const rawIp = (typeof ip === 'object' && ip != null) ? ip.clientIp : ip;
+
+        // Check IP exclusion list (only applicable if a valid IP is present)
+        if (typeof rawIp === 'string' && parent.config.settings.maxinvalidlogin.exclude) {
+            const excludes = Array.isArray(parent.config.settings.maxinvalidlogin.exclude)
+                ? parent.config.settings.maxinvalidlogin.exclude
+                : parent.config.settings.maxinvalidlogin.exclude.split(',');
+
+            const ipcheck = require('ipcheck');
+            for (const pattern of excludes) {
+                if (ipcheck.match(rawIp, pattern.trim())) return;
+            }
+        }
+
+        // Resolve key based on configuration ('ip', 'iprange', or 'username')
+        const key = getBadLoginKey(ip, username);
+        if (!key) return;
+
+        // Periodic cleanup trigger
+        if (++obj.badLoginTableLastClean > 100) { 
+            obj.cleanBadLoginTable(); 
+        }
+
+        const now = Date.now();
+
+        // Check cooloff period
+        if (typeof obj.badLoginTable[key] === 'number') {
+            if (obj.badLoginTable[key] < now) { 
+                delete obj.badLoginTable[key]; 
+            } else { 
+                return; 
+            }
+        }
+
+        // Record bad attempt timestamp
+        if (obj.badLoginTable[key] == null) {
+            obj.badLoginTable[key] = [now];
+        } else {
+            obj.badLoginTable[key].push(now);
+        }
+
+        // Enter cooloff period if threshold reached
+        const maxCount = parent.config.settings.maxinvalidlogin.count;
+        const cooloff = parent.config.settings.maxinvalidlogin.coolofftime;
+        if (cooloff != null && obj.badLoginTable[key].length >= maxCount) {
+            obj.badLoginTable[key] = now + (cooloff * 60000);
+        }
+    };
+    obj.checkAllowLogin = function (ip, username) { // Check if a login key is allowed to login
         if (parent.config.settings.maxinvalidlogin === false) return true;
-        if (typeof ip == 'object') { ip = ip.clientIp; }
-        var splitip = ip.split('.');
-        if (splitip.length == 4) { ip = (splitip[0] + '.' + splitip[1] + '.' + splitip[2] + '.*'); } // If this is IPv4, keep only the 3 first
-        var cutoffTime = Date.now() - (parent.config.settings.maxinvalidlogin.time * 60000); // Time in minutes
-        var ipTable = obj.badLoginTable[ip];
-        if (ipTable == null) return true;
-        if (typeof ipTable == 'number') { if (obj.badLoginTable[ip] < Date.now()) { delete obj.badLoginTable[ip]; } else { return false; } } // Check cooloff period
-        while ((ipTable.length > 0) && (ipTable[0] < cutoffTime)) { ipTable.shift(); }
-        if (ipTable.length == 0) { delete obj.badLoginTable[ip]; return true; }
-        return (ipTable.length < parent.config.settings.maxinvalidlogin.count); // No more than x bad logins in x minutes
+
+        const mode = parent.config.settings.maxinvalidlogin?.blocking || 'iprange';
+        if (mode === 'username') {
+            if (typeof username === 'string' && username.length > 0) {
+                return obj.isKeyAllowed(username.toLowerCase());
+            }
+            return true;
+        }
+
+        const ipKey = getBadLoginKey(ip);
+        return obj.isKeyAllowed(ipKey); // No more than x bad logins in x minutes
     }
     obj.cleanBadLoginTable = function () { // Clean up the IP address login blockage table, we do this occasionaly.
         if (parent.config.settings.maxinvalidlogin === false) return;

--- a/webserver.js
+++ b/webserver.js
@@ -1250,7 +1250,7 @@ module.exports.CreateWebServer = function (parent, db, args, certificates, doneF
             const sec = parent.decryptSessionData(req.session.e);
             xusername = sec.tuser; xpassword = sec.tpass;
         }
-console.log("blockingMode", blockingMode, xusername, obj.checkAllowLogin(null, xusername));
+
         // Check if the user is locked out
         if (blockingMode === 'username' && obj.checkAllowLogin(null, xusername) === false) {
             // Wait and redirect the user
@@ -9001,8 +9001,27 @@ console.log("blockingMode", blockingMode, xusername, obj.checkAllowLogin(null, x
             parent.debug('web', 'WSERROR: Session expired.'); try { ws.send(JSON.stringify({ action: 'close', cause: 'expired', msg: 'expired-1' })); ws.close(); } catch (e) { } return;
         }
 
-        // Check if this is a banned ip address
-        if (obj.checkAllowLogin(req) == false) { parent.debug('web', 'WSERROR: Banned connection.'); try { ws.send(JSON.stringify({ action: 'close', cause: 'banned', msg: 'banned-1' })); ws.close(); } catch (e) { } return; }
+        const blockingMode = parent.config.settings.maxinvalidlogin?.blocking || 'iprange';
+        
+        // Check if blocking mode is ip and this is a banned ip address
+        if (blockingMode !== 'username' && obj.checkAllowLogin(req) === false) { parent.debug('web', 'WSERROR: Banned connection.'); try { ws.send(JSON.stringify({ action: 'close', cause: 'banned', msg: 'banned-1' })); ws.close(); } catch (e) { } return; }
+        // Check if blocking mode is username and this is a banned username
+        if (blockingMode === 'username') {
+            let username = null;
+            if (req.query && req.query.user) {
+                username = req.query.user;
+                if (username.startsWith('~t:')) { tokenUser = username; }
+            } else if (req.headers && req.headers['x-meshauth']) {
+                try {
+                    username = Buffer.from(req.headers['x-meshauth'].split(',')[0], 'base64').toString();
+                } catch (e) {}
+            } else if (req.session) {
+                if (req.session.loginToken) { username = req.session.loginToken; }
+                if (req.session.userid) { username = req.session.userid.split('/')[2]; }
+            }
+            if(username && obj.checkAllowLogin(null, username) === false) { parent.debug('web', 'WSERROR: Locked user.'); try { ws.send(JSON.stringify({ action: 'close', cause: 'locked', msg: 'locked-1' })); ws.close(); } catch (e) { } return; }
+        }
+        
         try {
             // Hold this websocket until we are ready.
             ws._socket.pause();
@@ -9135,6 +9154,7 @@ console.log("blockingMode", blockingMode, xusername, obj.checkAllowLogin(null, x
                         } else {
                             // If not authenticated, close the websocket connection
                             parent.debug('web', 'ERR: Websocket bad user/pass auth');
+                            console.log("1");
                             //obj.parent.DispatchEvent(['*', 'server-users', 'user/' + domain.id + '/' + obj.args.user.toLowerCase()], obj, { action: 'authfail', userid: 'user/' + domain.id + '/' + obj.args.user.toLowerCase(), username: obj.args.user, domain: domain.id, msg: 'Invalid user login attempt from ' + req.clientIp });
                             //obj.setbadLogin(req);
                             try { ws.send(JSON.stringify({ action: 'close', cause: 'noauth', msg: 'noauth-2a' })); ws.close(); } catch (e) { }
@@ -9267,6 +9287,8 @@ console.log("blockingMode", blockingMode, xusername, obj.checkAllowLogin(null, x
                         } else {
                             // If not authenticated, close the websocket connection
                             parent.debug('web', 'ERR: Websocket bad user/pass auth');
+                            parent.debug("Failed login for user:", s[0]);
+                            obj.setbadLogin(req, s[0]);
                             try { ws.send(JSON.stringify({ action: 'close', cause: 'noauth', msg: 'noauth-2d' })); ws.close(); } catch (e) { }
                         }
                     }
@@ -10653,9 +10675,9 @@ console.log("blockingMode", blockingMode, xusername, obj.checkAllowLogin(null, x
     }
     obj.isKeyAllowed = function (key) {
         if (!parent.config.settings.maxinvalidlogin || !key) return true;
-console.log('Checking if key is allowed:', key);
+
         const entry = obj.badLoginTable[key];
-    console.log('Entry for key:', entry);
+    
         if (entry == null) return true;
 
         const now = Date.now();
@@ -10668,18 +10690,18 @@ console.log('Checking if key is allowed:', key);
             }
             return false;
         }
-console.log('Entry is an array:', entry);
+
         // Check sliding window timestamps (array)
         const cutoffTime = now - (parent.config.settings.maxinvalidlogin.time * 60000);
         while (entry.length > 0 && entry[0] < cutoffTime) {
             entry.shift();
         }
-console.log('Entry after cleanup:', entry);
+
         if (entry.length === 0) {
             delete obj.badLoginTable[key];
             return true;
         }
-console.log('Entry length:', entry.length, 'Max allowed:', parent.config.settings.maxinvalidlogin.count);
+
         return entry.length < parent.config.settings.maxinvalidlogin.count;
     };
     obj.setbadLogin = function (ip, username) {


### PR DESCRIPTION
# Summary

If I am not mistaken, currently only the ip range can be blocked after n invalid login tries. This can be bad when working in a company environment where different users from the same admin server access meshcentral, or are in the same subnet. I made this change to switch also just to a single IP or the username. I also added this for token user, saying that also a token user can now be locked out after in maxInvalidLogin defined turns.
Default value is still _iprange_.

To unlock a user, you still have to wait, or reboot the server. No option available in the menu.

<details>
<summary>Please follow this checklist to avoid unnecessary back and forth (click to expand)</summary>

- [X] 🧠 I used LLMs/AI in this contribution and reviewed all generated content.
      I understand that I am responsible for and able to explain every line of code I submit.
- [ ] 🔍 Any UI changes adhere to visual style of this project.
- [X] 🛠️ I have self-reviewed and self-tested my code to ensure it works as expected.
- [ ] 🤖 I added or updated automated tests where appropriate.
- [X] 📄 Documentation updates are included (if applicable).
- [ ] 🧰 Dependency updates are listed and explained.
- [ ] ⚠️ CI passes and is green.

</details>

I tested this with the normal web login, meshctrl and calling _wss://localhost:443/control.ashx?user=:UWpEUzGFpIWcPb5Y2&pass=wrongpassword_
and the setting:
```
"maxInvalidLogin": {
      "time": 10,
      "count": 2,
      "coolofftime": 10,
      "blocking": "username"
    },
```
