### PR TITLE
Fix: Add bash detection on BSD and add PATH for freebsd

### DIFF
--- a/agents/meshcore.js
+++ b/agents/meshcore.js
@@ -2909,13 +2909,18 @@ function terminal_promise_consent_resolved()
     {
         try
         {
-            var bash = fs.existsSync('/bin/bash') ? '/bin/bash' : false;
+            var bash = fs.existsSync('/bin/bash') ? '/bin/bash' : (fs.existsSync('/usr/local/bin/bash') ? '/usr/local/bin/bash' : false); // BSD pkg bash
             var sh = fs.existsSync('/bin/sh') ? '/bin/sh' : false;
             var login = process.platform == 'linux' ? '/bin/login' : '/usr/bin/login';
 
             var env = { HISTCONTROL: 'ignoreboth' };
             if (process.env['LANG']) { env['LANG'] = process.env['LANG']; }
-            if (process.env['PATH']) { env['PATH'] = process.env['PATH']; }
+            var termPath = process.env['PATH'] || '/usr/bin:/bin';
+            if (process.platform == 'freebsd') {
+                if ((':' + termPath + ':').indexOf(':/usr/local/bin:') == -1)  { termPath = '/usr/local/bin:'  + termPath; }
+                if ((':' + termPath + ':').indexOf(':/usr/local/sbin:') == -1) { termPath = '/usr/local/sbin:' + termPath; }
+            }
+            env['PATH'] = termPath;
             if (typeof this.httprequest.terminalUserVariable == 'string' && this.httprequest.terminalUserVariable != '') {
                 if (this.httprequest.terminalUserVariable == 'realname') {
                     env['MESHCENTRAL_USER'] = (this.httprequest.realname ? this.httprequest.realname : 'unknown');


### PR DESCRIPTION
Freebsd terminal from service has a minimal PATH, add /usr/local/(s)bin dirs

<details>

- [ ] 🧠 I used LLMs/AI in this contribution and reviewed all generated content.
      I understand that I am responsible for and able to explain every line of code I submit.
- [ ] 🔍 Any UI changes adhere to visual style of this project.
- [x] 🛠️ I have self-reviewed and self-tested my code to ensure it works as expected.
- [ ] 🤖 I added or updated automated tests where appropriate.
- [ ] 📄 Documentation updates are included (if applicable).
- [ ] 🧰 Dependency updates are listed and explained.
- [x] ⚠️ CI passes and is green.

</details>