### PR TITLE
Add on-screen input panel for Android devices in remote desktop views

### DIFF
--- a/views/default-mobile.handlebars
+++ b/views/default-mobile.handlebars
@@ -1023,6 +1023,16 @@
                                     <input type="button" onkeypress="return false" onkeydown="return false" value="Power Actions..." onclick="showPowerActionDlg()" style="display:none;height:28px">
                                     <!--<input type="button" id="DeskSpecialKeys" value="Keys" onkeypress="return false" onkeydown="return false" onclick="sendSpecialKeys()" style="height:28px">-->
                                     <input type="button" id="DeskScreens" value="Screens" onkeypress="return false" onkeydown="return false" onclick="deskSelectScreens()" style="display:none;height:28px">
+                                    <span id="DeskAndroidPanel" style="display:none">
+                                        <input type="button" value="Back" onkeypress="return false" onkeydown="return false" onclick="deskAndroidKey(27)" style="height:28px">
+                                        <input type="button" value="Home" onkeypress="return false" onkeydown="return false" onclick="deskAndroidKey(36)" style="height:28px">
+                                        <input type="button" value="Recent" onkeypress="return false" onkeydown="return false" onclick="deskAndroidKey(93)" style="height:28px">
+                                        <input type="button" value="Apps" onkeypress="return false" onkeydown="return false" onclick="deskAndroidKey(200)" style="height:28px">
+                                        <input type="button" value="Notifications" onkeypress="return false" onkeydown="return false" onclick="deskAndroidKey(201)" style="height:28px">
+                                        <input type="button" value="Quick" onkeypress="return false" onkeydown="return false" onclick="deskAndroidKey(202)" style="height:28px">
+                                        <input type="button" value="Lock" onkeypress="return false" onkeydown="return false" onclick="deskAndroidKey(203)" style="height:28px">
+                                        <input type="button" value="Power" onkeypress="return false" onkeydown="return false" onclick="deskAndroidKey(204)" style="height:28px">
+                                    </span>
                                     <label><span id="DeskControlSpan" style="display:none"><input id="DeskControl" type="checkbox" onkeypress="return false" onkeydown="return false">Input</span></label>
                                 </div>
                             </div>
@@ -4691,6 +4701,13 @@
         }
 
         // Show and enable the right buttons
+        // Android on-screen input panel. Key codes 200+ map to Android global actions in the agent.
+        function deskAndroidKey(kc) {
+            if ((desktop == null) || (desktop.State != 3)) return;
+            desktop.m.SendKeyMsgKC(1, kc);
+            desktop.m.SendKeyMsgKC(2, kc);
+        }
+
         function updateDesktopButtons() {
             var mesh = meshes[currentNode.meshid];
             var deskState = 0;
@@ -4699,6 +4716,7 @@
 
             // Show the right buttons
             QV('disconnectbutton1', (deskState != 0));
+            QV('DeskAndroidPanel', (deskState == 3) && (currentNode.agent != null) && (currentNode.agent.id == 14) && ((meshrights == 0xFFFFFFFF) || ((meshrights & 8) != 0)));
             QE('deskFullScreen', (deskState != 0));
             QV('connectbutton1', (deskState == 0) && ((meshrights & 8) || (meshrights & 256)) && (currentNode.agent != null) && (currentNode.agent.caps & 1));
             QV('connectbutton1h',

--- a/views/default-mobile.handlebars
+++ b/views/default-mobile.handlebars
@@ -1028,10 +1028,14 @@
                                         <input type="button" value="Home" onkeypress="return false" onkeydown="return false" onclick="deskAndroidKey(36)" style="height:28px">
                                         <input type="button" value="Recent" onkeypress="return false" onkeydown="return false" onclick="deskAndroidKey(93)" style="height:28px">
                                         <input type="button" value="Apps" onkeypress="return false" onkeydown="return false" onclick="deskAndroidKey(200)" style="height:28px">
-                                        <input type="button" value="Notifications" onkeypress="return false" onkeydown="return false" onclick="deskAndroidKey(201)" style="height:28px">
-                                        <input type="button" value="Quick" onkeypress="return false" onkeydown="return false" onclick="deskAndroidKey(202)" style="height:28px">
-                                        <input type="button" value="Lock" onkeypress="return false" onkeydown="return false" onclick="deskAndroidKey(203)" style="height:28px">
-                                        <input type="button" value="Power" onkeypress="return false" onkeydown="return false" onclick="deskAndroidKey(204)" style="height:28px">
+                                        <input type="button" value="More" onkeypress="return false" onkeydown="return false" onclick="deskAndroidToggleMore()" style="height:28px">
+                                        <div id="DeskAndroidMoreBg" style="display:none;position:fixed;inset:0;z-index:998" onclick="deskAndroidToggleMore()"></div>
+                                        <div id="DeskAndroidMore" style="display:none;position:absolute;bottom:32px;right:2px;min-width:150px;background:#f0f0f0;border:1px solid #808080;box-shadow:0 -1px 4px rgba(0,0,0,0.3);z-index:999;text-align:left">
+                                            <div onclick="deskAndroidKey(201);deskAndroidToggleMore()" style="padding:8px 12px;border-bottom:1px solid #d0d0d0;cursor:pointer">Notifications</div>
+                                            <div onclick="deskAndroidKey(202);deskAndroidToggleMore()" style="padding:8px 12px;border-bottom:1px solid #d0d0d0;cursor:pointer">Quick Settings</div>
+                                            <div onclick="deskAndroidKey(203);deskAndroidToggleMore()" style="padding:8px 12px;border-bottom:1px solid #d0d0d0;cursor:pointer">Lock Screen</div>
+                                            <div onclick="deskAndroidKey(204);deskAndroidToggleMore()" style="padding:8px 12px;cursor:pointer">Power Menu</div>
+                                        </div>
                                     </span>
                                     <label><span id="DeskControlSpan" style="display:none"><input id="DeskControl" type="checkbox" onkeypress="return false" onkeydown="return false">Input</span></label>
                                 </div>
@@ -4706,6 +4710,12 @@
             if ((desktop == null) || (desktop.State != 3)) return;
             desktop.m.SendKeyMsgKC(1, kc);
             desktop.m.SendKeyMsgKC(2, kc);
+        }
+        function deskAndroidToggleMore() {
+            var m = Q('DeskAndroidMore'), b = Q('DeskAndroidMoreBg');
+            var show = (m.style.display == 'none');
+            m.style.display = show ? 'block' : 'none';
+            b.style.display = show ? 'block' : 'none';
         }
 
         function updateDesktopButtons() {

--- a/views/default.handlebars
+++ b/views/default.handlebars
@@ -850,6 +850,16 @@
                             <input id="DeskESC" style="display:none" type="button" value="ESC" onkeypress="return false" onkeydown="return false" onclick="sendDeskEsc()" />
                             <input id="DeskClip" type="button" value="Clipboard" onkeypress="return false" onkeydown="return false" onclick="showDeskClip()" />
                             <input id="DeskType" cmenu="deskPreConfigShortcutContextMenu" type="button" value="Type" onkeypress="return false" onkeydown="return false" onclick="showDeskType()" />
+                            <span id="DeskAndroidPanel" style="display:none">
+                                <input type="button" value="Back" title="Back" onkeypress="return false" onkeydown="return false" onclick="deskAndroidKey(27)" />
+                                <input type="button" value="Home" title="Home" onkeypress="return false" onkeydown="return false" onclick="deskAndroidKey(36)" />
+                                <input type="button" value="Recent" title="Recent apps" onkeypress="return false" onkeydown="return false" onclick="deskAndroidKey(93)" />
+                                <input type="button" value="Apps" title="App drawer" onkeypress="return false" onkeydown="return false" onclick="deskAndroidKey(200)" />
+                                <input type="button" value="Notifications" title="Open notification shade" onkeypress="return false" onkeydown="return false" onclick="deskAndroidKey(201)" />
+                                <input type="button" value="Quick" title="Quick settings" onkeypress="return false" onkeydown="return false" onclick="deskAndroidKey(202)" />
+                                <input type="button" value="Lock" title="Lock screen" onkeypress="return false" onkeydown="return false" onclick="deskAndroidKey(203)" />
+                                <input type="button" value="Power" title="Power menu" onkeypress="return false" onkeydown="return false" onclick="deskAndroidKey(204)" />
+                            </span>
                             <label><span id="DeskControlSpan" title="Toggle mouse and keyboard input"><input id="DeskControl" type="checkbox" onkeypress="return false" onkeydown="return false" onclick="toggleKvmControl()" />Input</span></label>&nbsp;
                         </div>
                     </div>
@@ -9568,6 +9578,10 @@
             QV('DeskESC', browserfullscreen && inputAllowed);
             QE('DeskType', deskState == 3);
             QV('DeskType', inputAllowed);
+            // Android agents (id 14) are excluded from inputAllowed above but do accept input, so give
+            // them their own on-screen key/gesture panel when connected with remote control rights.
+            var androidInput = online && (deskState == 3) && (currentNode.agent != null) && (currentNode.agent.id == 14) && ((rights == 0xFFFFFFFF) || ((rights & 8) != 0));
+            QV('DeskAndroidPanel', androidInput);
             QE('DeskWD', deskState == 3);
             QV('DeskWD', inputAllowed);
             QV('deskkeys', inputAllowed);
@@ -10601,6 +10615,13 @@
                 for (var i = 0; i < keyArray2.length; i++) { keyArray.push(keyArray2[i]); }
                 desktop.m.SendKeyMsgKC(keyArray);
             }
+        }
+
+        // Android on-screen input panel. Key codes 200+ map to Android global actions in the agent.
+        function deskAndroidKey(kc) {
+            if ((desktop == null) || (desktop.State != 3)) return;
+            desktop.m.SendKeyMsgKC(1, kc);
+            desktop.m.SendKeyMsgKC(2, kc);
         }
 
         // Remote desktop typing

--- a/views/default3.handlebars
+++ b/views/default3.handlebars
@@ -1215,6 +1215,16 @@
                             <input id="DeskESC" style="display:none" type="button" class="btn btn-secondary btn-sm me-1" value="ESC" onkeypress="return false" onkeydown="return false" onclick="sendDeskEsc()" />
                             <input id="DeskClip" type="button" class="btn btn-secondary btn-sm me-1" value="Clipboard" onkeypress="return false" onkeydown="return false" onclick="showDeskClip()" />
                             <input id="DeskType" class="btn btn-secondary btn-sm me-1" cmenu="deskPreConfigShortcutContextMenu" type="button" value="Type" onkeypress="return false" onkeydown="return false" onclick="showDeskType()" />
+                            <span id="DeskAndroidPanel" style="display:none">
+                                <input type="button" class="btn btn-secondary btn-sm me-1" value="Back" title="Back" onkeypress="return false" onkeydown="return false" onclick="deskAndroidKey(27)" />
+                                <input type="button" class="btn btn-secondary btn-sm me-1" value="Home" title="Home" onkeypress="return false" onkeydown="return false" onclick="deskAndroidKey(36)" />
+                                <input type="button" class="btn btn-secondary btn-sm me-1" value="Recent" title="Recent apps" onkeypress="return false" onkeydown="return false" onclick="deskAndroidKey(93)" />
+                                <input type="button" class="btn btn-secondary btn-sm me-1" value="Apps" title="App drawer" onkeypress="return false" onkeydown="return false" onclick="deskAndroidKey(200)" />
+                                <input type="button" class="btn btn-secondary btn-sm me-1 d-none d-lg-inline-block" value="Notifications" title="Open notification shade" onkeypress="return false" onkeydown="return false" onclick="deskAndroidKey(201)" />
+                                <input type="button" class="btn btn-secondary btn-sm me-1 d-none d-lg-inline-block" value="Quick" title="Quick settings" onkeypress="return false" onkeydown="return false" onclick="deskAndroidKey(202)" />
+                                <input type="button" class="btn btn-secondary btn-sm me-1 d-none d-lg-inline-block" value="Lock" title="Lock screen" onkeypress="return false" onkeydown="return false" onclick="deskAndroidKey(203)" />
+                                <input type="button" class="btn btn-secondary btn-sm me-1 d-none d-lg-inline-block" value="Power" title="Power menu" onkeypress="return false" onkeydown="return false" onclick="deskAndroidKey(204)" />
+                            </span>
                             <!-- Mobile-only: toggle button for the soft keyboard -->
                             <button id="DeskSoftKbdBtn" class="btn btn-secondary btn-sm me-1" type="button"
                                 onclick="toggleMobileKeyboard()" title="Show/hide on-screen keyboard"
@@ -9936,6 +9946,12 @@
                 row(cls, 'fa-computer-mouse',    (trackpad ? "Disable Trackpad Mode" : "Enable Trackpad Mode"),  'deskToggleTrackpad();deskCloseMobileActions()') +
                 row(cls, 'fa-hand-pointer',      (swap ? "Disable Right-click Mode" : "Enable Right-click Mode"),   'deskToggleRightClickMode();deskCloseMobileActions()') +
                 row(cls, 'fa-font',              "Type Text",                                'showDeskType();deskCloseMobileActions()') +
+                (isAndroidDevice() ? (
+                    row(cls, 'fa-bell',          "Notifications",                            'deskAndroidKey(201);deskCloseMobileActions()') +
+                    row(cls, 'fa-sliders',       "Quick Settings",                           'deskAndroidKey(202);deskCloseMobileActions()') +
+                    row(cls, 'fa-lock',          "Lock Screen",                              'deskAndroidKey(203);deskCloseMobileActions()') +
+                    row(cls, 'fa-power-off',     "Power Menu",                               'deskAndroidKey(204);deskCloseMobileActions()')
+                ) : '') +
                 row(cls, 'fa-terminal',          'Ctrl + Alt + Del',                        'if(desktop&&desktop.m)desktop.m.sendcad();deskCloseMobileActions()') +
                 row(cls, 'fa-keyboard',          'Send ESC',                                 'sendDeskEsc();deskCloseMobileActions()') +
                 row(cls, 'fa-sliders',           "Keyboard Shortcuts",                       'deskCustomizeKeys();deskCloseMobileActions()') +
@@ -10886,6 +10902,10 @@
             QV('DeskESC', browserfullscreen && inputAllowed);
             QE('DeskType', deskState == 3);
             QV('DeskType', inputAllowed);
+            // Android agents (id 14) are excluded from inputAllowed above but do accept input, so give
+            // them their own on-screen key/gesture panel when connected with remote control rights.
+            var androidInput = online && (deskState == 3) && (currentNode.agent != null) && (currentNode.agent.id == 14) && ((rights == 0xFFFFFFFF) || ((rights & 8) != 0));
+            QV('DeskAndroidPanel', androidInput);
             QE('DeskWD', deskState == 3);
             QV('DeskWD', inputAllowed);
             QV('deskkeys', inputAllowed);
@@ -12071,6 +12091,16 @@
                 for (var i = 0; i < keyArray2.length; i++) { keyArray.push(keyArray2[i]); }
                 desktop.m.SendKeyMsgKC(keyArray);
             }
+        }
+
+        // Android on-screen input panel. Key codes 200+ map to Android global actions in the agent.
+        function deskAndroidKey(kc) {
+            if ((desktop == null) || (desktop.State != 3)) return;
+            desktop.m.SendKeyMsgKC(1, kc);
+            desktop.m.SendKeyMsgKC(2, kc);
+        }
+        function isAndroidDevice() {
+            return (typeof currentNode != 'undefined') && currentNode && currentNode.agent && (currentNode.agent.id == 14);
         }
 
         // Remote desktop typing

--- a/views/sharing-mobile.handlebars
+++ b/views/sharing-mobile.handlebars
@@ -520,6 +520,16 @@
                                 <div>
                                     <input type="button" value="Settings" onkeypress="return false" onkeydown="return false" onclick="showDesktopSettings()" style="height:28px">
                                     <input type="button" id="DeskScreens" value="Screens" onkeypress="return false" onkeydown="return false" onclick="deskSelectScreens()" style="display:none;height:28px">
+                                    <span id="DeskAndroidPanel" style="display:none">
+                                        <input type="button" value="Back" onkeypress="return false" onkeydown="return false" onclick="deskAndroidKey(27)" style="height:28px">
+                                        <input type="button" value="Home" onkeypress="return false" onkeydown="return false" onclick="deskAndroidKey(36)" style="height:28px">
+                                        <input type="button" value="Recent" onkeypress="return false" onkeydown="return false" onclick="deskAndroidKey(93)" style="height:28px">
+                                        <input type="button" value="Apps" onkeypress="return false" onkeydown="return false" onclick="deskAndroidKey(200)" style="height:28px">
+                                        <input type="button" value="Notifications" onkeypress="return false" onkeydown="return false" onclick="deskAndroidKey(201)" style="height:28px">
+                                        <input type="button" value="Quick" onkeypress="return false" onkeydown="return false" onclick="deskAndroidKey(202)" style="height:28px">
+                                        <input type="button" value="Lock" onkeypress="return false" onkeydown="return false" onclick="deskAndroidKey(203)" style="height:28px">
+                                        <input type="button" value="Power" onkeypress="return false" onkeydown="return false" onclick="deskAndroidKey(204)" style="height:28px">
+                                    </span>
                                     <label><span id="DeskControlSpan" style="display:none"><input id="DeskControl" type="checkbox" onkeypress="return false" onkeydown="return false">Input</span></label>
                                 </div>
                             </div>
@@ -1032,12 +1042,20 @@
         }
 
         // Show and enable the right buttons
+        // Android on-screen input panel. Key codes 200+ map to Android global actions in the agent.
+        function deskAndroidKey(kc) {
+            if ((desktop == null) || (desktop.State != 3)) return;
+            desktop.m.SendKeyMsgKC(1, kc);
+            desktop.m.SendKeyMsgKC(2, kc);
+        }
+
         function updateDesktopButtons() {
             var deskState = 0;
             if (desktop != null) { deskState = desktop.State; }
 
             // Show the right buttons
             QV('disconnectbutton1', (deskState != 0));
+            QV('DeskAndroidPanel', (deskState == 3) && (viewOnly != 1) && (currentNode != null) && (currentNode.agent != null) && (currentNode.agent.id == 14));
             QE('deskFullScreen', (deskState != 0));
             QV('connectbutton1', (deskState == 0));
             QV('connectbutton1h', false);

--- a/views/sharing-mobile.handlebars
+++ b/views/sharing-mobile.handlebars
@@ -525,10 +525,14 @@
                                         <input type="button" value="Home" onkeypress="return false" onkeydown="return false" onclick="deskAndroidKey(36)" style="height:28px">
                                         <input type="button" value="Recent" onkeypress="return false" onkeydown="return false" onclick="deskAndroidKey(93)" style="height:28px">
                                         <input type="button" value="Apps" onkeypress="return false" onkeydown="return false" onclick="deskAndroidKey(200)" style="height:28px">
-                                        <input type="button" value="Notifications" onkeypress="return false" onkeydown="return false" onclick="deskAndroidKey(201)" style="height:28px">
-                                        <input type="button" value="Quick" onkeypress="return false" onkeydown="return false" onclick="deskAndroidKey(202)" style="height:28px">
-                                        <input type="button" value="Lock" onkeypress="return false" onkeydown="return false" onclick="deskAndroidKey(203)" style="height:28px">
-                                        <input type="button" value="Power" onkeypress="return false" onkeydown="return false" onclick="deskAndroidKey(204)" style="height:28px">
+                                        <input type="button" value="More" onkeypress="return false" onkeydown="return false" onclick="deskAndroidToggleMore()" style="height:28px">
+                                        <div id="DeskAndroidMoreBg" style="display:none;position:fixed;inset:0;z-index:998" onclick="deskAndroidToggleMore()"></div>
+                                        <div id="DeskAndroidMore" style="display:none;position:absolute;bottom:32px;right:2px;min-width:150px;background:#f0f0f0;border:1px solid #808080;box-shadow:0 -1px 4px rgba(0,0,0,0.3);z-index:999;text-align:left">
+                                            <div onclick="deskAndroidKey(201);deskAndroidToggleMore()" style="padding:8px 12px;border-bottom:1px solid #d0d0d0;cursor:pointer">Notifications</div>
+                                            <div onclick="deskAndroidKey(202);deskAndroidToggleMore()" style="padding:8px 12px;border-bottom:1px solid #d0d0d0;cursor:pointer">Quick Settings</div>
+                                            <div onclick="deskAndroidKey(203);deskAndroidToggleMore()" style="padding:8px 12px;border-bottom:1px solid #d0d0d0;cursor:pointer">Lock Screen</div>
+                                            <div onclick="deskAndroidKey(204);deskAndroidToggleMore()" style="padding:8px 12px;cursor:pointer">Power Menu</div>
+                                        </div>
                                     </span>
                                     <label><span id="DeskControlSpan" style="display:none"><input id="DeskControl" type="checkbox" onkeypress="return false" onkeydown="return false">Input</span></label>
                                 </div>
@@ -760,6 +764,7 @@
         var authCookie = '{{{authCookie}}}';
         var authRelayCookie = '{{{authRelayCookie}}}';
         var viewOnly = parseInt('{{{viewOnly}}}');
+        var agentId = parseInt('{{{agentId}}}');
         var authCookieRenewTimer = null;
         var serverPublicNamePort = '{{{serverDnsName}}}:{{{serverPublicPort}}}';
         var debugmode = false;
@@ -1048,6 +1053,12 @@
             desktop.m.SendKeyMsgKC(1, kc);
             desktop.m.SendKeyMsgKC(2, kc);
         }
+        function deskAndroidToggleMore() {
+            var m = Q('DeskAndroidMore'), b = Q('DeskAndroidMoreBg');
+            var show = (m.style.display == 'none');
+            m.style.display = show ? 'block' : 'none';
+            b.style.display = show ? 'block' : 'none';
+        }
 
         function updateDesktopButtons() {
             var deskState = 0;
@@ -1055,7 +1066,7 @@
 
             // Show the right buttons
             QV('disconnectbutton1', (deskState != 0));
-            QV('DeskAndroidPanel', (deskState == 3) && (viewOnly != 1) && (currentNode != null) && (currentNode.agent != null) && (currentNode.agent.id == 14));
+            QV('DeskAndroidPanel', (deskState == 3) && (viewOnly != 1) && (agentId == 14));
             QE('deskFullScreen', (deskState != 0));
             QV('connectbutton1', (deskState == 0));
             QV('connectbutton1h', false);

--- a/views/sharing.handlebars
+++ b/views/sharing.handlebars
@@ -315,6 +315,7 @@
         var domainUrl = '{{{domainurl}}}';
         var authCookie = '{{{authCookie}}}';
         var viewOnly = parseInt('{{{viewOnly}}}');
+        var agentId = parseInt('{{{agentId}}}');
         var urlargs = parseUriArgs();
         var debugmode = urlargs.debug;
         var attemptWebRTC = false;
@@ -510,7 +511,7 @@
             QE('DeskClip', deskState == 3);
             QE('DeskType', deskState == 3);
             // Android agents (id 14) get an on-screen key panel; input UI is otherwise disabled for them.
-            QV('DeskAndroidPanel', (deskState == 3) && (viewOnly != 1) && (currentNode != null) && (currentNode.agent != null) && (currentNode.agent.id == 14));
+            QV('DeskAndroidPanel', (deskState == 3) && (viewOnly != 1) && (agentId == 14));
             QV('DeskWD', viewOnly != 1);
             QE('DeskWD', deskState == 3);
             QV('deskkeys', viewOnly != 1);

--- a/views/sharing.handlebars
+++ b/views/sharing.handlebars
@@ -98,6 +98,16 @@
                     <input id="DeskWD" type=button value="Send" onkeypress="return false" onkeydown="return false" onclick="deskSendKeys()" />
                     <input id="DeskClip" style="" type="button" value="Clipboard" onkeypress="return false" onkeydown="return false" onclick="showDeskClip()" />
                     <input id="DeskType" style="" type="button" value="Type" onkeypress="return false" onkeydown="return false" onclick="showDeskType()" />
+                    <span id="DeskAndroidPanel" style="display:none">
+                        <input type="button" value="Back" title="Back" onkeypress="return false" onkeydown="return false" onclick="deskAndroidKey(27)" />
+                        <input type="button" value="Home" title="Home" onkeypress="return false" onkeydown="return false" onclick="deskAndroidKey(36)" />
+                        <input type="button" value="Recent" title="Recent apps" onkeypress="return false" onkeydown="return false" onclick="deskAndroidKey(93)" />
+                        <input type="button" value="Apps" title="App drawer" onkeypress="return false" onkeydown="return false" onclick="deskAndroidKey(200)" />
+                        <input type="button" value="Notifications" title="Open notification shade" onkeypress="return false" onkeydown="return false" onclick="deskAndroidKey(201)" />
+                        <input type="button" value="Quick" title="Quick settings" onkeypress="return false" onkeydown="return false" onclick="deskAndroidKey(202)" />
+                        <input type="button" value="Lock" title="Lock screen" onkeypress="return false" onkeydown="return false" onclick="deskAndroidKey(203)" />
+                        <input type="button" value="Power" title="Power menu" onkeypress="return false" onkeydown="return false" onclick="deskAndroidKey(204)" />
+                    </span>
                     <label><span id="DeskControlSpan" title="Toggle mouse and keyboard input"><input id="DeskControl" type="checkbox" onkeypress="return false" onkeydown="return false" onclick="toggleKvmControl()" />Input</span></label>&nbsp;
                 </div>
             </div>
@@ -499,6 +509,8 @@
             QV('DeskClip', false); // Clipboard not supported on this page
             QE('DeskClip', deskState == 3);
             QE('DeskType', deskState == 3);
+            // Android agents (id 14) get an on-screen key panel; input UI is otherwise disabled for them.
+            QV('DeskAndroidPanel', (deskState == 3) && (viewOnly != 1) && (currentNode != null) && (currentNode.agent != null) && (currentNode.agent.id == 14));
             QV('DeskWD', viewOnly != 1);
             QE('DeskWD', deskState == 3);
             QV('deskkeys', viewOnly != 1);
@@ -1062,6 +1074,13 @@
                 */
                 return desktop.m.handleKeyUp(e);
             }
+        }
+
+        // Android on-screen input panel. Key codes 200+ map to Android global actions in the agent.
+        function deskAndroidKey(kc) {
+            if ((desktop == null) || (desktop.State != 3)) return;
+            desktop.m.SendKeyMsgKC(1, kc);
+            desktop.m.SendKeyMsgKC(2, kc);
         }
 
         // Remote desktop typing

--- a/webserver.js
+++ b/webserver.js
@@ -4515,7 +4515,7 @@ module.exports.CreateWebServer = function (parent, db, args, certificates, doneF
                     var httpsPort = ((obj.args.aliasport == null) ? obj.args.port : obj.args.aliasport); // Use HTTPS alias port is specified
                     parent.debug('web', 'handleSharingRequest: Sending guest sharing page for \"' + c.uid + '\", guest \"' + c.gn + '\".');
                     res.set({ 'Cache-Control': 'no-store' });
-                    render(req, res, getRenderPage('sharing', req, domain), getRenderArgs({ authCookie: authCookie, authRelayCookie: '', domainurl: encodeURIComponent(domain.url).replace(/'/g, '%27'), nodeid: c.nid, serverDnsName: obj.getWebServerName(domain, req), serverRedirPort: args.redirport, serverPublicPort: httpsPort, expire: c.expire, viewOnly: (c.vo == 1) ? 1 : 0, nodeName: encodeURIComponent(node.name).replace(/'/g, '%27'), features: c.p, features2: features2 }, req, domain));
+                    render(req, res, getRenderPage('sharing', req, domain), getRenderArgs({ authCookie: authCookie, authRelayCookie: '', domainurl: encodeURIComponent(domain.url).replace(/'/g, '%27'), nodeid: c.nid, serverDnsName: obj.getWebServerName(domain, req), serverRedirPort: args.redirport, serverPublicPort: httpsPort, expire: c.expire, viewOnly: (c.vo == 1) ? 1 : 0, agentId: (node.agent != null) ? node.agent.id : 0, nodeName: encodeURIComponent(node.name).replace(/'/g, '%27'), features: c.p, features2: features2 }, req, domain));
                 }
             });
         });


### PR DESCRIPTION
# Summary

This is the MeshCentral side of the Android agent changes for input/unattended access. The Android agent accepts remote input via the agent's accessibility service, but the web UI has disabled input controls for them. This adds an on-screen control panel to the remote desktop viewer, shown only when connected to an Android agent with remote-control rights.

Navigation/actions: Back, Home, Recent, App drawer, Notifications, Quick settings, Lock, Power. Sent as key messages; keycodes 200+ map to Android global actions in the agent.

Added to all desktop UIs (default, default3, sharing, default-mobile, sharing-mobile), fitted to each toolbar. Uses the existing SendKeyMsgKC / SendStringUnicode paths.

Depends on the Android agent's input support ([MeshCentralAndroidAgent #45](https://github.com/Ylianst/MeshCentralAndroidAgent/pull/45)).


- [x] 🧠 I used LLMs/AI in this contribution and reviewed all generated content. I understand that I am responsible for and able to explain every line of code I submit.
- [x] 🔍 Any UI changes adhere to visual style of this project.
- [x] 🛠️ I have self-reviewed and self-tested my code to ensure it works as expected.
- [ ] 🤖 I added or updated automated tests where appropriate.
- [ ] 📄 Documentation updates are included (if applicable).
- [ ] 🧰 Dependency updates are listed and explained.
- [x] ⚠️ CI passes and is green.


## Screenshots for Visual Changes
| Template              | Before                | After                |
| ------------------ | --------------------- | -------------------- |
| `default3`               | <img width="1087" height="71" alt="image" src="https://github.com/user-attachments/assets/a1d2e26f-e323-45bc-981e-998bb48beb85" /> | <img width="1078" height="138" alt="image" src="https://github.com/user-attachments/assets/113b809f-f467-4035-a0dc-baa977c49556" /> |
| `default`             | <img width="1058" height="61" alt="image" src="https://github.com/user-attachments/assets/a79b3a45-8299-42dd-9614-d0adaf071f22" /> | <img width="1059" height="81" alt="image" src="https://github.com/user-attachments/assets/cc14fcc8-abdd-4784-bea0-cd10ddcd2b08" /> |
| `default-mobile` | <img width="454" height="88" alt="image" src="https://github.com/user-attachments/assets/64c4bc23-3aeb-4890-a6e9-1cf5483ca97b" /> | <img width="541" height="85" alt="image" src="https://github.com/user-attachments/assets/d78f43e7-4288-4c06-9ee9-a7f7477aa59b" /> |
| `sharing-mobile`            | <img width="432" height="86" alt="image" src="https://github.com/user-attachments/assets/2cbab314-bf42-4eb9-9055-81875b27ade0" /> | <img width="450" height="262" alt="image" src="https://github.com/user-attachments/assets/e6bd17ee-43cc-4dd1-b647-499f26f4569d" /> |
| `sharing`            | <img width="964" height="45" alt="image" src="https://github.com/user-attachments/assets/5fbaf36f-18b3-426a-905d-4c827927189e" /> | <img width="972" height="94" alt="image" src="https://github.com/user-attachments/assets/c8b5d5cd-511e-4926-96f6-7c2e6fd18b73" /> |