### PR TITLE
Add configurable child server restart policy

### DIFF
--- a/meshcentral-config-schema.json
+++ b/meshcentral-config-schema.json
@@ -645,6 +645,11 @@
           "default": null,
           "description": "Execute this when the server has to restart due to an error. The first parameter will be the server version."
         },
+        "RestartOnServerError": {
+          "type": "boolean",
+          "default": true,
+          "description": "When false, the built-in supervisor exits after an unexpected child server error instead of restarting the child. Expected restarts for configuration changes, certificate updates, server updates and administrator requests are not affected. External service managers may start MeshCentral again according to their own restart policy."
+        },
         "publicPushNotifications": {
           "type": "boolean",
           "default": false,

--- a/meshcentral.js
+++ b/meshcentral.js
@@ -663,8 +663,13 @@ function CreateMeshCentralServer(config, args) {
                 if (error != null) {
                     // This is an un-expected restart
                     console.log(error);
-                    console.log('ERROR: MeshCentral failed with critical error, check mesherrors.txt. Restarting in 5 seconds...');
-                    setTimeout(function () { obj.launchChildServer(startArgs); }, 5000);
+                    const restartOnServerError = (obj.config.settings.restartonservererror !== false);
+                    if (restartOnServerError) {
+                        console.log('ERROR: MeshCentral failed with critical error, check mesherrors.txt. Restarting in 5 seconds...');
+                        setTimeout(function () { obj.launchChildServer(startArgs); }, 5000);
+                    } else {
+                        console.log('ERROR: MeshCentral failed with critical error, check mesherrors.txt. Automatic restart is disabled, exiting.');
+                    }
 
                     // Run the server error script if present
                     if (typeof obj.config.settings.runonservererror == 'string') {
@@ -673,6 +678,7 @@ function CreateMeshCentralServer(config, args) {
                         if ((__dirname.endsWith('/node_modules/meshcentral')) || (__dirname.endsWith('\\node_modules\\meshcentral')) || (__dirname.endsWith('/node_modules/meshcentral/')) || (__dirname.endsWith('\\node_modules\\meshcentral\\'))) { parentpath = require('path').join(__dirname, '../..'); }
                         child_process.exec(obj.config.settings.runonservererror + ' ' + getCurrentVersion(), { maxBuffer: 512000, timeout: 120000, cwd: parentpath }, function (error, stdout, stderr) { });
                     }
+                    if (restartOnServerError == false) { process.exit(1); }
                 }
             }
         });

--- a/sample-config-advanced.json
+++ b/sample-config-advanced.json
@@ -106,6 +106,7 @@
     "_runOnServerStarted": "c:\\tmp\\mcstart.bat",
     "_runOnServerUpdated": "c:\\tmp\\mcupdate.bat",
     "_runOnServerError": "c:\\tmp\\mcerror.bat",
+    "_restartOnServerError": false,
     "_log": "main,web,webrequest,cert",
     "_debug": "main,web,webrequest,cert",
     "_syslog": "meshcentral",


### PR DESCRIPTION
# Summary

In this pull request, the following changes are made:

- Added the `RestartOnServerError` setting, enabled by default for backward compatibility.
- When disabled, MeshCentral does not restart the child process after a critical error and exits the parent process.
- Documented the setting in the configuration schema and advanced sample configuration.

<details>
<summary>Please follow this checklist to avoid unnecessary back and forth (click to expand)</summary>

- [x] 🧠 I used LLMs/AI in this contribution and reviewed all generated content.  
      I understand that I am responsible for and able to explain every line of code I submit.
- [x] 🔍 Any UI changes adhere to visual style of this project.
- [x] 🛠️ I have self-reviewed and self-tested my code to ensure it works as expected.
- [ ] 🤖 I added or updated automated tests where appropriate.
- [x] 📄 Documentation updates are included (if applicable).
- [x] 🧰 Dependency updates are listed and explained.
- [ ] ⚠️ CI passes and is green.

</details>