### PR TITLE
Fix upload dialog staying open for small files in modern UI

### DIFF
--- a/views/default3.handlebars
+++ b/views/default3.handlebars
@@ -6922,6 +6922,8 @@
         }
 
         var xxModal;
+        var xxModalShown = false;   // true once the current modal's Bootstrap show transition has completed
+        var xxModalHidePending = false; // a hide() was requested while the modal was still fading in
 
         // A dialog/modal opening over the active remote desktop swallows the in-flight key-up (the
         // ondockey* handlers stop forwarding once xxdialogMode is set), leaving that key held down on
@@ -6994,8 +6996,17 @@
                     QV(id, (id != 'idx_dlgDeleteButton' ? true : false));
                 });
                 xxModal = new bootstrap.Modal(document.getElementById(modalId));
+                xxModalShown = false; xxModalHidePending = false;
+                // mark shown so a hide deferred during the fade-in can fire
+                var shownModal = function (event) {
+                    xxModalShown = true;
+                    document.getElementById(modalId).removeEventListener('shown.bs.modal', shownModal);
+                    if (xxModalHidePending) { xxModalHidePending = false; if (xxModal) xxModal.hide(); }
+                }
+                document.getElementById(modalId).addEventListener('shown.bs.modal', shownModal);
                 var hiddenModal = function (event) {
                     if (xxModal) { xxModal.dispose(); xxModal = null; }
+                    xxModalShown = false; xxModalHidePending = false;
                     if (xxdialogMode != 0) { xxdialogMode = 0; }
                     document.getElementById(modalId).removeEventListener('hidden.bs.modal', hiddenModal);
                 }
@@ -7012,6 +7023,13 @@
                     if (xxModal) { xxModal.hide(); }
                 }
             };
+        }
+
+        // Bootstrap drops hide() during the fade-in, which left tiny-file uploads with a stuck-open dialog.
+        // Defer the hide until shown.bs.modal fires if the modal has not finished showing yet.
+        function hideModal() {
+            if (xxModal == null) return;
+            if (xxModalShown) { xxModal.hide(); } else { xxModalHidePending = true; }
         }
 
         function copyAgentIdValue(id) {
@@ -22994,7 +23012,7 @@
             for (var i = 1; i < 24; i++) { QV('dialog' + i, i == x); } // Edit this line when more dialogs are added
             QV('dialog', x);
             if (c) { if (x == 2) { QH('id_dialogOptions', c); } else { QH('id_dialogMessage', c); } }
-            if (x == 0) { if (xxModal) xxModal.hide(); }
+            if (x == 0) { hideModal(); }
             MoreToggle(false);
         }
 


### PR DESCRIPTION
# Summary

Uploading a small file from a devices Files tab in the modern UI left the upload dialog open instead of auto-closing.

Bootstrap drops `Modal.hide()` when it is called mid show-transition. A small file finishes uploading before the dialogs fade-in completes, so the `setDialogMode(0)` close fired during the transition and was ignored. The hide is now deferred until `shown.bs.modal` fires when the modal is still animating.

Only `default3.handlebars` uses Bootstrap modals. The classic, mobile, and sharing templates use the synchronous `setDialogMode` dialog and never had the race, so no change was needed there.

Resolves #8079

- [x] 🧠 I used LLMs/AI in this contribution and reviewed all generated content.
      I understand that I am responsible for and able to explain every line of code I submit.
- [x] 🔍 Any UI changes adhere to visual style of this project.
- [x] 🛠️ I have self-reviewed and self-tested my code to ensure it works as expected.
- [ ] 🤖 I added or updated automated tests where appropriate.
- [ ] 📄 Documentation updates are included (if applicable).
- [ ] 🧰 Dependency updates are listed and explained.
- [x] ⚠️ CI passes and is green.