### PR TITLE
Fix: keyboard stops working after desktop reconnect

### DIFF
--- a/public/scripts/agent-desktop-0.0.2.js
+++ b/public/scripts/agent-desktop-0.0.2.js
@@ -841,6 +841,12 @@ var CreateAgentRemoteDesktop = function (canvasid, scrolldiv) {
 
     obj.GrabKeyInput = function () {
         if (obj.xxKeyInputGrab == true) return;
+        // Save the current handlers so UnGrabKeyInput can restore them instead of
+        // leaving the document without any keyboard handler. Only take ownership
+        // of slots this instance does not already own.
+        if (document.onkeydown !== obj.xxKeyDown) { obj._savedOnKeyDown = document.onkeydown; }
+        if (document.onkeyup !== obj.xxKeyUp) { obj._savedOnKeyUp = document.onkeyup; }
+        if (document.onkeypress !== obj.xxKeyPress) { obj._savedOnKeyPress = document.onkeypress; }
         document.onkeyup = obj.xxKeyUp;
         document.onkeydown = obj.xxKeyDown;
         document.onkeypress = obj.xxKeyPress;
@@ -849,9 +855,14 @@ var CreateAgentRemoteDesktop = function (canvasid, scrolldiv) {
 
     obj.UnGrabKeyInput = function () {
         if (obj.xxKeyInputGrab == false) return;
-        document.onkeyup = null;
-        document.onkeydown = null;
-        document.onkeypress = null;
+        // Restore the handlers that were in place before GrabKeyInput, but only
+        // for slots this instance still owns. A newer session may have taken over
+        // the slots meanwhile (disconnect + reconnect of a grabbed session), in
+        // which case leave the current handlers alone.
+        if (document.onkeydown === obj.xxKeyDown) { document.onkeydown = obj._savedOnKeyDown || null; }
+        if (document.onkeyup === obj.xxKeyUp) { document.onkeyup = obj._savedOnKeyUp || null; }
+        if (document.onkeypress === obj.xxKeyPress) { document.onkeypress = obj._savedOnKeyPress || null; }
+        obj._savedOnKeyDown = obj._savedOnKeyUp = obj._savedOnKeyPress = null;
         obj.xxKeyInputGrab = false;
     }
 


### PR DESCRIPTION
# Summary

- Fix regression from `6d33535` causing occasional keyboard entry failure due to `GrabKeyInput` overwriting handlers without saving. 

- Manually tested and deployed changes to a test server, verified that it has resolved the reproducible bug. To hotfix, simply deploy patched `public/scripts/agent-desktop-0.0.2.js` to your install's `node_modules/meshcentral` or other install location and refresh the page to load the new js file. If minify config is enabled, either minify it and replace the minified file, or turn minify off. 

## Repro (deterministic, MeshCentral 1.2.5 classic UI + any desktop agent)

- Connect desktop → send a key (arrives) → Settings → OK → Disconnect → `document.onkeydown === null` 

- Reconnect → keys send nothing → Settings → OK → keys work again.

## Fix (`public/scripts/agent-desktop-0.0.2.js`)

`GrabKeyInput` now saves the existing `document.on{keydown,keyup,keypress}` handlers before installing the session's own handler. `UnGrabKeyInput` restores them (would set to null, causing bug). 

<!--Please link any GitHub issues or tasks that this pull request addresses-->

- Resolves https://github.com/Ylianst/MeshCentral/issues/8134 (confirmed by issue opener)

<details>
<summary>Please follow this checklist to avoid unnecessary back and forth (click to expand)</summary>

- [x] 🧠 I used LLMs/AI in this contribution and reviewed all generated content.
      I understand that I am responsible for and able to explain every line of code I submit.
- [ ] 🔍 Any UI changes adhere to visual style of this project.
- [x] 🛠️ I have self-reviewed and self-tested my code to ensure it works as expected.
- [ ] 🤖 I added or updated automated tests where appropriate.
- [ ] 📄 Documentation updates are included (if applicable).
- [ ] 🧰 Dependency updates are listed and explained.
- [ ] ⚠️ CI passes and is green.

</details>
