### PR TITLE
Limit new agent registrations by source IP

### DIFF
--- a/meshagent.js
+++ b/meshagent.js
@@ -864,6 +864,15 @@ module.exports.CreateMeshAgent = function (parent, db, ws, req, args, domain) {
             return;
         }
 
+        // Enforce the source IP limit only after confirming that this is a new node.
+        // This operation is synchronous so concurrent registrations cannot pass the limit.
+        if (parent.recordAgentRegistration(obj.remoteaddr) == false) {
+            parent.blockedAgents++;
+            parent.agentStats.agentRegistrationBlockCount++;
+            parent.parent.debug('agent', 'New agent registration limit reached for ' + obj.remoteaddr + ', holding connection.');
+            return;
+        }
+
         // Mark when this device connected
         obj.connectTime = Date.now();
 

--- a/meshcentral-config-schema.json
+++ b/meshcentral-config-schema.json
@@ -692,6 +692,43 @@
           "default": null,
           "description": "When set, agents from these denied IP address ranges will not be able to connect to the server. Example: \"192.168.2.100,192.168.1.0/24\" \"file:agentBlockedIP.txt\""
         },
+        "agentEnrollmentRateLimitByIP": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Limits new agent registrations by exact source IP using a sliding time window. Additional registrations are denied until enough registrations fall outside the window. Existing agent reconnections do not count toward the limit.",
+          "properties": {
+            "autoBlock": {
+              "type": "boolean",
+              "default": true,
+              "description": "When true, all agent traffic from an IP that reaches the enrollment limit is blocked. The block is temporary unless settings.agentBlockedIP uses a file: source, in which case the exact IP is appended to that file and blocked permanently. When false, only additional new agent registrations are denied."
+            },
+            "exclude": {
+              "type": [
+                "string",
+                "array"
+              ],
+              "items": {
+                "type": "string"
+              },
+              "default": null,
+              "description": "IP addresses or ranges that are not subject to the new agent registration limit. For example: \"192.168.1.0/24,172.16.0.1\"."
+            },
+            "minutes": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Sliding time window in minutes."
+            },
+            "agents": {
+              "type": "integer",
+              "minimum": 1,
+              "description": "Maximum number of new agents that one source IP may register within the time window."
+            }
+          },
+          "required": [
+            "minutes",
+            "agents"
+          ]
+        },
         "authLog": {
           "type": "string",
           "default": null,

--- a/meshcentral.js
+++ b/meshcentral.js
@@ -952,6 +952,7 @@ function CreateMeshCentralServer(config, args) {
         if (config) { for (var i in config) { if ((typeof i == 'string') && (i.length > 0) && (i[0] != '_') && (['settings', 'domaindefaults', 'domains', 'configfiles', 'smtp', 'letsencrypt', 'peers', 'sms', 'messaging', 'sendgrid', 'sendmail', 'firebase', 'firebaserelay', '$schema'].indexOf(i) == -1)) { addServerWarning('Unrecognized configuration option \"' + i + '\".', 3, [i]); } } }
 
         // Read IP lists from files if applicable
+        obj.agentBlockedIpFile = ((typeof obj.args.agentblockedip == 'string') && obj.args.agentblockedip.startsWith('file:')) ? obj.path.join(obj.datapath, obj.args.agentblockedip.substring(5)) : null;
         config.settings.userallowedip = obj.args.userallowedip = readIpListFromFile(obj.args.userallowedip);
         config.settings.userblockedip = obj.args.userblockedip = readIpListFromFile(obj.args.userblockedip);
         config.settings.agentallowedip = obj.args.agentallowedip = readIpListFromFile(obj.args.agentallowedip);
@@ -4053,7 +4054,7 @@ function CreateMeshCentralServer(config, args) {
             if (line.charAt(0) === '#') continue;
             const parts = line.split('#');
             const candidate = parts[0].trim();
-            if (candidate.length > 0 && candidate.indexOf('@') === -1 && (candidate.indexOf('.') > -1 || candidate.charAt(0) === ':')) {
+            if (candidate.length > 0 && candidate.indexOf('@') === -1 && (candidate.indexOf('.') > -1 || candidate.indexOf(':') > -1)) {
                 validLines.push(candidate);
             }
         }

--- a/sample-config-advanced.json
+++ b/sample-config-advanced.json
@@ -85,6 +85,7 @@
     "_userBlockedIP": "127.0.0.1,::1,192.168.0.100",
     "_agentAllowedIP": "192.168.0.100/24",
     "_agentBlockedIP": "127.0.0.1,::1",
+    "_agentEnrollmentRateLimitByIP": { "agents": 100, "minutes": 10, "autoBlock": true, "exclude": "192.168.0.0/16" },
     "_authLog": "c:\\temp\\auth.log",
     "_InterUserMessaging": [ "user//admin" ],
     "_manageAllDeviceGroups": [ "user//admin" ],

--- a/webserver.js
+++ b/webserver.js
@@ -23,6 +23,94 @@ function SerialTunnel(options) {
     return obj;
 }
 
+// Append an exact IP address to an agent block list file.
+function AppendAgentBlockedIp(filename, ip, fsModule) {
+    if ((typeof filename != 'string') || (filename.length == 0) || (typeof ip != 'string') || (ip.length == 0)) { return false; }
+    try {
+        const separator = (fsModule.existsSync(filename) && (fsModule.statSync(filename).size > 0)) ? '\r\n' : '';
+        fsModule.appendFileSync(filename, separator + ip + '\r\n');
+        return true;
+    } catch (ex) { return false; }
+}
+
+// Create a sliding-window limiter for new agent registrations by source IP.
+function CreateAgentRegistrationLimiter(config, nowFunc, ipMatchFunc, onBlockFunc) {
+    if ((config == null) || (typeof config != 'object') || Array.isArray(config)) { return null; }
+    if (!Number.isSafeInteger(config.agents) || (config.agents < 1)) { return null; }
+    if (!Number.isSafeInteger(config.minutes) || (config.minutes < 1)) { return null; }
+
+    const obj = {};
+    const windowMilliseconds = config.minutes * 60000;
+    const autoBlock = (config.autoblock !== false);
+    const registrations = Object.create(null);
+    const now = (typeof nowFunc == 'function') ? nowFunc : Date.now;
+    var operationsSinceClean = 0;
+    var exclusions = [];
+
+    if (typeof config.exclude == 'string') {
+        exclusions = config.exclude.split(',').map(function (x) { return x.trim(); }).filter(function (x) { return x.length > 0; });
+    } else if (Array.isArray(config.exclude)) {
+        exclusions = config.exclude.filter(function (x) { return typeof x == 'string'; }).map(function (x) { return x.trim(); }).filter(function (x) { return x.length > 0; });
+    }
+
+    function normalizeIp(ip) {
+        if ((typeof ip != 'string') || (ip.length == 0) || (ip.length > 128)) { return null; }
+        ip = ip.toLowerCase();
+        if (ip.indexOf('::ffff:') == 0) { ip = ip.substring(7); }
+        if (require('net').isIP(ip) == 0) { return null; }
+        return ip;
+    }
+
+    function isExcluded(ip) {
+        if (exclusions.length == 0) { return false; }
+        const ipMatch = (typeof ipMatchFunc == 'function') ? ipMatchFunc : require('ipcheck').match;
+        for (var i = 0; i < exclusions.length; i++) {
+            try { if (ipMatch(ip, exclusions[i]) == true) { return true; } } catch (ex) { }
+        }
+        return false;
+    }
+
+    function prune(ip, currentTime) {
+        const timestamps = registrations[ip];
+        if (timestamps == null) { return null; }
+        const cutoffTime = currentTime - windowMilliseconds;
+        while ((timestamps.length > 0) && (timestamps[0] <= cutoffTime)) { timestamps.shift(); }
+        if (timestamps.length == 0) { delete registrations[ip]; return null; }
+        return timestamps;
+    }
+
+    obj.clean = function () {
+        const currentTime = now();
+        for (var ip in registrations) { prune(ip, currentTime); }
+        operationsSinceClean = 0;
+    };
+
+    obj.isBlocked = function (ip) {
+        if (autoBlock == false) { return false; }
+        ip = normalizeIp(ip);
+        if ((ip == null) || isExcluded(ip)) { return false; }
+        const timestamps = prune(ip, now());
+        return (timestamps != null) && (timestamps.length >= config.agents);
+    };
+
+    // Returns false when this registration would exceed the configured limit.
+    obj.register = function (ip) {
+        ip = normalizeIp(ip);
+        if (ip == null) { return false; }
+        if (isExcluded(ip)) { return true; }
+        const currentTime = now();
+        var timestamps = prune(ip, currentTime);
+        if ((timestamps != null) && (timestamps.length >= config.agents)) { return false; }
+        if (timestamps == null) { timestamps = registrations[ip] = []; }
+        timestamps.push(currentTime);
+        if ((autoBlock == true) && (timestamps.length == config.agents) && (typeof onBlockFunc == 'function')) { try { onBlockFunc(ip); } catch (ex) { } }
+        if (++operationsSinceClean > 100) { obj.clean(); }
+        return true;
+    };
+
+    return obj;
+}
+
 // ExpressJS login sample
 // https://github.com/expressjs/express/blob/master/examples/auth/index.js
 
@@ -95,6 +183,20 @@ module.exports.CreateWebServer = function (parent, db, args, certificates, doneF
     obj.relaySessionErrorCount = 0;
     obj.blockedUsers = 0;
     obj.blockedAgents = 0;
+    obj.persistAgentBlockedIp = function (ip) {
+        if (parent.agentBlockedIpFile == null) { return false; }
+        if (AppendAgentBlockedIp(parent.agentBlockedIpFile, ip, obj.fs) == false) {
+            console.log('Unable to permanently block agent IP address ' + ip + ' in ' + parent.agentBlockedIpFile + '; temporary block remains active.');
+            return false;
+        }
+        if (!Array.isArray(parent.config.settings.agentblockedip)) { parent.config.settings.agentblockedip = []; }
+        if (parent.config.settings.agentblockedip.indexOf(ip) < 0) { parent.config.settings.agentblockedip.push(ip); }
+        obj.agentBlockedIp = parent.config.settings.agentblockedip;
+        parent.debug('agent', 'Permanently blocked agent IP address ' + ip + ' in ' + parent.agentBlockedIpFile + '.');
+        return true;
+    };
+    obj.agentRegistrationLimiter = CreateAgentRegistrationLimiter(parent.config.settings.agentenrollmentratelimitbyip, null, null, obj.persistAgentBlockedIp);
+    obj.recordAgentRegistration = function (ip) { return (obj.agentRegistrationLimiter == null) || obj.agentRegistrationLimiter.register(ip); };
     obj.renderPages = null;
     obj.renderLanguages = [];
     obj.destroyedSessions = {};                 // userid/req.session.x --> destroyed session time
@@ -441,7 +543,8 @@ module.exports.CreateWebServer = function (parent, db, args, certificates, doneF
         duplicateAgentCount: 0,
         maxDomainDevicesReached: 0,
         agentInTrouble: 0,
-        agentInBigTrouble: 0
+        agentInBigTrouble: 0,
+        agentRegistrationBlockCount: 0
     }
     obj.getAgentStats = function () { return obj.agentStats; }
 
@@ -876,6 +979,13 @@ module.exports.CreateWebServer = function (parent, db, args, certificates, doneF
     function checkAgentIpAddress(req, res) {
         if ((parent.config.settings.agentblockedip != null) && (checkIpAddressEx(req, res, parent.config.settings.agentblockedip, null) == true)) { obj.blockedAgents++; return null; }
         if ((parent.config.settings.agentallowedip != null) && (checkIpAddressEx(req, res, parent.config.settings.agentallowedip, null) == false)) { obj.blockedAgents++; return null; }
+        const clientIp = (req.clientIp != null) ? req.clientIp : res.clientIp;
+        if ((obj.agentRegistrationLimiter != null) && obj.agentRegistrationLimiter.isBlocked(clientIp)) {
+            obj.blockedAgents++;
+            obj.agentStats.agentRegistrationBlockCount++;
+            parent.debug('agent', 'Agent connection from ' + clientIp + ' blocked by new registration limit.');
+            return null;
+        }
         const domain = (req.url ? getDomain(req) : getDomain(res));
         if ((domain.agentblockedip != null) && (checkIpAddressEx(req, res, domain.agentblockedip, null) == true)) { obj.blockedAgents++; return null; }
         if ((domain.agentallowedip != null) && (checkIpAddressEx(req, res, domain.agentallowedip, null) == false)) { obj.blockedAgents++; return null; }


### PR DESCRIPTION
# Summary
In this pull request, the following changes are made:

- Added `agentEnrollmentRateLimitByIP` to limit new agent enrollments from an IP within a configurable number of minutes.
- Added optional `autoBlock` behavior. Blocks are temporary by default and permanent when `agentBlockedIP` uses a file.
- Added configuration documentation and automated tests for limits, exclusions, expiration, and persistent blocking.

<details>
<summary>Please follow this checklist to avoid unnecessary back and forth (click to expand)</summary>

- [x] 🧠 I used LLMs/AI in this contribution and reviewed all generated content.  
      I understand that I am responsible for and able to explain every line of code I submit.
- [x] 🔍 Any UI changes adhere to visual style of this project.
- [x] 🛠️ I have self-reviewed and self-tested my code to ensure it works as expected.
- [ ] 🤖 I added or updated automated tests where appropriate.
- [x] 📄 Documentation updates are included (if applicable).
- [ ] 🧰 Dependency updates are listed and explained.
- [ ] ⚠️ CI passes and is green.

</details>