### PR TITLE
Add option to disable recovery agent

### DIFF
--- a/meshagent.js
+++ b/meshagent.js
@@ -677,6 +677,9 @@ module.exports.CreateMeshAgent = function (parent, db, ws, req, args, domain) {
 
         // If this is a recovery agent
         if (obj.agentInfo.capabilities & 0x40) {
+            // Recovery agents are disabled by server policy.
+            if (args.disablerecoveryagent === true) { obj.close(1); return; }
+
             // Inform mesh agent that it's authenticated.
             delete obj.pendingCompleteAgentConnection;
             obj.authenticated = 2;

--- a/meshcentral-config-schema.json
+++ b/meshcentral-config-schema.json
@@ -589,6 +589,11 @@
           "default": true,
           "description": "Set to false to not allow temporary agents to be updated."
         },
+        "disableRecoveryAgent": {
+          "type": "boolean",
+          "default": false,
+          "description": "When true, rejects recovery agent connections (agents with capability bit 0x40)."
+        },
         "amtScanner": {
           "type": "boolean",
           "default": true,

--- a/sample-config-advanced.json
+++ b/sample-config-advanced.json
@@ -71,6 +71,7 @@
     "_noAgentUpdate": 1,
     "_agentUpdateSystem": 1,
     "_temporaryAgentUpdate": false,
+    "_disableRecoveryAgent": false,
     "_amtScanner": false,
     "_meshScanner": false,
     "_meshErrorLogPath": "c:\\tmp",


### PR DESCRIPTION
# Summary

In this pull request, the following changes are made:

- Added the `disableRecoveryAgent` server setting to reject recovery agents with capability bit `0x40`.
- This opt-in measure hardens the server because recovery agents receive elevated authentication without registering as nodes, which may facilitate attacks in some situations.
- Documented the setting in the configuration schema and advanced configuration example.

<details>
<summary>Please follow this checklist to avoid unnecessary back and forth (click to expand)</summary>

- [x] 🧠 I used LLMs/AI in this contribution and reviewed all generated content.  
      I understand that I am responsible for and able to explain every line of code I submit.
- [x] 🔍 Any UI changes adhere to visual style of this project.
- [x] 🛠️ I have self-reviewed and self-tested my code to ensure it works as expected.
- [ ] 🤖 I added or updated automated tests where appropriate.
- [x] 📄 Documentation updates are included (if applicable).
- [x] 🧰 Dependency updates are listed and explained.
- [ ] ⚠️ CI passes and is green.

</details>